### PR TITLE
Remove btrfs-progs in favor of libbtrfs-dev

### DIFF
--- a/deb/debian-buster/Dockerfile.aarch64
+++ b/deb/debian-buster/Dockerfile.aarch64
@@ -4,7 +4,7 @@ FROM debian:buster
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-progs build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion libbtrfs-dev build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev gnupg dirmngr --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local

--- a/deb/debian-buster/Dockerfile.armv7l
+++ b/deb/debian-buster/Dockerfile.armv7l
@@ -4,7 +4,7 @@ FROM arm32v7/debian:buster
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-progs build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion libbtrfs-dev build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-armv6l.tar.gz" | tar xzC /usr/local

--- a/deb/debian-buster/Dockerfile.x86_64
+++ b/deb/debian-buster/Dockerfile.x86_64
@@ -4,7 +4,7 @@ FROM debian:buster
 ARG APT_MIRROR=deb.debian.org
 RUN sed -ri "s/(httpredir|deb).debian.org/$APT_MIRROR/g" /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-progs build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apparmor bash-completion libbtrfs-dev build-essential cmake curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libseccomp-dev pkg-config vim-common libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ARG GO_VERSION
 RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local


### PR DESCRIPTION
`btrfs-progs` doesn't actually contain the files we need, since we only
need the headers for btrfs, which `libbtrfs-dev` now provides.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>