### PR TITLE
Add support to fedora-27 for armv7l platform

### DIFF
--- a/rpm/fedora-27/Dockerfile.armv7l
+++ b/rpm/fedora-27/Dockerfile.armv7l
@@ -1,0 +1,17 @@
+FROM arm32v7/fedora:27
+RUN dnf -y upgrade
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+ENV GO_VERSION 1.9.4
+ENV DISTRO fedora
+ENV SUITE 27
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
+COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
I couldn't find any discussion for this, but I currently do not know of any technical reasons to not support Fedora on armv7l, considering that Ubuntu already has armv7l support.

I compiled docker-ce into an rpm for Fedora using the standard process. Installation was a success. I launched several different containers without issue. I tested on Raspberry Pi and Orange Pi hardware.

Based on Dockerfile.aarch64, changing it to pull arm32v7 and download the armv6l build of Go.

**Output of `docker version`:**

```
Client:
 Version:       18.02.0-ce
 API version:   1.36
 Go version:    go1.9.4
 Git commit:    fc4de447b5-unsupported
 Built: Fri Mar  2 20:13:09 2018
 OS/Arch:       linux/arm
 Experimental:  false
 Orchestrator:  swarm

Server:
 Engine:
  Version:      18.02.0-ce
  API version:  1.36 (minimum version 1.12)
  Go version:   go1.9.4
  Git commit:   fc4de447b5-unsupported
  Built:        Fri Mar  2 20:34:55 2018
  OS/Arch:      linux/arm
  Experimental: false
```

**Output of `docker info`:**

```
Containers: 6
 Running: 1
 Paused: 0
 Stopped: 5
Images: 26
Server Version: 18.02.0-ce
Storage Driver: overlay2
 Backing Filesystem: extfs
 Supports d_type: true
 Native Overlay Diff: true
Logging Driver: json-file
Cgroup Driver: cgroupfs
Plugins:
 Volume: local
 Network: bridge host macvlan null overlay
 Log: awslogs fluentd gcplogs gelf journald json-file logentries splunk syslog
Swarm: inactive
Runtimes: runc
Default Runtime: runc
Init Binary: docker-init
containerd version: 9b55aab90508bd389d7654c4baf173a981477d55
runc version: 9f9c96235cc97674e935002fc3d78361b696a69e
init version: 949e6fa
Security Options:
 seccomp
  Profile: default
Kernel Version: 4.15.6-300.fc27.armv7hl
Operating System: Fedora 27 (Twenty Seven)
OSType: linux
Architecture: armv7l
CPUs: 4
Total Memory: 974.3MiB
Name: localhost.localdomain
ID: 5DOT:3XFN:4R5T:4ETU:D4IB:MJ6X:RSWC:X7PS:SCSM:UGQQ:CQGA:4FZD
Docker Root Dir: /var/lib/docker
Debug Mode (client): false
Debug Mode (server): false
Username: stellstall
Registry: https://index.docker.io/v1/
Labels:
Experimental: false
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: false
```