### PR TITLE
Make DOCKER_BUILD_PKGS reflective

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ clean: ## remove build artifacts
 	$(MAKE) -C static clean
 
 .PHONY: rpm
-rpm: DOCKER_BUILD_PKGS:=fedora-27 fedora-26 centos-7
+rpm: DOCKER_BUILD_PKGS:=$(shell find rpm -type d | grep ".*-.*" | sed 's/^rpm\///')
 rpm: ## build rpm packages
 	for p in $(DOCKER_BUILD_PKGS); do \
 		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
 	done
 
 .PHONY: deb
-deb: DOCKER_BUILD_PKGS:=ubuntu-xenial ubuntu-trusty debian-buster debian-stretch debian-wheezy debian-jessie raspbian-stretch raspbian-jessie
+deb: DOCKER_BUILD_PKGS:=$(shell find deb -type d | grep ".*-.*" | sed 's/^deb\///')
 deb: ## build deb packages
 	for p in $(DOCKER_BUILD_PKGS); do \
 		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \


### PR DESCRIPTION
The hardcoded values make it so that we have to update this everytime we
add/subtract something which is sometimes followed/not followed.

This makes it so that we no longer have to update this.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>