### PR TITLE
Fixes binary installation

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -7,15 +7,15 @@ if [[ -z "$DEB_VERSION" ]]; then
     exit 1
 fi
 
-# I want to rip this install-binaries script out so badly
-cd engine
-TMP_GOPATH="/go" bash hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
-if [[ $? -ne 0 ]]; then
-    echo "Binaries required for package building not installed correctly."
-    echo "Exiting..."
-    exit 1
-fi
-cd -
+(
+    set -e
+    cd engine
+    # I want to rip this install-binaries script out so badly
+    for component in tini proxy runc containerd;do
+        TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+    done
+)
+
 echo VERSION AAA $VERSION
 
 VERSION=${VERSION:-$( cat engine/VERSION )}

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -67,7 +67,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -65,7 +65,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 mkdir -p plugin

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -66,7 +66,9 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-TMP_GOPATH="/go" hack/dockerfile/install-binaries.sh runc-dynamic containerd-dynamic proxy-dynamic tini
+for component in tini proxy runc containerd;do
+    TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
+done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
 mkdir -p plugin


### PR DESCRIPTION
Binary installation was broken after the
hack/dockerfile/install-binaries script was removed in https://github.com/moby/moby/pull/36336

This remedies that.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>