### PR TITLE
Enable new test versioning scheme

### DIFF
--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -3,6 +3,8 @@
 ENGINE_DIR="$1"
 VERSION="$2"
 
+SUFFIX=${SUFFIX:=ce}
+
 [[ $# < 2 ]] && echo 'not enough args' && exit 1
 
 DATE_COMMAND="date"
@@ -10,12 +12,41 @@ if [[ $(uname) -eq "Darwin" ]]; then
     DATE_COMMAND="docker run --rm alpine date"
 fi
 
-TZ=UTC
+gen_deb_version() {
+    # Adds an increment to the deb version to get proper order
+    # 18.01.0-${SUFFIX}-tp1   -> 18.01.0-${SUFFIX}-0.1-tp1
+    # 18.01.0-${SUFFIX}-beta1 -> 18.01.0-${SUFFIX}-1.1-beta1
+    # 18.01.0-${SUFFIX}-rc1   -> 18.01.0-${SUFFIX}-2.1-rc1
+    # 18.01.0-${SUFFIX}       -> 18.01.0-${SUFFIX}-3
+    fullVersion="$1"
+    pattern="$2"
+    increment="$3"
+    testVersion="${fullVersion#*-$SUFFIX-*$pattern}"
+    baseVersion="${fullVersion%-"$pattern"*}"
+    echo "$baseVersion-$increment.$testVersion.$pattern$testVersion"
+}
+
+case "$VERSION" in
+    *-tp[0-9]*)
+        debVersion="$(gen_deb_version "$VERSION" tp 0)"
+        ;;
+    *-beta[0-9]*)
+        debVersion="$(gen_deb_version "$VERSION" beta 1)"
+        ;;
+    *-rc[0-9]*)
+        debVersion="$(gen_deb_version "$VERSION" rc 2)"
+        ;;
+    *)
+        debVersion="$VERSION-3"
+        ;;
+esac
+
+export TZ=UTC
 
 tilde='~' # ouch Bash 4.2 vs 4.3, you keel me
 # git running in different directories, backwards compatible too
 GIT_COMMAND="git -C $ENGINE_DIR"
-debVersion="${VERSION//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
+debVersion="${debVersion//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
 # if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
 if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -11,22 +11,30 @@ if [[ $(uname) -eq "Darwin" ]]; then
 fi
 
 GIT_COMMAND="git -C $ENGINE_DIR"
-rpmName=docker-ce
 rpmVersion="$VERSION"
-rpmRelease=1
+rpmRelease=3
 
 # rpmRelease versioning is as follows
-# Docker 1.7.0:  version=1.7.0, release=1
-# Docker 1.7.0-rc1: version=1.7.0, release=0.1.rc1
-# Docker 1.7.0-cs1: version=1.7.0.cs1, release=1
-# Docker 1.7.0-cs1-rc1: version=1.7.0.cs1, release=0.1.rc1
-# Docker 1.7.0-dev nightly: version=1.7.0, release=0.0.YYYYMMDD.HHMMSS.gitHASH
+# Docker 18.01.0-ce:  version=18.01.0.ce, release=3
+# Docker 18.01.0-ce-tp1: version=18.01.0.ce, release=0.1.tp1
+# Docker 18.01.0-ce-beta1: version=18.01.0.ce, release=1.1.beta1
+# Docker 18.01.0-ce-rc1: version=18.01.0.ce, release=2.1.rc1
+# Docker 18.01.0-ce-cs1: version=18.01.0.ce.cs1, release=1
+# Docker 18.01.0-ce-cs1-rc1: version=18.01.0.ce.cs1, release=0.1.rc1
+# Docker 18.01.0-ce-dev nightly: version=18.01.0.ce, release=0.0.YYYYMMDD.HHMMSS.gitHASH
 
-# if we have a "-rc*" suffix, set appropriate release
-if [[ "$rpmVersion" =~ .*-rc[0-9]+$ ]] ; then
+if [[ "$rpmVersion" =~ .*-tp[0-9]+$ ]]; then
+    tpVersion=${rpmVersion#*-tp}
+    rpmVersion=${rpmVersion%-tp*}
+    rpmRelease="0.${tpVersion}.tp${tpVersion}"
+elif [[ "$rpmVersion" =~ .*-beta[0-9]+$ ]]; then
+    betaVersion=${rpmVersion#*-beta}
+    rpmVersion=${rpmVersion%-beta*}
+    rpmRelease="1.${betaVersion}.beta${betaVersion}"
+elif [[ "$rpmVersion" =~ .*-rc[0-9]+$ ]]; then
     rcVersion=${rpmVersion#*-rc}
     rpmVersion=${rpmVersion%-rc*}
-    rpmRelease="0.${rcVersion}.rc${rcVersion}"
+    rpmRelease="2.${rcVersion}.rc${rcVersion}"
 fi
 
 DOCKER_GITCOMMIT=$($GIT_COMMAND rev-parse --short HEAD)


### PR DESCRIPTION
Enables the usage of a new versioning scheme for test builds:
```
* tp   -> Technical Previews
* beta -> Beta Releases
* rc   -> Release Candidates
* ga   -> General Availability Releases
```
This PR fixes the versioning order for both `deb` and `rpm` packages
when it relates to the new versioning scheme (which may or may not be
used).

## Proof of execution:

<details>
<summary>gen-rpm-ver</summary>

```
❯ for version in "tp1" "beta2" "rc3" ""; do echo -n "18.01.0-ce-$version: "; ./gen-rpm-ver ~/work/docker-ce/ "18.01.0-ce-$version"; done
18.01.0-ce-tp1: 18.01.0.ce 0.1.tp1 0b63fed
18.01.0-ce-beta2: 18.01.0.ce 1.2.beta2 0b63fed
18.01.0-ce-rc3: 18.01.0.ce 2.3.rc3 0b63fed
18.01.0-ce-: 18.01.0.ce. 3 0b63fed
```

</details>

<details>
<summary>gen-deb-ver</summary>

```
❯ for version in "tp1" "beta2" "rc3" ""; do echo -n "18.01.0-ce-$version: "; ./gen-deb-ver ~/work/docker-ce/ "18.01.0-ce-$version"; done
18.01.0-ce-tp1: 18.01.0~ce~0.1.tp1
18.01.0-ce-beta2: 18.01.0~ce~1.2.beta2
18.01.0-ce-rc3: 18.01.0~ce~2.3.rc3
18.01.0-ce-: 18.01.0~ce~~3
```

</details>

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>