### PR TITLE
deb: Fix VERSION detection to build one release

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -3,7 +3,7 @@ ARCH:=$(shell uname -m)
 ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
-VERSION?=$(shell cat $(ENGINE_DIR)/VERSION)
+VERSION?=$(shell cat $(CURDIR)/../../../VERSION)
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 


### PR DESCRIPTION
The easiest way to build just one deb for docker-ce is to run `make ubuntu-xenial` inside `components/packaging/deb` in `docker/docker-ce`. However, the Makefile in this directory looks in the wrong place for a VERSION file.

(If building from the top of `docker/docker-ce`, VERSION gets set correctly, but you can't build just one release from there.)