### PR TITLE
Prefixes documentation files per component

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -130,11 +130,11 @@ install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
 mkdir -p build-docs
-for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
-    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+for engine_file in AUTHORS CHANGELOG.md CONTRIBUTING.md LICENSE MAINTAINERS NOTICE README.md; do
+    cp "engine/$engine_file" "build-docs/engine-$engine_file"
 done
-for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
-    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
+    cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
 # list files owned by the package here

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -129,9 +129,18 @@ install -p -m 644 engine/contrib/syntax/vim/syntax/dockerfile.vim $RPM_BUILD_ROO
 install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
+mkdir -p build-docs
+for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
+    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+done
+for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
+    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+done
+
 # list files owned by the package here
 %files
-%doc engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md
+%doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
+%doc build-docs/cli-LICENSE build-docs/cli-MAINTAINERS build-docs/cli-NOTICE build-docs/cli-README.md
 /%{_bindir}/docker
 /%{_bindir}/dockerd
 /%{_bindir}/docker-containerd

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -130,9 +130,18 @@ install -p -m 644 engine/contrib/syntax/vim/syntax/dockerfile.vim $RPM_BUILD_ROO
 install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
+mkdir -p build-docs
+for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
+    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+done
+for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
+    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+done
+
 # list files owned by the package here
 %files
-%doc engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md
+%doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
+%doc build-docs/cli-LICENSE build-docs/cli-MAINTAINERS build-docs/cli-NOTICE build-docs/cli-README.md
 /%{_bindir}/docker
 /%{_bindir}/dockerd
 /%{_bindir}/docker-containerd

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -131,11 +131,11 @@ install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
 mkdir -p build-docs
-for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
-    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+for engine_file in AUTHORS CHANGELOG.md CONTRIBUTING.md LICENSE MAINTAINERS NOTICE README.md; do
+    cp "engine/$engine_file" "build-docs/engine-$engine_file"
 done
-for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
-    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
+    cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
 # list files owned by the package here

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -129,11 +129,11 @@ install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
 mkdir -p build-docs
-for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
-    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+for engine_file in AUTHORS CHANGELOG.md CONTRIBUTING.md LICENSE MAINTAINERS NOTICE README.md; do
+    cp "engine/$engine_file" "build-docs/engine-$engine_file"
 done
-for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
-    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
+    cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
 # list files owned by the package here

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -128,9 +128,18 @@ install -p -m 644 engine/contrib/syntax/vim/syntax/dockerfile.vim $RPM_BUILD_ROO
 install -d $RPM_BUILD_ROOT/usr/share/nano
 install -p -m 644 engine/contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/share/nano/Dockerfile.nanorc
 
+mkdir -p build-docs
+for engine_file in engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md; do
+    cp "$engine_file" "build-docs/engine-$(basename $engine_file)"
+done
+for cli_file in cli/LICENSE cli/MAINTAINERS cli/NOTICE cli/README.md; do
+    cp "$cli_file" "build-docs/cli-$(basename $cli_file)"
+done
+
 # list files owned by the package here
 %files
-%doc engine/AUTHORS engine/CHANGELOG.md engine/CONTRIBUTING.md engine/LICENSE engine/MAINTAINERS engine/NOTICE engine/README.md
+%doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
+%doc build-docs/cli-LICENSE build-docs/cli-MAINTAINERS build-docs/cli-NOTICE build-docs/cli-README.md
 /%{_bindir}/docker
 /%{_bindir}/dockerd
 /%{_bindir}/docker-containerd


### PR DESCRIPTION
Since we pull from multiple components to build docker-ce now it makes sense to have all of the related files associated with each component packaged into RPMS.

This will prefix all files that were previously included in the RPM with the component from which they originate.

End result will look like so:

<img width="575" alt="screen shot 2017-06-19 at 1 19 47 pm" src="https://user-images.githubusercontent.com/1700823/27304210-36c7e3ca-54f2-11e7-9148-18ed622e0566.png">
