### PR TITLE
Switches ubuntu trusty mirror to one that works

### DIFF
--- a/deb/ubuntu-trusty/Dockerfile.armv7l
+++ b/deb/ubuntu-trusty/Dockerfile.armv7l
@@ -1,5 +1,7 @@
 FROM arm32v7/ubuntu:trusty
 
+# Temorary fix until ubuntu trusty package repositories are back up
+RUN sed -i 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV GO_VERSION 1.8.3


### PR DESCRIPTION
Was getting 404's with the old one, consider this one temporary until
canonical fixes their stuff.

Related:
https://bugs.launchpad.net/cloud-images/+bug/1711735

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>