### PR TITLE
Bump Golang to 1.9.5

### DIFF
--- a/deb/debian-buster/Dockerfile.armv7l
+++ b/deb/debian-buster/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.x86_64
+++ b/deb/debian-buster/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.aarch64
+++ b/deb/debian-jessie/Dockerfile.aarch64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev libudev-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.armv7l
+++ b/deb/debian-jessie/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.x86_64
+++ b/deb/debian-jessie/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.aarch64
+++ b/deb/debian-stretch/Dockerfile.aarch64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.armv7l
+++ b/deb/debian-stretch/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.x86_64
+++ b/deb/debian-stretch/Dockerfile.x86_64
@@ -6,7 +6,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-wheezy/Dockerfile.x86_64
+++ b/deb/debian-wheezy/Dockerfile.x86_64
@@ -8,7 +8,7 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list.d
 RUN apt-get update && apt-get install -y -t wheezy-backports btrfs-tools --no-install-recommends && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/raspbian-jessie/Dockerfile.armv7l
+++ b/deb/raspbian-jessie/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/raspbian-stretch/Dockerfile.armv7l
+++ b/deb/raspbian-stretch/Dockerfile.armv7l
@@ -6,7 +6,7 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/deb/ubuntu-artful/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ppc64le/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.s390x
+++ b/deb/ubuntu-artful/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM s390x/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/deb/ubuntu-artful/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.aarch64
+++ b/deb/ubuntu-bionic/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/deb/ubuntu-bionic/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.armv7l
+++ b/deb/ubuntu-trusty/Dockerfile.armv7l
@@ -4,7 +4,7 @@ FROM arm32v7/ubuntu:trusty
 RUN sed -i 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.x86_64
+++ b/deb/ubuntu-trusty/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.aarch64
+++ b/deb/ubuntu-xenial/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-xenial/Dockerfile.armv7l
+++ b/deb/ubuntu-xenial/Dockerfile.armv7l
@@ -2,7 +2,7 @@ FROM arm32v7/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.ppc64le
+++ b/deb/ubuntu-xenial/Dockerfile.ppc64le
@@ -2,7 +2,7 @@ FROM ppc64le/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.s390x
+++ b/deb/ubuntu-xenial/Dockerfile.s390x
@@ -2,7 +2,7 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.x86_64
+++ b/deb/ubuntu-xenial/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -17,7 +17,7 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -17,7 +17,7 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-26/Dockerfile.aarch64
+++ b/rpm/fedora-26/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/fedora:26
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 26
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-26/Dockerfile.x86_64
+++ b/rpm/fedora-26/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:26
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 26
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM arm64v8/fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -2,7 +2,7 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -2,7 +2,7 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.9.4
+ENV GO_VERSION 1.9.5
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local


### PR DESCRIPTION
go1.9.5 (released 2018/03/28) includes fixes to the compiler, go command, and
net/http/pprof package. See the Go 1.9.5 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.9.5

ping @andrewhsu @seemethere 