### PR TITLE
Remove RPM changelog

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -202,21 +202,3 @@ if [ $1 -ge 0 ] ; then
 fi
 
 %changelog
-
-* Wed Jun 21 2017 <eli.uriegas@docker.com> 17.06.0-ce
-- release docker-ce 17.06.0-ce
-
-* Mon Jun 19 2017 <eli.uriegas@docker.com> 17.06.0-ce-rc5
-- release docker-ce 17.06.0-ce-rc5
-
-* Thu Jun 15 2017 <andrewhsu@docker.com> 17.06.0-ce-rc4
-- release docker-ce 17.06.0-ce-rc4
-
-* Tue Jun 13 2017 <andrewhsu@docker.com> 17.06.0-ce-rc3
-- release docker-ce 17.06.0-ce-rc3
-
-* Wed Jun 07 2017 <andrewhsu@docker.com> 17.06.0-ce-rc2
-- release docker-ce 17.06.0-ce-rc2
-
-* Mon May 29 2017 <andrewhsu@docker.com> 17.06.0-ce-rc1
-- release docker-ce 17.06.0-ce-rc1

--- a/rpm/fedora-25/docker-ce.spec
+++ b/rpm/fedora-25/docker-ce.spec
@@ -201,21 +201,3 @@ if [ $1 -ge 0 ] ; then
 fi
 
 %changelog
-
-* Wed Jun 21 2017 <eli.uriegas@docker.com> 17.06.0-ce
-- release docker-ce 17.06.0-ce
-
-* Mon Jun 19 2017 <eli.uriegas@docker.com> 17.06.0-ce-rc5
-- release docker-ce 17.06.0-ce-rc5
-
-* Thu Jun 15 2017 <andrewhsu@docker.com> 17.06.0-ce-rc4
-- release docker-ce 17.06.0-ce-rc4
-
-* Tue Jun 13 2017 <andrewhsu@docker.com> 17.06.0-ce-rc3
-- release docker-ce 17.06.0-ce-rc3
-
-* Wed Jun 07 2017 <andrewhsu@docker.com> 17.06.0-ce-rc2
-- release docker-ce 17.06.0-ce-rc2
-
-* Mon May 29 2017 <andrewhsu@docker.com> 17.06.0-ce-rc1
-- release docker-ce 17.06.0-ce-rc1

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -203,21 +203,3 @@ if [ $1 -ge 0 ] ; then
 fi
 
 %changelog
-
-* Wed Jun 21 2017 <eli.uriegas@docker.com> 17.06.0-ce
-- release docker-ce 17.06.0-ce
-
-* Mon Jun 19 2017 <eli.uriegas@docker.com> 17.06.0-ce-rc5
-- release docker-ce 17.06.0-ce-rc5
-
-* Thu Jun 15 2017 <andrewhsu@docker.com> 17.06.0-ce-rc4
-- release docker-ce 17.06.0-ce-rc4
-
-* Tue Jun 13 2017 <andrewhsu@docker.com> 17.06.0-ce-rc3
-- release docker-ce 17.06.0-ce-rc3
-
-* Wed Jun 07 2017 <andrewhsu@docker.com> 17.06.0-ce-rc2
-- release docker-ce 17.06.0-ce-rc2
-
-* Mon May 29 2017 <andrewhsu@docker.com> 17.06.0-ce-rc1
-- release docker-ce 17.06.0-ce-rc1


### PR DESCRIPTION
We haven't been updating it, seems like a waste to just track releases
through it.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>