### PR TITLE
Adds a warning to postinst if docker group exists

### DIFF
--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -6,6 +6,15 @@ case "$1" in
 		if [ -z "$2" ]; then
 			if ! getent group docker > /dev/null; then
 				groupadd --system docker
+			else
+				echo
+				echo "WARNING! The 'docker' group is already created, the following users now have access to Docker:"
+				awk -F':' '{print $1}' /etc/passwd | while IFS= read -r user; do
+					if groups "$user" | grep docker >/dev/null; then
+						echo "    - $user"
+					fi
+				done
+				echo
 			fi
 		fi
 		;;

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -182,6 +182,15 @@ fi
 %systemd_post docker
 if ! getent group docker > /dev/null; then
     groupadd --system docker
+else
+    echo
+    echo "WARNING! The 'docker' group is already created, the following users now have access to Docker:"
+    awk -F':' '{print $1}' /etc/passwd | while IFS= read -r user; do
+        if groups "$user" | grep docker >/dev/null; then
+            echo "    - $user"
+        fi
+    done
+    echo
 fi
 
 %preun

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -181,6 +181,15 @@ fi
 %systemd_post docker
 if ! getent group docker > /dev/null; then
     groupadd --system docker
+else
+    echo
+    echo "WARNING! The 'docker' group is already created, the following users now have access to Docker:"
+    awk -F':' '{print $1}' /etc/passwd | while IFS= read -r user; do
+    if groups "$user" | grep docker >/dev/null; then
+        echo "    - $user"
+    fi
+    done
+    echo
 fi
 
 %preun

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -183,6 +183,15 @@ fi
 %systemd_post docker
 if ! getent group docker > /dev/null; then
     groupadd --system docker
+else
+    echo
+    echo "WARNING! The 'docker' group is already created, the following users now have access to Docker:"
+    awk -F':' '{print $1}' /etc/passwd | while IFS= read -r user; do
+        if groups "$user" | grep docker >/dev/null; then
+            echo "    - $user"
+        fi
+    done
+    echo
 fi
 
 %preun


### PR DESCRIPTION
If the docker group is before docker installed, all users in the docker
group are automagically granted docker access, which is equivalent to
root access.

This commit adds a warning message along with the list of users that
will now have docker access.

Found by @eiais

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>