### PR TITLE
also have deb pkg conflict docker-engine

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -16,7 +16,7 @@ Recommends: aufs-tools,
             git,
             xz-utils,
             ${apparmor:Recommends}
-Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine-cs, docker-ee
+Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs, docker-ee
 Replaces: docker-engine
 Description: Docker: the open-source application container engine
  Docker is an open source project to build, ship and run any application as a


### PR DESCRIPTION
Without this PR, docker-ce and docker-engine deb packages will be installed on the system at the same time.

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>