### PR TITLE
Uncomment TasksMax=unlimited for recent distros

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 VERSION ?= $(shell cat engine/VERSION)
-SYSTEMD_VERSION := $(shell dpkg-query -W -f='$${Version}\n' systemd | cut -d- -f1)
+SYSTEMD_VERSION := $(shell dpkg-query -W -f='$${Version}\n' systemd libsystemd-dev | head -1 | cut -d- -f1)
 SYSTEMD_GT_227 := $(shell [ '$(SYSTEMD_VERSION)' ] && [ '$(SYSTEMD_VERSION)' -gt 227 ] && echo true )
 
 override_dh_gencontrol:

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -103,6 +103,8 @@ install -p -m 644 engine/contrib/udev/80-docker.rules $RPM_BUILD_ROOT/%{_sysconf
 install -d $RPM_BUILD_ROOT/etc/sysconfig
 install -d $RPM_BUILD_ROOT/%{_initddir}
 install -d $RPM_BUILD_ROOT/%{_unitdir}
+# Fedora 25+ supports (and needs) TasksMax
+sed -i 's/^#TasksMax=/TasksMax=/' /systemd/docker.service
 install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 # add bash, zsh, and fish completions
 install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -104,6 +104,8 @@ install -p -m 644 engine/contrib/udev/80-docker.rules $RPM_BUILD_ROOT/%{_sysconf
 install -d $RPM_BUILD_ROOT/etc/sysconfig
 install -d $RPM_BUILD_ROOT/%{_initddir}
 install -d $RPM_BUILD_ROOT/%{_unitdir}
+# Fedora 25+ supports (and needs) TasksMax
+sed -i 's/^#TasksMax=/TasksMax=/' /systemd/docker.service
 install -p -m 644 /systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 # add bash, zsh, and fish completions
 install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions


### PR DESCRIPTION
This fixes running Docker Engine under limited number of processes (https://github.com/docker/for-linux/issues/73). It was supposedly fixed for deb packaged, but the fix was/is not working. For Fedora, it was never fixed.

See https://github.com/docker/for-linux/issues/73 and https://github.com/docker/docker-ee/pull/164 for more details