### PR TITLE
Use new 'dynamic' args in install.sh

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -11,7 +11,7 @@ fi
     set -e
     cd engine
     # I want to rip this install-binaries script out so badly
-    for component in tini proxy runc containerd;do
+    for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
         TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
     done
 )

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -67,7 +67,7 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-for component in tini proxy runc containerd;do
+for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
 VERSION=%{_origversion} hack/make.sh dynbinary

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -65,7 +65,7 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-for component in tini proxy runc containerd;do
+for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
 VERSION=%{_origversion} hack/make.sh dynbinary

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -66,7 +66,7 @@ pushd /go/src/github.com/docker/cli
 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
-for component in tini proxy runc containerd;do
+for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
 VERSION=%{_origversion} hack/make.sh dynbinary


### PR DESCRIPTION
Scripts were changed around to do static by default, this changes so
that we have "dynamic" inserted where it needs to be inserted

Relies on https://github.com/moby/moby/pull/36518

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>