### PR TITLE
Re-add Git Commit time to deb dev builds

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -4,6 +4,7 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
+DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) $(VERSION))
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 
@@ -32,6 +33,7 @@ raspbian: raspbian-stretch debian-jessie ## build all raspbian deb packages
 ubuntu-xenial: ## build ubuntu xenial deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -45,6 +47,7 @@ ubuntu-xenial: ## build ubuntu xenial deb packages
 ubuntu-trusty: ## build ubuntu trusty deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -58,6 +61,7 @@ ubuntu-trusty: ## build ubuntu trusty deb packages
 ubuntu-artful: ## build ubuntu artful deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -71,6 +75,7 @@ ubuntu-artful: ## build ubuntu artful deb packages
 debian-buster: ## build debian buster deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -84,6 +89,7 @@ debian-buster: ## build debian buster deb packages
 debian-jessie: ## build debian jessie deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -97,6 +103,7 @@ debian-jessie: ## build debian jessie deb packages
 debian-stretch: ## build debian stretch deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -110,6 +117,7 @@ debian-stretch: ## build debian stretch deb packages
 debian-wheezy: ## build debian wheezy deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -123,6 +131,7 @@ debian-wheezy: ## build debian wheezy deb packages
 raspbian-jessie: ## build raspbian jessie deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \
@@ -136,6 +145,7 @@ raspbian-jessie: ## build raspbian jessie deb packages
 raspbian-stretch: ## build raspbian stretch deb packages
 	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 	docker run --rm -i \
+		-e DEB_VERSION=$(DEB_VERSION) \
 		-e VERSION=$(VERSION) \
 		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 		-v $(CURDIR)/debbuild/$@:/build \

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -x
 set -e
+
+if [[ -z "$DEB_VERSION" ]]; then
+    echo "DEB_VERSION is required to build deb packages"
+    exit 1
+fi
+
 # I want to rip this install-binaries script out so badly
 cd engine
 TMP_GOPATH="/go" bash hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
@@ -15,36 +21,13 @@ echo VERSION AAA $VERSION
 VERSION=${VERSION:-$( cat engine/VERSION )}
 
 echo VERSION bbb $VERSION
-export TZ=UTC
 
-tilde='~' # ouch Bash 4.2 vs 4.3, you keel me
-# git running in different directories, backwards compatible too
-GIT_COMMAND="git --git-dir=/root/build-deb/engine/.git --work-tree=/root/build-deb/engine/"
-debVersion="${VERSION//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
-# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
-if [[ "$VERSION" == *-dev ]]; then
-    # TODO: Re-introduce git commit time into version number
-    todaysDate="$(date +'%Y%m%d.%H%M%S')"
-    # We're guaranteed to have DOCKER_GITCOMMIT in the env
-    gitVersion="git${todaysDate}.0.${DOCKER_GITCOMMIT}"
-    # gitVersion is now something like 'git20150128.112847.0.17e840a'
-    debVersion="$debVersion~$gitVersion"
-
-    # $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
-    # true
-    # $ dpkg --compare-versions 1.5.0~rc1 gt 1.5.0~git20150128.112847.17e840a && echo true || echo false
-    # true
-    # $ dpkg --compare-versions 1.5.0~git20150128.112847.17e840a gt 1.5.0~dev~git20150128.112847.17e840a && echo true || echo false
-    # true
-
-    # ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
-fi
 debSource="$(awk -F ': ' '$1 == "Source" { print $2; exit }' debian/control)"
 debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)"
 debDate="$(date --rfc-2822)"
 
 cat > "debian/changelog" <<-EOF
-$debSource (${debVersion}-0~${DISTRO}) $SUITE; urgency=low
+$debSource (${DEB_VERSION}-0~${DISTRO}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ENGINE_DIR="$1"
+VERSION="$2"
+
+[[ $# < 2 ]] && echo 'not enough args' && exit 1
+
+DATE_COMMAND="date"
+if [[ $(uname) -eq "Darwin" ]]; then
+    DATE_COMMAND="docker run --rm alpine date"
+fi
+
+TZ=UTC
+
+tilde='~' # ouch Bash 4.2 vs 4.3, you keel me
+# git running in different directories, backwards compatible too
+GIT_COMMAND="git -C $ENGINE_DIR"
+debVersion="${VERSION//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
+# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
+if [[ "$VERSION" == *-dev ]]; then
+    gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
+    gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
+    gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
+    gitVersion="git${gitDate}.0.${gitCommit}"
+    debVersion="$debVersion~$gitVersion"
+
+    # $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
+    # true
+    # $ dpkg --compare-versions 1.5.0~rc1 gt 1.5.0~git20150128.112847.17e840a && echo true || echo false
+    # true
+    # $ dpkg --compare-versions 1.5.0~git20150128.112847.17e840a gt 1.5.0~dev~git20150128.112847.17e840a && echo true || echo false
+    # true
+
+    # ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
+fi
+
+echo "$debVersion"


### PR DESCRIPTION
Dev builds for debian packages previously had system time inserted into
their packaging names while both static and rpm builds instead had the
git commit time.

This commit remedies that by pushing the generation of the debian
package version into a separate script to mirror what is being done in
static and rpm builds.

To give you an idea of what it looks like take the following examples:

```
❯ ./gen-deb-ver ~/work/docker-ce/components/engine/ $(cat ~/work/docker-ce/VERSION)
18.03.0~ce~dev~git20180202.170651.0.e232737
```

```
❯ ./gen-rpm-ver ~/work/docker-ce/components/engine $(cat ~/work/docker-ce/VERSION)
18.03.0.ce 0.0.dev.git20180202.170651.0.e232737 e232737
```

```
❯ ./gen-static-ver ~/work/docker-ce/components/engine/ $(cat ~/work/docker-ce/VERSION)
18.03.0-ce-dev-20180202.170651-e232737
```

Previous commit for reference: https://github.com/docker/docker-ce-packaging/commit/3618e4aa262f154f79c804752d69110772e636a3

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>