### PR TITLE
Add some essential packages required for the build to succeed

### DIFF
--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -19,6 +19,12 @@ Packager: Docker <support@docker.com>
 
 BuildRequires: pkgconfig(systemd)
 BuildRequires: pkgconfig(libsystemd-journal)
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: btrfs-progs-devel
+BuildRequires: device-mapper-devel
+BuildRequires: glibc-static
+BuildRequires: cmake
 
 # required packages on install
 Requires: /bin/sh

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -19,6 +19,12 @@ Packager: Docker <support@docker.com>
 %global _missing_build_ids_terminate_build 0
 
 BuildRequires: pkgconfig(systemd)
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: btrfs-progs-devel
+BuildRequires: device-mapper-devel
+BuildRequires: glibc-static
+BuildRequires: cmake
 
 # required packages on install
 Requires: /bin/sh

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -19,6 +19,12 @@ Packager: Docker <support@docker.com>
 %global _missing_build_ids_terminate_build 0
 
 BuildRequires: pkgconfig(systemd)
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: btrfs-progs-devel
+BuildRequires: device-mapper-devel
+BuildRequires: glibc-static
+BuildRequires: cmake
 
 # required packages on install
 Requires: /bin/sh


### PR DESCRIPTION
These turned out to be needed when bootstrapping CentOS 7 builds (eg without a working Docker infrastructure in place).  With any of them missing, the resulting build fails.

Listing them in `BuildRequires` seems like the correct approach, as it means rpm build tooling (eg `yum-builddep`) can automatically install them when missing.

This doesn't conflict with the Dockerfile setup approach either, so shouldn't be any issues there.