### PR TITLE
restart docker service if needed for rpm upgrade

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -154,6 +154,20 @@ install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/u
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
 
+%pre
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
+
 %post
 %systemd_post docker
 if ! getent group docker > /dev/null; then
@@ -165,6 +179,17 @@ fi
 
 %postun
 %systemd_postun_with_restart docker
+
+%posttrans
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %changelog
 

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -155,6 +155,20 @@ install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/u
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
 
+%pre
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
+
 %post
 %systemd_post docker
 if ! getent group docker > /dev/null; then
@@ -166,6 +180,17 @@ fi
 
 %postun
 %systemd_postun_with_restart docker
+
+%posttrans
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %changelog
 

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -153,6 +153,20 @@ install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/u
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
 
+%pre
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
+
 %post
 %systemd_post docker
 if ! getent group docker > /dev/null; then
@@ -164,6 +178,17 @@ fi
 
 %postun
 %systemd_postun_with_restart docker
+
+%posttrans
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %changelog
 


### PR DESCRIPTION
Addresses issue moby/moby#33688: Container can not start after docker engine upgrade from 17.03.1-ce to 17.06.0-ce-rc3

This PR will stop the docker service if it is running in an upgrade scenario (docker service is never started on a fresh install as per RPM behaviour conventions). It will then restart the service after the new files are installed so that the new daemon is used to launch the service.

For reference, RPM spec file scriptlet ordering https://fedoraproject.org/wiki/Packaging:Scriptlets

To build a centos rpm:
```
$ make -C rpm ENGINE_DIR=/path/to/engine/code CLI_DIR=/path/to/cli/code centos-7 # rpm will be in rpm/rpmbuild
```

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>