### PR TITLE
Mark docker-*-selinux pkgs as obsolete

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -36,6 +36,11 @@ Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
 
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
+
 %description
 Docker is an open source project to build, ship and run any application as a
 lightweight container.

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -27,6 +27,7 @@ Requires: libcgroup
 Requires: systemd-units
 Requires: tar
 Requires: xz
+Requires: container-selinux >= 1.10.3-55
 
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1
@@ -35,6 +36,11 @@ Requires: device-mapper-libs >= 1.02.90-1
 Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
+
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
 
 %description
 Docker is an open source project to build, ship and run any application as a

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -35,6 +35,11 @@ Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
 
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
+
 %description
 Docker is an open source project to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
These are replaced by `container-selinux` on fedora-25 and centos-7.
Marking these packages as obsolete makes the installation process a bit
smoother, otherwise the user will have to manually uninstall the older
packages to install the new one.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>