### PR TITLE
[ppc64le] add deb support for ubuntu-xenial

### DIFF
--- a/deb/ubuntu-xenial/Dockerfile.ppc64le
+++ b/deb/ubuntu-xenial/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+FROM ppc64le/ubuntu:xenial
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.8.3
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE xenial
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/detect_alpine_image
+++ b/detect_alpine_image
@@ -11,6 +11,8 @@ elif [ "$arch" = "s390x" ]; then
     img="s390x/alpine"
 elif [ "$arch" = "aarch64" ]; then
     img="aarch64/alpine"
+elif [ "$arch" = "ppc64le" ]; then
+    img="ppc64le/alpine"
 else
     echo "Architecture $(arch) not supported"
     exit 1;


### PR DESCRIPTION
Adds ubuntu-xenial as a make deb target for ppc64le.

I've tested this with 17.06, but can't get a successful build with
the upstream cli repo because of https://github.com/docker/for-linux/issues/54.

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>