### PR TITLE
set the limit max open file to 1048576 in rpm's systemd file

### DIFF
--- a/rpm/systemd/docker.service
+++ b/rpm/systemd/docker.service
@@ -11,9 +11,9 @@ Type=notify
 # for containers run by docker
 ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 # Uncomment TasksMax if your systemd version supports it.


### PR DESCRIPTION
set the limit max open file to 1048576 (2^20)
since the the systemd default `infinity` only 65535 on Centos 7.x
see: https://github.com/systemd/systemd/pull/5795

```
[root@iZuf626h1w5m1739dw25bsZ ~]# lsb_release
LSB Version:	:core-4.1-amd64:core-4.1-noarch
[root@iZuf626h1w5m1739dw25bsZ ~]# lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 7.4.1708 (Core)
Release:	7.4.1708
Codename:	Core
[root@iZuf626h1w5m1739dw25bsZ ~]# cat /proc/$(pidof dockerd)/limits
Limit                     Soft Limit           Hard Limit           Units
Max cpu time              unlimited            unlimited            seconds
Max file size             unlimited            unlimited            bytes
Max data size             unlimited            unlimited            bytes
Max stack size            8388608              unlimited            bytes
Max core file size        unlimited            unlimited            bytes
Max resident set          unlimited            unlimited            bytes
Max processes             unlimited            unlimited            processes
Max open files            65536                65536                files
Max locked memory         65536                65536                bytes
Max address space         unlimited            unlimited            bytes
Max file locks            unlimited            unlimited            locks
Max pending signals       15088                15088                signals
Max msgqueue size         819200               819200               bytes
Max nice priority         0                    0
Max realtime priority     0                    0
Max realtime timeout      unlimited            unlimited            us
```

Signed-off-by: bingshen.wbs <bingshen.wbs@alibaba-inc.com>