### PR TITLE
Add libseccomp requirement for CentOS 7

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -22,6 +22,7 @@ BuildRequires: pkgconfig(libsystemd-journal)
 # required packages on install
 Requires: /bin/sh
 Requires: container-selinux >= 2.9
+Requires: libseccomp >= 2.3
 Requires: iptables
 Requires: libcgroup
 Requires: systemd-units


### PR DESCRIPTION
Adds a requirement to check for a minimum version of `libseccomp` for CentOS 7.

As reported by users in:
* https://github.com/moby/moby/issues/35906

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>