### PR TITLE
deb: add sudo users to the docker group

### DIFF
--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -7,6 +7,11 @@ case "$1" in
 			if ! getent group docker > /dev/null; then
 				groupadd --system docker
 			fi
+
+			# Add each sudo user to the docker group
+			for u in $(getent group sudo | sed -e "s/^.*://" -e "s/,/ /g"); do
+				adduser "$u" docker >/dev/null || true
+			done
 		fi
 		;;
 	abort-*)


### PR DESCRIPTION
When users install docker-ce, the first thing they have to do is add
themselves to the docker group (see below). Let's instead do this for them, so
a simple `newgrp docker` is all that's required. (See the patch notes for a sample terminal session for why this is helpful)

Note: since having access to the docker API is effectively equivalent to root
access, we should only do this for users in the sudo group.

Also, this probably needs a update to the docs and such. Where should I send those PRs?