### PR TITLE
Add initial scripts for Ubuntu Cosmic (18.10)

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -63,6 +63,13 @@ debian: debian-stretch debian-jessie ## build all debian deb packages
 .PHONY: raspbian
 raspbian: raspbian-stretch debian-jessie ## build all raspbian deb packages
 
+.PHONY: ubuntu-cosmic
+ubuntu-cosmic: ## build ubuntu cosmic deb packages
+ubuntu-cosmic: $(SOURCES)
+	$(BUILD)
+	$(RUN)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
 .PHONY: ubuntu-bionic
 ubuntu-bionic: ## build ubuntu bionic deb packages
 ubuntu-bionic: $(SOURCES)

--- a/deb/ubuntu-cosmic/Dockerfile
+++ b/deb/ubuntu-cosmic/Dockerfile
@@ -1,0 +1,38 @@
+ARG GO_IMAGE
+ARG ENGINE_IMAGE
+ARG BUILD_IMAGE=ubuntu:cosmic
+FROM ${GO_IMAGE} as golang
+FROM ${ENGINE_IMAGE} as engine
+
+FROM ${BUILD_IMAGE}
+
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ARG GO_VERSION
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+# Copy our sources and untar them
+COPY sources/ /sources
+RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
+
+RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
+
+ENV DISTRO ubuntu
+ENV SUITE cosmic
+
+COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
Cosmic isn't scheduled for GA until [October 18, 2018](https://wiki.ubuntu.com/Releases) but let's go ahead and add the scripts to get ahead of the curve.

~Biggest change is a shift from `btrfs-tools` -> `libbtrfs-dev`, which was already done for Debian Buster here https://github.com/docker/docker-ce-packaging/pull/113~

![cuttlefish](https://media.giphy.com/media/5Z0lBEtpdZf7a/giphy.gif)

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>