### PR TITLE
Switch aarch64 images to arm64v8

### DIFF
--- a/deb/ubuntu-xenial/Dockerfile.aarch64
+++ b/deb/ubuntu-xenial/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:xenial
+FROM arm64v8/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y golang-go apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/detect_alpine_image
+++ b/detect_alpine_image
@@ -10,7 +10,7 @@ elif [ "$arch" = "armv7l" ]; then
 elif [ "$arch" = "s390x" ]; then
     img="s390x/alpine"
 elif [ "$arch" = "aarch64" ]; then
-    img="aarch64/alpine"
+    img="arm64v8/alpine"
 elif [ "$arch" = "ppc64le" ]; then
     img="ppc64le/alpine"
 else


### PR DESCRIPTION
The "aarch64" images on Docker Hub are deprecated in favor of the "arm64v8" images.


@seemethere @tianon PTAL :heart: