### PR TITLE
replace all '-' in version when generate rpm version

### DIFF
--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -46,5 +46,5 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
 fi
 
 # Replace any other dashes with periods
-rpmVersion="${rpmVersion/-/.}"
+rpmVersion="${rpmVersion//-/.}"
 echo $rpmVersion $rpmRelease $DOCKER_GITCOMMIT


### PR DESCRIPTION
Such as  "17.09.1-ce-dev". The generation now will produce "17.09.1.ce-dev" rpm version. This version will cause rpm build error. Replace all "-" in version will resolve this problem.

🐼