### PR TITLE
Increments Epoch to 1

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -7,7 +7,7 @@ VERSION?=0.0.0-dev
 DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
 DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
-EPOCH?=
+EPOCH?=1
 
 BUILD=docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 RUN=docker run --rm -i \

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -9,6 +9,7 @@ Source1: cli.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
+Epoch: 1
 
 # DWZ problem with multiple golang binary, see bug
 # https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12

--- a/rpm/fedora-26/docker-ce.spec
+++ b/rpm/fedora-26/docker-ce.spec
@@ -9,6 +9,7 @@ Source1: cli.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
+Epoch: 1
 
 # DWZ problem with multiple golang binary, see bug
 # https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -9,6 +9,7 @@ Source1: cli.tgz
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
+Epoch: 1
 
 # DWZ problem with multiple golang binary, see bug
 # https://bugzilla.redhat.com/show_bug.cgi?id=995136#c12


### PR DESCRIPTION
Found a bug in our nightly build system after the introduction of the
new testing build suffixes where the latest builds weren't actually
being counted as the latest builds.

As seen in:
```
18.04.0~ce~dev~git20180315.170650.0.8fabfd2-0~debian
18.04.0~ce~dev~git20180314.170605.0.8024288-0~debian
...
18.04.0~ce~dev~3~git20180319.170823.0.4836f8c-0~debian
```

Where the last image is actually the latest package but is counted as
being a lesser version due to the inclusion of the `3` in the package
name.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>