### PR TITLE
Fix paths for completion scripts

### DIFF
--- a/deb/common/docker-ce.bash-completion
+++ b/deb/common/docker-ce.bash-completion
@@ -1,1 +1,1 @@
-engine/contrib/completion/bash/docker
+cli/contrib/completion/bash/docker

--- a/deb/common/docker-ce.install
+++ b/deb/common/docker-ce.install
@@ -3,8 +3,8 @@
 #engine/contrib/syntax/vim/syntax/* /usr/share/vim/vimfiles/syntax/
 engine/contrib/*-integration usr/share/docker-ce/contrib/
 engine/contrib/check-config.sh usr/share/docker-ce/contrib/
-engine/contrib/completion/fish/docker.fish usr/share/fish/vendor_completions.d/
-engine/contrib/completion/zsh/_docker usr/share/zsh/vendor-completions/
+cli/contrib/completion/fish/docker.fish usr/share/fish/vendor_completions.d/
+cli/contrib/completion/zsh/_docker usr/share/zsh/vendor-completions/
 systemd/docker.service lib/systemd/system/
 systemd/docker.socket lib/systemd/system/
 engine/contrib/mk* usr/share/docker-ce/contrib/

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -106,9 +106,9 @@ install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.ser
 install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
 install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
 install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
-install -p -m 644 engine/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
-install -p -m 644 engine/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
-install -p -m 644 engine/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
 
 # install manpages
 install -d %{buildroot}%{_mandir}/man1

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -107,9 +107,9 @@ install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.ser
 install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
 install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
 install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
-install -p -m 644 engine/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
-install -p -m 644 engine/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
-install -p -m 644 engine/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
 
 # install manpages
 install -d %{buildroot}%{_mandir}/man1

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -105,9 +105,9 @@ install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.ser
 install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
 install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
 install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
-install -p -m 644 engine/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
-install -p -m 644 engine/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
-install -p -m 644 engine/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
 
 # install manpages
 install -d %{buildroot}%{_mandir}/man1


### PR DESCRIPTION
The completion scripts have been moved to the docker/cli repository, so should be taken from that directory.

Note that the docker/docker-ce repository is currently in a mixed state; these two pull requests should be included there;

https://github.com/docker/cli/pull/189
https://github.com/moby/moby/pull/33665


ping @tiborvass @andrewhsu PTAL