### PR TITLE
Switch image name on hub

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -4,7 +4,7 @@ CLI_DIR:=$(CURDIR)/../../cli
 VERSION?=0.0.0-dev
 STATIC_VERSION=$(shell ../static/gen-static-ver $(ENGINE_DIR) $(VERSION))
 DOCKER_HUB_ORG?=docker
-ENGINE_IMAGE?=ce-engine
+ENGINE_IMAGE?=engine-community
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
For the Q3 release the names will be refined slightly, and "ce" will no
longer be used - it's now just the docker engine, with "community" or
"enterprise" at the end if disambiguation is needed.