### PR TITLE
Adds EnvironmentFile and $DOCKER_OPTS

### DIFF
--- a/deb/systemd/docker.service
+++ b/deb/systemd/docker.service
@@ -6,11 +6,12 @@ Wants=network-online.target
 Requires=docker.socket
 
 [Service]
+EnvironmentFile=-/etc/default/docker
 Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/rpm/systemd/docker.service
+++ b/rpm/systemd/docker.service
@@ -5,11 +5,12 @@ After=network-online.target firewalld.service
 Wants=network-online.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/docker
 Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
Allows users to customize their docker service startup.

Debian based systems will be located at: `/etc/default/docker`

Source: https://www.linuxquestions.org/questions/slackware-14/the-directory-etc-default-723942/#post3531173

RPM based systemd will be located at: `/etc/sysconfig/docker`

Source: https://www.centos.org/docs/5/html/Deployment_Guide-en-US/ch-sysconfig.html
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

Relates to: https://github.com/docker/for-linux/issues/204