### PR TITLE
Restores deb naming to previous behavior

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -43,7 +43,7 @@ debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/cont
 debDate="$(date --rfc-2822)"
 
 cat > "debian/changelog" <<-EOF
-$debSource (${debVersion}-0~${DISTRO}) $SUITE; urgency=low
+$debSource (${debVersion}-0~${DISTRO}-${SUITE}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF


### PR DESCRIPTION
Deb naming now includes Distro version:

`docker-ce_17.06.0~ce-0~ubuntu_amd64.deb` -> `docker-ce_17.06.0~ce-0~ubuntu-xenial_amd64.deb`