### PR TITLE
Add building code for Ubuntu Bionic (18.04) LTS

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -34,7 +34,7 @@ clean: ## remove build artifacts
 deb: ubuntu debian raspbian ## build all deb packages
 
 .PHONY: ubuntu
-ubuntu: ubuntu-xenial ubuntu-trusty ## build all ubuntu deb packages
+ubuntu: ubuntu-bionic ubuntu-artful ubuntu-xenial ubuntu-trusty ## build all ubuntu deb packages
 
 .PHONY: debian
 debian: debian-stretch debian-wheezy debian-jessie ## build all debian deb packages
@@ -56,6 +56,12 @@ ubuntu-trusty: ## build ubuntu trusty deb packages
 
 .PHONY: ubuntu-artful
 ubuntu-artful: ## build ubuntu artful deb packages
+	$(BUILD)
+	$(RUN)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
+.PHONY: ubuntu-bionic
+ubuntu-bionic: ## build ubuntu bionic deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/deb/ubuntu-bionic/Dockerfile.s390x
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV GO_VERSION 1.9.4
+RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+COPY common/ /root/build-deb/debian
+COPY build-deb /root/build-deb/build-deb
+
+RUN mkdir -p /go/src/github.com/docker && \
+	mkdir -p /go/src/github.com/opencontainers && \
+	ln -snf /engine /root/build-deb/engine && \
+	ln -snf /cli /root/build-deb/cli && \
+	ln -snf /root/build-deb/engine /go/src/github.com/docker/docker && \
+	ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+
+
+ENV DISTRO ubuntu
+ENV SUITE bionic
+
+WORKDIR /root/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
Ubuntu Bionic (18.04) isn't scheduled to release until [April 26th](https://wiki.ubuntu.com/BionicBeaver/ReleaseSchedule) but Docker images are already up on Hub so we should get ahead of the curve when it comes to building the packages in our nightly pipeline.

![beaver power](https://sites.google.com/a/wiltonhs.com/the-north-american-beaver/home/defense-mechanisms/forest_animals_wallpaper_-_beaver.jpg?attredirects=0)

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>