### PR TITLE
Set GO_VERSION with a build arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ENGINE_DIR:=$(CURDIR)/../engine
 CLI_DIR:=$(CURDIR)/../cli
 VERSION?=0.0.0-dev
 DOCKER_GITCOMMIT:=abcdefg
+GO_VERSION:=1.10.2
 
 .PHONY: help
 help: ## show make targets
@@ -18,19 +19,19 @@ clean: ## remove build artifacts
 rpm: DOCKER_BUILD_PKGS:=$(shell find rpm -type d | grep ".*-.*" | sed 's/^rpm\///')
 rpm: ## build rpm packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) $${p}; \
 	done
 
 .PHONY: deb
 deb: DOCKER_BUILD_PKGS:=$(shell find deb -type d | grep ".*-.*" | sed 's/^deb\///')
 deb: ## build deb packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) $${p}; \
 	done
 
 .PHONY: static
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm
 static: ## build static-compiled packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) $${p}; \
 	done

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -4,11 +4,12 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
+GO_VERSION:=1.10.2
 DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 EPOCH?=
 
-BUILD=docker build -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
+BUILD=docker build --build-arg GO_VERSION=$(GO_VERSION) -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 RUN=docker run --rm -i \
 	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(DEB_VERSION) \

--- a/deb/debian-buster/Dockerfile.aarch64
+++ b/deb/debian-buster/Dockerfile.aarch64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.aarch64
+++ b/deb/debian-buster/Dockerfile.aarch64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.armv7l
+++ b/deb/debian-buster/Dockerfile.armv7l
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.armv7l
+++ b/deb/debian-buster/Dockerfile.armv7l
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.x86_64
+++ b/deb/debian-buster/Dockerfile.x86_64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile.x86_64
+++ b/deb/debian-buster/Dockerfile.x86_64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.aarch64
+++ b/deb/debian-jessie/Dockerfile.aarch64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev libudev-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.aarch64
+++ b/deb/debian-jessie/Dockerfile.aarch64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev libudev-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.armv7l
+++ b/deb/debian-jessie/Dockerfile.armv7l
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.armv7l
+++ b/deb/debian-jessie/Dockerfile.armv7l
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.x86_64
+++ b/deb/debian-jessie/Dockerfile.x86_64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-jessie/Dockerfile.x86_64
+++ b/deb/debian-jessie/Dockerfile.x86_64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.aarch64
+++ b/deb/debian-stretch/Dockerfile.aarch64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.aarch64
+++ b/deb/debian-stretch/Dockerfile.aarch64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.armv7l
+++ b/deb/debian-stretch/Dockerfile.armv7l
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.armv7l
+++ b/deb/debian-stretch/Dockerfile.armv7l
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.x86_64
+++ b/deb/debian-stretch/Dockerfile.x86_64
@@ -7,7 +7,6 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-stretch/Dockerfile.x86_64
+++ b/deb/debian-stretch/Dockerfile.x86_64
@@ -6,7 +6,8 @@ RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/raspbian-jessie/Dockerfile.armv7l
+++ b/deb/raspbian-jessie/Dockerfile.armv7l
@@ -6,7 +6,8 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/raspbian-jessie/Dockerfile.armv7l
+++ b/deb/raspbian-jessie/Dockerfile.armv7l
@@ -7,7 +7,6 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libudev-dev pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/raspbian-stretch/Dockerfile.armv7l
+++ b/deb/raspbian-stretch/Dockerfile.armv7l
@@ -6,7 +6,8 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/raspbian-stretch/Dockerfile.armv7l
+++ b/deb/raspbian-stretch/Dockerfile.armv7l
@@ -7,7 +7,6 @@ RUN sed -ri "s/archive.raspbian.org/$APT_MIRROR/g" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV GOARM 6
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/deb/ubuntu-artful/Dockerfile.armv7l
@@ -2,7 +2,8 @@ FROM arm32v7/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.armv7l
+++ b/deb/ubuntu-artful/Dockerfile.armv7l
@@ -3,7 +3,6 @@ FROM arm32v7/ubuntu:artful
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -2,7 +2,8 @@ FROM ppc64le/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.ppc64le
+++ b/deb/ubuntu-artful/Dockerfile.ppc64le
@@ -3,7 +3,6 @@ FROM ppc64le/ubuntu:artful
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.s390x
+++ b/deb/ubuntu-artful/Dockerfile.s390x
@@ -3,7 +3,6 @@ FROM s390x/ubuntu:artful
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.s390x
+++ b/deb/ubuntu-artful/Dockerfile.s390x
@@ -2,7 +2,8 @@ FROM s390x/ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/deb/ubuntu-artful/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM ubuntu:artful
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-artful/Dockerfile.x86_64
+++ b/deb/ubuntu-artful/Dockerfile.x86_64
@@ -3,7 +3,6 @@ FROM ubuntu:artful
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.aarch64
+++ b/deb/ubuntu-bionic/Dockerfile.aarch64
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-bionic/Dockerfile.aarch64
+++ b/deb/ubuntu-bionic/Dockerfile.aarch64
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.armv7l
+++ b/deb/ubuntu-bionic/Dockerfile.armv7l
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.ppc64le
+++ b/deb/ubuntu-bionic/Dockerfile.ppc64le
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev pkg-config vim-common libseccomp-dev libsystemd-dev libltdl-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/deb/ubuntu-bionic/Dockerfile.s390x
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.s390x
+++ b/deb/ubuntu-bionic/Dockerfile.s390x
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile.x86_64
+++ b/deb/ubuntu-bionic/Dockerfile.x86_64
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.armv7l
+++ b/deb/ubuntu-trusty/Dockerfile.armv7l
@@ -4,7 +4,8 @@ FROM arm32v7/ubuntu:trusty
 RUN sed -i 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.armv7l
+++ b/deb/ubuntu-trusty/Dockerfile.armv7l
@@ -5,7 +5,6 @@ RUN sed -i 's|security.ubuntu.com/ubuntu|ports.ubuntu.com/ubuntu-ports|' /etc/ap
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.x86_64
+++ b/deb/ubuntu-trusty/Dockerfile.x86_64
@@ -3,7 +3,6 @@ FROM ubuntu:trusty
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-trusty/Dockerfile.x86_64
+++ b/deb/ubuntu-trusty/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM ubuntu:trusty
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev  pkg-config vim-common libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.aarch64
+++ b/deb/ubuntu-xenial/Dockerfile.aarch64
@@ -2,7 +2,8 @@ FROM arm64v8/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-xenial/Dockerfile.aarch64
+++ b/deb/ubuntu-xenial/Dockerfile.aarch64
@@ -3,7 +3,6 @@ FROM arm64v8/ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go

--- a/deb/ubuntu-xenial/Dockerfile.armv7l
+++ b/deb/ubuntu-xenial/Dockerfile.armv7l
@@ -2,7 +2,8 @@ FROM arm32v7/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.armv7l
+++ b/deb/ubuntu-xenial/Dockerfile.armv7l
@@ -3,7 +3,6 @@ FROM arm32v7/ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.ppc64le
+++ b/deb/ubuntu-xenial/Dockerfile.ppc64le
@@ -3,7 +3,6 @@ FROM ppc64le/ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.ppc64le
+++ b/deb/ubuntu-xenial/Dockerfile.ppc64le
@@ -2,7 +2,8 @@ FROM ppc64le/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-ppc64le.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.s390x
+++ b/deb/ubuntu-xenial/Dockerfile.s390x
@@ -2,7 +2,8 @@ FROM s390x/ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.s390x
+++ b/deb/ubuntu-xenial/Dockerfile.s390x
@@ -3,7 +3,6 @@ FROM s390x/ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-s390x.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:/$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.x86_64
+++ b/deb/ubuntu-xenial/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM ubuntu:xenial
 
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-xenial/Dockerfile.x86_64
+++ b/deb/ubuntu-xenial/Dockerfile.x86_64
@@ -3,7 +3,6 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -3,6 +3,7 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
+GO_VERSION:=1.10.2
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
@@ -39,19 +40,19 @@ centos: centos-7 ## build all centos rpm packages
 
 .PHONY: fedora-28
 fedora-28: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
-	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-27
 fedora-27: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
-	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: centos-7
 centos-7: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
-	docker build -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -17,7 +17,8 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -18,7 +18,6 @@ RUN yum install -y \
    vim-common
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -17,7 +17,8 @@ RUN yum install -y \
    rpmdevtools \
    vim-common
 
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -18,7 +18,6 @@ RUN yum install -y \
    vim-common
 
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO centos
 ENV SUITE 7
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -2,7 +2,8 @@ FROM arm64v8/fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -3,7 +3,6 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM fedora:27
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -3,7 +3,6 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 27
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -2,7 +2,8 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -3,7 +3,6 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -3,7 +3,6 @@ RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
 ARG GO_VERSION
-ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -2,7 +2,8 @@ FROM fedora:28
 RUN dnf -y upgrade
 RUN dnf install -y @development-tools fedora-packager
 RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
-ENV GO_VERSION 1.10.2
+ARG GO_VERSION
+ENV GO_VERSION $GO_VERSION
 ENV DISTRO fedora
 ENV SUITE 28
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local


### PR DESCRIPTION
Use a variable in the Makefile to set the GO_VERSION for the builds.
GO_VERSION is defaulted in all Makefiles as `1.10.2`, but can be set when running make: `make GO_VERSION=1.10.1 deb`.

```
$ make DOCKER_BUILD_PKGS=ubuntu-xenial GO_VERSION=1.10.1 deb
for p in ubuntu-xenial; do \
	make -C deb VERSION=0.0.0-dev ENGINE_DIR=/home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/../engine CLI_DIR=/home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/../cli GO_VERSION=1.10.1 ${p}; \
done
make[1]: Entering directory '/home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/deb'
docker build --build-arg GO_VERSION=1.10.1 -t debbuild-ubuntu-xenial/x86_64 -f /home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/deb/ubuntu-xenial/Dockerfile.x86_64 .
Sending build context to Docker daemon  96.77kB
Step 1/16 : FROM ubuntu:xenial
 ---> 0b1edfbffd27
Step 2/16 : RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 3ede1973b4ee
Step 3/16 : ARG GO_VERSION
 ---> Running in 3f6ed3eedd28
 ---> 15f140b0d325
Removing intermediate container 3f6ed3eedd28
Step 4/16 : ENV GO_VERSION $GO_VERSION
 ---> Running in 4a53eda50372
 ---> 08f7a6a56f92

...

make[1]: Entering directory '/root/build-deb'
# if we're on Ubuntu, we need to Recommends: apparmor
echo 'apparmor:Recommends=apparmor' >> debian/docker-ce.substvars
dh_gencontrol
dpkg-gencontrol: warning: Depends field of package docker-ce: unknown substitution variable ${perl:Depends}
dpkg-gencontrol: warning: File::FcntlLock not available; using flock which is not NFS-safe
make[1]: Leaving directory '/root/build-deb'
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'docker-ce' in '../docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.deb'.
 dpkg-genchanges  >../docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.changes
dpkg-genchanges: including full source code in upload
 dpkg-source -I.git --after-build build-deb
dpkg-buildpackage: full upload; Debian-native package (full source is included)
+ destination=/build
+ mkdir -p /build
+ mv -v /root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.dsc /root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.tar.gz /root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.changes /root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.deb /build
'/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.dsc' -> '/build/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.dsc'
removed '/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.dsc'
'/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.tar.gz' -> '/build/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.tar.gz'
removed '/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu.tar.gz'
'/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.changes' -> '/build/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.changes'
removed '/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.changes'
'/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.deb' -> '/build/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.deb'
removed '/root/docker-ce_0.0.0~dev~git20180521.220527.0.5108bbc-0~ubuntu_amd64.deb'
docker run --rm -v /home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/deb:/v -w /v alpine chown -R 1000:1000 debbuild/ubuntu-xenial
make[1]: Leaving directory '/home/docker/go/src/github.com/docker/docker-ce/components/docker-ce-packaging/deb'
```

Signed-off-by: corbin-coleman <corbin.coleman@docker.com>