### PR TITLE
Don't append number when doing a dev build

### DIFF
--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -27,6 +27,9 @@ gen_deb_version() {
 }
 
 case "$VERSION" in
+    *-dev)
+        debVersion="$VERSION"
+        ;;
     *-tp[0-9]*)
         debVersion="$(gen_deb_version "$VERSION" tp 0)"
         ;;


### PR DESCRIPTION
Found a bug where a number was being appended to the nightly dev builds
package name causing the latest packages not to be considered as the
latest packages by the package manager.

This makes it so that the number is not included on dev builds.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>