### PR TITLE
Add dev portion to RPM package version

### DIFF
--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -39,10 +39,10 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    gitVersion="${gitDate}.git${gitCommit}"
+    gitVersion="git${gitDate}.0.${gitCommit}"
     # gitVersion is now something like '20150128.112847.17e840a'
     rpmVersion="${rpmVersion%-dev}"
-    rpmRelease="0.0.$gitVersion"
+    rpmRelease="0.0.dev.$gitVersion"
 fi
 
 # Replace any other dashes with periods


### PR DESCRIPTION
-dev was being removed, per legacy code, but we'd like to add it back
into the naming so that deb / rpm packages will look mostly the same
when compiled with a `-dev` version.

RPMS end up looking like:

`docker-ce-18.02.0.ce-0.0.dev.git20180120.170357.0.fa4fb35.el7.centos.x86_64.rpm`

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>