### PR TITLE
Remove "experimental" env-vars

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -5,7 +5,6 @@ CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
 DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
-DOCKER_EXPERIMENTAL:=0
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 EPOCH?=
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -3,7 +3,6 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
-DOCKER_EXPERIMENTAL=0
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
@@ -18,7 +17,6 @@ RPMBUILD_FLAGS=-ba\
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(VERSION)' \
-	--define '_experimental $(DOCKER_EXPERIMENTAL)' \
 	SPECS/docker-ce.spec
 
 .PHONY: help


### PR DESCRIPTION
Experimental features are no longer a build-time option, and can be enabled at runtime.


ping @seemethere @vdemeester I think these were no longer needed, but perhaps I missed something 😅 