### PR TITLE
Change dev versioning to be purely git based

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -12,8 +12,8 @@ EPOCH?=
 BUILD=docker build --build-arg GO_VERSION=$(GO_VERSION) -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 RUN=docker run --rm -i \
 	-e EPOCH='$(EPOCH)' \
-	-e DEB_VERSION=$(DEB_VERSION) \
-	-e VERSION=$(VERSION) \
+	-e DEB_VERSION=$(word 1, $(DEB_VERSION)) \
+	-e VERSION=$(word 2, $(DEB_VERSION)) \
 	-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
 	-v $(CURDIR)/debbuild/$@:/build \
 	-v $(ENGINE_DIR):/engine \

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -7,7 +7,7 @@ VERSION?=0.0.0-dev
 GO_VERSION:=1.10.3
 DEB_VERSION=$(shell ./gen-deb-ver $(ENGINE_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
-EPOCH?=
+EPOCH?=1
 
 BUILD=docker build --build-arg GO_VERSION=$(GO_VERSION) -t debbuild-$@/$(ARCH) -f $(CURDIR)/$@/Dockerfile.$(ARCH) .
 RUN=docker run --rm -i \

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -2,6 +2,7 @@
 
 ENGINE_DIR="$1"
 VERSION="$2"
+origVersion=$VERSION
 
 SUFFIX=${SUFFIX:=ce}
 
@@ -55,8 +56,8 @@ if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    gitVersion="git${gitDate}.0.${gitCommit}"
-    debVersion="$debVersion~$gitVersion"
+    debVersion="0.${gitDate}~${gitCommit}"
+    origVersion=$debVersion
 
     # $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
     # true
@@ -68,4 +69,4 @@ if [[ "$VERSION" == *-dev ]]; then
     # ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
 fi
 
-echo "$debVersion"
+echo "$debVersion" "$origVersion"

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -5,8 +5,10 @@ GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
 GO_VERSION:=1.10.3
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
+EPOCH?=1
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
+	-e EPOCH="$(EPOCH)" \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES \
 	-v $(CURDIR)/rpmbuild/BUILD:/root/rpmbuild/BUILD \
 	-v $(CURDIR)/rpmbuild/BUILDROOT:/root/rpmbuild/BUILDROOT \

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -17,7 +17,7 @@ RPMBUILD_FLAGS=-ba\
 	--define '_gitcommit $(word 3,$(GEN_RPM_VER))' \
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
-	--define '_origversion $(VERSION)' \
+	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
 	SPECS/docker-ce.spec
 
 .PHONY: help

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -1,6 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
+Epoch: %{getenv:EPOCH}
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -1,6 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
+Epoch: %{getenv:EPOCH}
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -1,6 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
+Epoch: %{getenv:EPOCH}
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -11,6 +11,7 @@ if [[ $(uname) -eq "Darwin" ]]; then
 fi
 
 GIT_COMMAND="git -C $ENGINE_DIR"
+origVersion="$VERSION"
 rpmVersion="$VERSION"
 rpmRelease=3
 
@@ -47,12 +48,12 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    gitVersion="git${gitDate}.0.${gitCommit}"
     # gitVersion is now something like '20150128.112847.17e840a'
-    rpmVersion="${rpmVersion%-dev}"
-    rpmRelease="0.0.dev.$gitVersion"
+    rpmVersion="0.${gitDate}~${gitCommit}"
+    rpmRelease="0"
+    origVersion="0.${gitDate}~${gitCommit}"
 fi
 
 # Replace any other dashes with periods
 rpmVersion="${rpmVersion//-/.}"
-echo $rpmVersion $rpmRelease $DOCKER_GITCOMMIT
+echo $rpmVersion $rpmRelease $DOCKER_GITCOMMIT $origVersion

--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -19,7 +19,7 @@ if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    staticVersion="${VERSION}-${gitDate}-${gitCommit}"
+    staticVersion="${gitDate}~${gitCommit}"
 fi
 
 echo "$staticVersion"


### PR DESCRIPTION
# Overview
Switches dev versioning from being based on a set version like
`18.06.0-dev` to being based purely on the git commit timestamp / git
commit sha.

This should give us a bit more flexibility in terms of nightlies not
being tied to specific versions.

# Implementation details

Versioning will now look like this:

`0.${gitTimestamp}~${gitCommit}`

The prefixed `0.` is so that it will not *ever* get sorted above actual versions,
although it should never be in a position to be put in the same channel as actual
versions. 🤷‍♂️ 

<details>
<summary> Partial output of `docker version` </summary>

```
Client:
 Version:      0.20180706.170746~23d14578b4
 API version:  1.38
 Go version:   go1.10.3
 Git commit:   23d14578b4
 Built:        Fri Jul  6 17:26:29 2018
 OS/Arch:      linux/amd64
 Experimental: false
```

</details>



Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>