### PR TITLE
Remove pigz requirement for CentOS

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -28,7 +28,6 @@ Requires: libcgroup
 Requires: systemd-units
 Requires: tar
 Requires: xz
-Requires: pigz
 
 # Resolves: rhbz#1165615
 Requires: device-mapper-libs >= 1.02.90-1


### PR DESCRIPTION
The pigz binary is used to improve performance when pulling images, but is not available in the default CentOS package repositories.

Given that RPM's don't have a "recommends" option, it's better to remove it as a requirement for now, instead of failing to install for some users.

relates to https://github.com/moby/moby/pull/35697

fixes https://github.com/docker/for-linux/issues/299
