### PR TITLE
Aarch64 rpm support 

### DIFF
--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -1,0 +1,33 @@
+FROM arm64v8/centos:7
+RUN yum groupinstall -y "Development Tools"
+RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
+RUN yum install -y \
+   glibc-static \
+   btrfs-progs-devel \
+   device-mapper-devel \
+   libseccomp-devel \
+   libselinux-devel \
+   libtool-ltdl-devel \
+   selinux-policy-devel \
+   systemd-devel \
+   pkgconfig \
+   tar \
+   git \
+   cmake \
+   rpmdevtools \
+   vim-common
+
+ENV GO_VERSION 1.9.2
+ENV DISTRO centos
+ENV SUITE 7
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+RUN mkdir -p /go
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:/go/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-25/Dockerfile.aarch64
+++ b/rpm/fedora-25/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+FROM arm64v8/fedora:25
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.2
+ENV DISTRO fedora
+ENV SUITE 25
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-26/Dockerfile.aarch64
+++ b/rpm/fedora-26/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+FROM arm64v8/fedora:26
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.2
+ENV DISTRO fedora
+ENV SUITE 26
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+FROM arm64v8/fedora:27
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.2
+ENV DISTRO fedora
+ENV SUITE 27
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
Like [#25](https://github.com/docker/docker-ce-packaging/pull/25) and [#35](https://github.com/docker/docker-ce-packaging/pull/35), this PR extends aarch64 support with RPMs builds.
I'm currently using the rpm package on fedora 27 with RPi 3.