### PR TITLE
remove desktop-integration contrib from .deb

### DIFF
--- a/deb/common/docker-ce.install
+++ b/deb/common/docker-ce.install
@@ -1,7 +1,6 @@
 #engine/contrib/syntax/vim/doc/* /usr/share/vim/vimfiles/doc/
 #engine/contrib/syntax/vim/ftdetect/* /usr/share/vim/vimfiles/ftdetect/
 #engine/contrib/syntax/vim/syntax/* /usr/share/vim/vimfiles/syntax/
-engine/contrib/*-integration usr/share/docker-ce/contrib/
 engine/contrib/check-config.sh usr/share/docker-ce/contrib/
 engine/contrib/completion/fish/docker.fish usr/share/fish/vendor_completions.d/
 engine/contrib/completion/zsh/_docker usr/share/zsh/vendor-completions/


### PR DESCRIPTION
these examples are not nescessary for day-to-day use of docker, so don't have to be included in the packages.