### PR TITLE
Add a `0.` to be more consistent with dev version

### DIFF
--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -19,7 +19,7 @@ if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    staticVersion="${gitDate}~${gitCommit}"
+    staticVersion="0.${gitDate}~${gitCommit}"
 fi
 
 echo "$staticVersion"


### PR DESCRIPTION
`.deb` and `.rpm` package dev version schemes are prefixed with a `0.` why not static tgz's as well. 🤷‍♂️ 

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>