### PR TITLE
Add content verification to the plugin installation

### DIFF
--- a/common/docker-telemetry-plugin
+++ b/common/docker-telemetry-plugin
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+
+BASE=/var/lib/docker
+PLUGIN_NAME=docker/telemetry
+EDITION_INFO=$BASE/.edition-information
+
+# make sure that docker is running
+DOCKER_SOCKET=
+if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+        DOCKER_SOCKET=/var/run/docker.sock
+else
+        DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)' | sed 1q)
+fi
+
+if [ -n "$DOCKER_SOCKET" ]; then
+        while ! [ -e "$DOCKER_SOCKET" ]; do
+                sleep 0.1
+        done
+else
+        # docker socket not found, exiting...
+        exit
+fi
+
+# check if the file exists
+if ! [ -e "$EDITION_INFO" ]; then
+        # edition metadata not found, exiting...
+        exit
+fi
+
+# Create the engine UUID, if it doesn't exist
+# This will be eventually handled by the docker engine
+# ref. https://github.com/moby/moby/issues/33356
+if [ -f $BASE/engine_uuid ]; then
+    UUID=$(cat $BASE/engine_uuid)
+fi
+if [ -z ${UUID+x} ]; then
+    UUID=$(cat /proc/sys/kernel/random/uuid | tee $BASE/engine_uuid)
+fi
+
+# store the metrics plugin state
+plugin_name=$(docker plugin ls | grep $PLUGIN_NAME | awk 'NR==1{print $2}')
+if docker inspect $plugin_name > /dev/null 2>&1; then
+        plugin_state=$(docker plugin inspect -f '{{.Enabled}}' $plugin_name)
+        # remove previous plugin state
+        sed -i 's/,"Enabled":.*/\}/g' $EDITION_INFO
+        # add new plugin state
+        sed -i "s/\}/,\"Enabled\":$plugin_state\}/g" $EDITION_INFO
+fi
+
+# install/upgrade telemetry plugin in case it's not present (ignore stdout/stderror)
+plugin_version=$(cat $EDITION_INFO | sed 's/{.*plugin_version":"*\([0-9a-zA-Z._-]*\)"*,*.*}/\1/')
+plugin_name=$PLUGIN_NAME:$plugin_version
+if ! docker inspect $plugin_name > /dev/null 2>&1; then
+        # remove old plugin versions
+        docker plugin rm -f `docker plugin ls | grep $PLUGIN_NAME | awk '{print $2}'` > /dev/null 2>&1
+        # create new plugin (disabled by default)
+        docker plugin install --disable --grant-all-permissions $plugin_name > /dev/null 2>&1
+        # extract all the edition variables, including the engine uuid
+        uuid=$(cat /var/lib/docker/engine_uuid)
+        edition_version=$(cat $EDITION_INFO | sed 's/{.*edition_version":"*\([0-9a-zA-Z._-]*\)"*,*.*}/\1/')
+        edition_type=$(cat $EDITION_INFO | sed 's/{.*edition_type":"*\([0-9a-zA-Z._-]*\)"*,*.*}/\1/')
+        edition_name=$(cat $EDITION_INFO | sed 's/{.*edition_name":"*\([0-9a-zA-Z._-]*\)"*,*.*}/\1/')
+        docker plugin set $plugin_name edition_name=$edition_name edition_type=$edition_type edition_version=$edition_version anonymous_id=$uuid > /dev/null 2>&1
+        # set the metrics plugin to its previous state
+        if grep 'true' $EDITION_INFO > /dev/null 2>&1 ; then
+                docker plugin enable $plugin_name > /dev/null 2>&1
+        fi
+fi

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -3,8 +3,10 @@ ALPINE_IMG:=$(shell $(CURDIR)/../detect_alpine_image)
 ARCH:=$(shell uname -m)
 ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
+COMMON_DIR:=$(CURDIR)/../common
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=$(shell cat $(ENGINE_DIR)/VERSION)
+PLUGIN_VERSION?=1.0.0.linux-$(ARCH)-test
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown
 

--- a/deb/common/docker-ce.docker.init
+++ b/deb/common/docker-ce.docker.init
@@ -114,6 +114,8 @@ case "$1" in
 				$DOCKER_OPTS \
 					>> "$DOCKER_LOGFILE" 2>&1
 		log_end_msg $?
+		# load metrics plugin (disabled by default)
+		/usr/bin/docker-telemetry-plugin
 		;;
 
 	stop)

--- a/deb/common/docker-ce.docker.upstart
+++ b/deb/common/docker-ce.docker.upstart
@@ -69,4 +69,6 @@ post-start script
 		done
 		echo "$DOCKER_SOCKET is up"
 	fi
+	# load metrics plugin (disabled by default)
+	/usr/bin/docker-telemetry-plugin
 end script

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -11,6 +11,8 @@ override_dh_gencontrol:
 	dh_gencontrol
 
 override_dh_auto_build:
+	# create metrics plugin metadata
+	printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s", "plugin_version":"%s"}\n' "$(DISTRO)" "$(VERSION)" "$(PLUGIN_VERSION)" > .edition-information
 	cd engine && ./hack/make.sh dynbinary
 	cd /go/src/github.com/docker/cli && LDFLAGS='' make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
@@ -31,6 +33,9 @@ override_dh_auto_install:
 	cp -aT /usr/local/bin/docker-runc debian/docker-ce/usr/bin/docker-runc
 	cp -aT /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
 	mkdir -p debian/docker-ce/usr/lib/docker
+	mkdir -p debian/docker-ce/var/lib/docker
+	cp -aTL .edition-information debian/docker-ce/var/lib/docker/.edition-information
+	cp -aTL /root/build-deb/common/docker-telemetry-plugin debian/docker-ce/usr/bin/docker-telemetry-plugin
 
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"

--- a/deb/systemd/docker.service
+++ b/deb/systemd/docker.service
@@ -12,6 +12,7 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
+ExecStartPost=/usr/bin/docker-telemetry-plugin
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,9 +1,11 @@
 ARCH=$(shell uname -m)
 ALPINE_IMG:=$(shell $(CURDIR)/../detect_alpine_image)
 ENGINE_DIR:=$(CURDIR)/../../engine
+COMMON_DIR:=$(CURDIR)/../common
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION=$(shell cat $(ENGINE_DIR)/VERSION)
+PLUGIN_VERSION?=1.0.0.linux-$(ARCH)-test
 DOCKER_EXPERIMENTAL=0
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v $(ALPINE_IMG) chown

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -68,6 +68,7 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s", "plugin_version":"%s"}\n' "${DISTRO}" "%{_version}" "%{_plugin_version}" > .edition-information
 
 %check
 cli/build/docker -v
@@ -138,6 +139,11 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 644 .package-information $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 755 /common/docker-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/docker-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -163,6 +169,8 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/.edition-information
+/usr/bin/docker-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/rpm/fedora-24/docker-ce.spec
+++ b/rpm/fedora-24/docker-ce.spec
@@ -69,6 +69,7 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s", "plugin_version":"%s"}\n' "${DISTRO}" "%{_version}" "%{_plugin_version}" > .edition-information
 
 %check
 cli/build/docker -v
@@ -139,6 +140,11 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 644 .edition-information $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 755 /common/docker-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/docker-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -164,6 +170,8 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/.edition-information
+/usr/bin/docker-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -67,6 +67,8 @@ pushd engine
 TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
 hack/make.sh dynbinary
 popd
+mkdir -p plugin
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s", "plugin_version":"%s"}\n' "${DISTRO}" "%{_version}" "%{_plugin_version}" > .edition-information
 
 %check
 cli/build/docker -v
@@ -137,6 +139,11 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 644 .edition-information $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 755 /common/docker-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/docker-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -162,6 +169,8 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/.edition-information
+/usr/bin/docker-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -68,7 +68,7 @@ TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dyn
 hack/make.sh dynbinary
 popd
 mkdir -p plugin
-printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
+printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s", "plugin_version":"%s"}\n' "${DISTRO}" "%{_version}" "%{_plugin_version}" > .edition-information
 
 %check
 cli/build/docker -v
@@ -139,6 +139,11 @@ for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
     cp "cli/$cli_file" "build-docs/cli-$cli_file"
 done
 
+# add telemetry plugin
+install -d $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 644 .edition-information $RPM_BUILD_ROOT/var/lib/docker
+install -p -m 755 /common/docker-telemetry-plugin $RPM_BUILD_ROOT/%{_bindir}/docker-telemetry-plugin
+
 # list files owned by the package here
 %files
 %doc build-docs/engine-AUTHORS build-docs/engine-CHANGELOG.md build-docs/engine-CONTRIBUTING.md build-docs/engine-LICENSE build-docs/engine-MAINTAINERS build-docs/engine-NOTICE build-docs/engine-README.md
@@ -164,6 +169,8 @@ done
 /usr/share/vim/vimfiles/ftdetect/dockerfile.vim
 /usr/share/vim/vimfiles/syntax/dockerfile.vim
 /usr/share/nano/Dockerfile.nanorc
+/var/lib/docker/.edition-information
+/usr/bin/docker-telemetry-plugin
 
 %pre
 if [ $1 -gt 0 ] ; then

--- a/rpm/systemd/docker.service
+++ b/rpm/systemd/docker.service
@@ -11,6 +11,7 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
+ExecStartPost=/usr/bin/docker-telemetry-plugin
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNOFILE=infinity


### PR DESCRIPTION
  - remove the `tgz` artifacts and use `docker plugin install` instead

Signed-off-by: Roberto Gandolfo Hashioka <roberto_hashioka@hotmail.com>