### PR TITLE
`~` -> `-` for dev versions

### DIFF
--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -56,7 +56,7 @@ if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    debVersion="0.${gitDate}~${gitCommit}"
+    debVersion="0.${gitDate}-${gitCommit}"
     origVersion=$debVersion
 
     # $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -49,9 +49,9 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
     # gitVersion is now something like '20150128.112847.17e840a'
-    rpmVersion="0.${gitDate}~${gitCommit}"
+    rpmVersion="0.${gitDate}-${gitCommit}"
     rpmRelease="0"
-    origVersion="0.${gitDate}~${gitCommit}"
+    origVersion="0.${gitDate}-${gitCommit}"
 fi
 
 # Replace any other dashes with periods

--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -19,7 +19,7 @@ if [[ "$VERSION" == *-dev ]]; then
     gitUnix="$($GIT_COMMAND log -1 --pretty='%at')"
     gitDate="$($DATE_COMMAND --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
     gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
-    staticVersion="0.${gitDate}~${gitCommit}"
+    staticVersion="0.${gitDate}-${gitCommit}"
 fi
 
 echo "$staticVersion"


### PR DESCRIPTION
tilde doesn't play nice with docker images so to be uniform let's
replace the tilde with a dash

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>