### PR TITLE
Add pigz to recommended packages

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -14,6 +14,7 @@ Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,
             git,
+            pigz,
             xz-utils,
             ${apparmor:Recommends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs, docker-ee

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -27,6 +27,7 @@ Requires: libcgroup
 Requires: systemd-units
 Requires: tar
 Requires: xz
+Requires: pigz
 
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -26,6 +26,7 @@ Requires: libcgroup
 Requires: systemd-units
 Requires: tar
 Requires: xz
+Requires: pigz
 
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -27,6 +27,7 @@ Requires: libcgroup
 Requires: systemd-units
 Requires: tar
 Requires: xz
+Requires: pigz
 
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1


### PR DESCRIPTION
This change is in response to https://github.com/moby/moby/pull/35697
It adds pigz to the recommended binaries that should be installed with
docker-ce.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>