### PR TITLE
deb pkg stop service before upgrade, start after upgrade

### DIFF
--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -9,6 +9,9 @@ case "$1" in
 			fi
 		fi
 		;;
+	upgrade)
+		invoke-rc.d docker start || exit $?
+		;;
 	abort-*)
 		# How'd we get here??
 		exit 1

--- a/deb/common/docker-ce.preinst
+++ b/deb/common/docker-ce.preinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+	upgrade)
+		invoke-rc.d docker stop || exit $?
+		;;
+	abort-*)
+		# How'd we get here??
+		exit 1
+		;;
+	*)
+		;;
+esac
+
+#DEBHELPER#


### PR DESCRIPTION
Similar to PR #20 **restart docker service if needed for rpm upgrade**, this PR addresses issue moby/moby#33688 **Container can not start after docker engine upgrade from 17.03.1-ce to 17.06.0-ce-rc3** for deb packages.

This PR will stop the docker service if it is running in an upgrade scenario. It will then start the service after the new files are installed so that the new daemon is used to launch the service. Unlike rpm packages, installing the docker-ce deb package is always expected to finish by starting the service.

For reference, deb pkg script event hooks: https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html#s-maintscripts

To build a xenial deb pkg:
```
$ make -C rpm ENGINE_DIR=/path/to/engine/code CLI_DIR=/path/to/cli/code ubuntu-xenial # deb will be in deb/debbuild
```

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>