### PR TITLE
use seccomp for xenial

### DIFF
--- a/deb/ubuntu-xenial/Dockerfile.s390x
+++ b/deb/ubuntu-xenial/Dockerfile.s390x
@@ -6,8 +6,8 @@ ENV GO_VERSION 1.9.4
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 selinux
-ENV RUNC_BUILDTAGS apparmor selinux
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 COPY common/ /root/build-deb/debian
 COPY build-deb /root/build-deb/build-deb


### PR DESCRIPTION
For Xenial on s390x, we initially refrained from using seccomp buildtags as there has been a bug in the libseccomp2 version that was in 16.04.
However, libseccomp2 for Xenial is now on a level which does not have any restrictions anymore. (That is also true for all other s390x distributions).
Therefore, keep in sync with the rest of the world and use libseccomp for xenial.