### PR TITLE
Make the hash_files target non interactive

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -4,7 +4,7 @@ CLI_DIR:=$(CURDIR)/../../cli
 ENGINE_VER=$(shell cat $(ENGINE_DIR)/VERSION)
 VERSION=$(shell cat $(ENGINE_DIR)/VERSION)
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
-HASH_CMD=docker run -v $(CURDIR):/sum -it -w /sum debian:jessie bash hash_files
+HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 
 .PHONY: help clean static static-linux cross-mac cross-win cross-arm static-cli static-engine cross-all-cli cross-win-engine hash_files


### PR DESCRIPTION
This part was failing on the jenkins job:

<img width="236" alt="screen shot 2017-05-24 at 10 14 20 am" src="https://cloud.githubusercontent.com/assets/1700823/26416159/c9f51ade-4069-11e7-894d-851097e9c5f2.png">