### PR TITLE
Have docker cli be compiled in GOPATH

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -12,7 +12,7 @@ override_dh_gencontrol:
 
 override_dh_auto_build:
 	cd engine && ./hack/make.sh dynbinary
-	LDFLAGS='' make -C cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
+	LDFLAGS='' make -C /go/src/github.com/docker/cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
 override_dh_auto_test:
 	./engine/bundles/$(BUNDLE_VERSION)/dynbinary-daemon/dockerd -v


### PR DESCRIPTION
manpage generation was failing for docker cli when being run under
aarch64: 

https://ci.qa.aws.dckr.io/job/docker/job/release-packaging/view/change-requests/job/PR-41/5/execution/node/360/log/

The way to remedy this is to compile the cli and the manpages while in
the GOPATH so that dependencies found in the vendor folder are
discovered by the go build tools.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>