### PR TITLE
add ClefOS as CentOS flavor for s390x

### DIFF
--- a/rpm/centos-7/Dockerfile.s390x
+++ b/rpm/centos-7/Dockerfile.s390x
@@ -1,0 +1,34 @@
+FROM clefos/clefos:clefos7
+RUN yum groupinstall -y "Development Tools"
+RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
+RUN yum install -y \
+   glibc-static \
+   btrfs-progs-devel \
+   device-mapper-devel \
+   libseccomp-devel \
+   libselinux-devel \
+   libtool-ltdl-devel \
+   selinux-policy-devel \
+   systemd-devel \
+   pkgconfig \
+   tar \
+   git \
+   cmake \
+   rpmdevtools \
+   vim-common
+
+ENV GO_VERSION 1.9.2
+ENV DISTRO centos
+ENV SUITE 7
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
+RUN mkdir -p /go
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:/go/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+RUN ln -s /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
On s390x, the RHEL clone is called ClefOS (not CentOS, since the team is not officially part of the CentOS organization). To enable RHEL/ClefOS anyway for docker-ce, this adds a Dockerfile to build docker-ce accordingly for s390x.

Essentially, this change only uses a different parent image as suitable for s390x, downloads the s390x binary of golang, and adds a symbolic link since gcc is not found otherwise. Other than that, the content is taken from the x86 file.