### PR TITLE
Refactor epoch to be a passable variable for debian packaging

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -4,9 +4,20 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
-DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) $(VERSION))
+DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
+
+BUILD=docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
+RUN=docker run --rm -i \
+	-e DEB_VERSION=$(DEB_VERSION) \
+	-e VERSION=$(VERSION) \
+	-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+	-v $(CURDIR)/debbuild/$@:/build \
+	-v $(ENGINE_DIR):/engine \
+	-v $(CLI_DIR):/cli \
+	-v $(CURDIR)/systemd:/root/build-deb/systemd \
+	debbuild-$@/$(ARCH)
 
 .PHONY: help
 help: ## show make targets
@@ -31,126 +42,54 @@ raspbian: raspbian-stretch debian-jessie ## build all raspbian deb packages
 
 .PHONY: ubuntu-xenial
 ubuntu-xenial: ## build ubuntu xenial deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: ubuntu-trusty
 ubuntu-trusty: ## build ubuntu trusty deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: ubuntu-artful
 ubuntu-artful: ## build ubuntu artful deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-buster
 debian-buster: ## build debian buster deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-jessie
 debian-jessie: ## build debian jessie deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-stretch
 debian-stretch: ## build debian stretch deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-wheezy
 debian-wheezy: ## build debian wheezy deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: raspbian-jessie
 raspbian-jessie: ## build raspbian jessie deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: raspbian-stretch
 raspbian-stretch: ## build raspbian stretch deb packages
-	docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
-	docker run --rm -i \
-		-e DEB_VERSION=$(DEB_VERSION) \
-		-e VERSION=$(VERSION) \
-		-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
-		-v $(CURDIR)/debbuild/$@:/build \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CLI_DIR):/cli \
-		-v $(CURDIR)/systemd:/root/build-deb/systemd \
-		debbuild-$@/$(ARCH)
+	$(BUILD)
+	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -7,9 +7,11 @@ VERSION?=0.0.0-dev
 DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
+EPOCH?=
 
 BUILD=docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 RUN=docker run --rm -i \
+	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(DEB_VERSION) \
 	-e VERSION=$(VERSION) \
 	-e DOCKER_GITCOMMIT=$(GITCOMMIT) \

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -2,6 +2,12 @@
 set -x
 set -e
 
+EPOCH="${EPOCH:-}"
+EPOCH_SEP=""
+if [[ ! -z "$EPOCH" ]]; then
+    EPOCH_SEP=":"
+fi
+
 if [[ -z "$DEB_VERSION" ]]; then
     echo "DEB_VERSION is required to build deb packages"
     exit 1
@@ -27,7 +33,7 @@ debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/cont
 debDate="$(date --rfc-2822)"
 
 cat > "debian/changelog" <<-EOF
-$debSource (${DEB_VERSION}-0~${DISTRO}) $SUITE; urgency=low
+$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF


### PR DESCRIPTION
This refactors a large portion of `deb/Makefile` to make it easier to edit the run /build commands.

This also makes it so that `epoch` can be passed as a make variable and changed at the package building step allowing us to be a bit more flexible if/when the epoch needs to be changed.