### PR TITLE
Remove ubuntu-zesty from the default DOCKER_BUILD_PKGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ rpm: ## build rpm packages
 	done
 
 .PHONY: deb
-deb: DOCKER_BUILD_PKGS:=ubuntu-zesty ubuntu-xenial ubuntu-trusty debian-buster debian-stretch debian-wheezy debian-jessie raspbian-stretch raspbian-jessie
+deb: DOCKER_BUILD_PKGS:=ubuntu-xenial ubuntu-trusty debian-buster debian-stretch debian-wheezy debian-jessie raspbian-stretch raspbian-jessie
 deb: ## build deb packages
 	for p in $(DOCKER_BUILD_PKGS); do \
 		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \


### PR DESCRIPTION
Zesty is EOL and doesn't even have a subdirectory in the `deb` directory of this repo. There's no need to have it as a default.

Signed-off-by: Corbin <corbin.coleman@docker.com>