### PR TITLE
Change make -C to a cd command for manpage generation

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -12,7 +12,7 @@ override_dh_gencontrol:
 
 override_dh_auto_build:
 	cd engine && ./hack/make.sh dynbinary
-	LDFLAGS='' make -C /go/src/github.com/docker/cli VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
+	cd /go/src/github.com/docker/cli && LDFLAGS='' make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
 override_dh_auto_test:
 	./engine/bundles/$(BUNDLE_VERSION)/dynbinary-daemon/dockerd -v


### PR DESCRIPTION
Tried out make -C in this scenario and it did not seem to function
correctly, changed to cd.

Remedies issues found in #36 #11 

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>