### PR TITLE
Add RPM packaging for 18.09.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 debbuild
 rpmbuild
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 debbuild
 rpmbuild
 tmp
+artifacts

--- a/common/dockerd.json
+++ b/common/dockerd.json
@@ -1,0 +1,11 @@
+{
+        "image": "${ENGINE_IMAGE}",
+        "namespace":"docker",
+        "args": [
+                "-s", "overlay",
+                "--containerd", "/run/containerd/containerd.sock",
+                "--default-runtime", "containerd",
+                "--add-runtime", "containerd=runc"
+        ],
+        "scope": "ce"
+}

--- a/common/dockerd.json
+++ b/common/dockerd.json
@@ -1,11 +1,11 @@
 {
-        "image": "${ENGINE_IMAGE}",
-        "namespace":"docker",
-        "args": [
-                "-s", "overlay",
-                "--containerd", "/run/containerd/containerd.sock",
-                "--default-runtime", "containerd",
-                "--add-runtime", "containerd=runc"
-        ],
-        "scope": "ce"
+    "image": "docker.io/seemethere/engine-community:0.0.0-20180814124044-678d4b3a6d.x86_64",
+    "namespace":"docker",
+    "args": [
+        "-s", "overlay",
+        "--containerd", "/run/containerd/containerd.sock",
+        "--default-runtime", "containerd",
+        "--add-runtime", "containerd=runc"
+    ],
+    "scope": "ce"
 }

--- a/containerd.mk
+++ b/containerd.mk
@@ -1,0 +1,17 @@
+# Common things for containerd functionality
+
+CONTAINERD_PROXY_COMMIT=3337fb47f10892318361b58c8483f19b1ffa8203
+CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:a4d1531
+
+# If the docker-containerd.sock is available use that, else use the default containerd.sock
+ifeq (,$(wildcard /var/run/docker/containerd/docker-containerd.sock))
+CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock
+else
+CONTAINERD_SOCK:=/var/run/containerd/containerd.sock
+endif
+CTR=docker run \
+	--rm -i \
+	-v $(CONTAINERD_SOCK):/ours/containerd.sock \
+	-v $(CURDIR)/artifacts:/artifacts \
+	docker:18.06.0-ce \
+	docker-containerd-ctr -a /ours/containerd.sock

--- a/containerd.mk
+++ b/containerd.mk
@@ -3,11 +3,11 @@
 CONTAINERD_PROXY_COMMIT=82ae3d13e91d062dd4853379fe018638023c8da2
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
-# If the docker-containerd.sock is available use that, else use the default containerd.sock
-ifeq (,$(wildcard /var/run/docker/containerd/docker-containerd.sock))
-CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock
-else
+# If containerd is running use that socket instead
+ifeq ($(shell systemctl status containerd 2>/dev/null >/dev/null && echo -n "yes"), "yes")
 CONTAINERD_SOCK:=/var/run/containerd/containerd.sock
+else
+CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock
 endif
 CTR=docker run \
 	--rm -i \

--- a/containerd.mk
+++ b/containerd.mk
@@ -1,7 +1,7 @@
 # Common things for containerd functionality
 
-CONTAINERD_PROXY_COMMIT=6615ae0be4014152533a83d44cdf9d3baa600d19
-CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:a4d1531
+CONTAINERD_PROXY_COMMIT=82ae3d13e91d062dd4853379fe018638023c8da2
+CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If the docker-containerd.sock is available use that, else use the default containerd.sock
 ifeq (,$(wildcard /var/run/docker/containerd/docker-containerd.sock))

--- a/containerd.mk
+++ b/containerd.mk
@@ -1,6 +1,6 @@
 # Common things for containerd functionality
 
-CONTAINERD_PROXY_COMMIT=3337fb47f10892318361b58c8483f19b1ffa8203
+CONTAINERD_PROXY_COMMIT=6615ae0be4014152533a83d44cdf9d3baa600d19
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:a4d1531
 
 # If the docker-containerd.sock is available use that, else use the default containerd.sock

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -45,49 +45,49 @@ debian: debian-stretch debian-jessie ## build all debian deb packages
 raspbian: raspbian-stretch debian-jessie ## build all raspbian deb packages
 
 .PHONY: ubuntu-xenial
-ubuntu-xenial: engine-$(ARCH).tar ## build ubuntu xenial deb packages
+ubuntu-xenial: ## build ubuntu xenial deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: ubuntu-trusty
-ubuntu-trusty: engine-$(ARCH).tar ## build ubuntu trusty deb packages
+ubuntu-trusty: ## build ubuntu trusty deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: ubuntu-bionic
-ubuntu-bionic: engine-$(ARCH).tar ## build ubuntu bionic deb packages
+ubuntu-bionic: ## build ubuntu bionic deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-buster
-debian-buster: engine-$(ARCH).tar ## build debian buster deb packages
+debian-buster: ## build debian buster deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-jessie
-debian-jessie: engine-$(ARCH).tar ## build debian jessie deb packages
+debian-jessie: ## build debian jessie deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: debian-stretch
-debian-stretch: engine-$(ARCH).tar ## build debian stretch deb packages
+debian-stretch: ## build debian stretch deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: raspbian-jessie
-raspbian-jessie: engine-$(ARCH).tar ## build raspbian jessie deb packages
+raspbian-jessie: ## build raspbian jessie deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 .PHONY: raspbian-stretch
-raspbian-stretch: engine-$(ARCH).tar ## build raspbian stretch deb packages
+raspbian-stretch: ## build raspbian stretch deb packages
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/image/Makefile
+++ b/image/Makefile
@@ -3,7 +3,7 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 VERSION?=0.0.0-dev
 STATIC_VERSION=$(shell ../static/gen-static-ver $(ENGINE_DIR) $(VERSION))
-DOCKER_HUB_ORG?=docker
+DOCKER_HUB_ORG?=dockereng
 ARCH=$(shell uname -m)
 ENGINE_IMAGE?=engine-community
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -15,7 +15,12 @@ RPMBUILD_FLAGS=-ba\
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
-	SPECS/docker-ce-cli.spec SPECS/docker-ce.spec
+	SPECS/docker-ce.spec SPECS/docker-ce-cli.spec
+
+SOURCE_TGZS=containerd-proxy.tgz cli.tgz
+SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_TGZS))
+
+CONTAINERD_PROXY_COMMIT=3337fb47f10892318361b58c8483f19b1ffa8203
 
 .PHONY: help
 help: ## show make targets
@@ -24,7 +29,8 @@ help: ## show make targets
 .PHONY: clean
 clean: ## remove build artifacts
 	[ ! -d rpmbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-	rm -rf rpmbuild
+	$(RM) -r rpmbuild
+	$(RM) -r tmp/
 
 .PHONY: rpm
 rpm: fedora centos ## build all rpm packages
@@ -36,19 +42,22 @@ fedora: fedora-28 fedora-27 fedora-26 ## build all fedora rpm packages
 centos: centos-7 ## build all centos rpm packages
 
 .PHONY: fedora-28
-fedora-28: rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
+fedora-28: ## build fedora-28 rpm packages
+fedora-28: $(SOURCES)
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-27
-fedora-27: rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
+fedora-27: ## build fedora-27 rpm packages
+fedora-27: $(SOURCES)
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: centos-7
-centos-7: rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
+centos-7: ## build centos-7 rpm packages
+centos-7: $(SOURCES)
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
@@ -60,3 +69,14 @@ rpmbuild/SOURCES/cli.tgz:
 		-v $(CURDIR)/rpmbuild/SOURCES:/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
+
+rpmbuild/SOURCES/containerd-proxy.tgz:
+	mkdir -p tmp/
+	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT)/ours.tar.gz"
+	tar xzf tmp/containerd-proxy.tgz -C tmp/
+	mv tmp/containerd-proxy-$(CONTAINERD_PROXY_COMMIT) tmp/containerd-proxy
+	mkdir -p $(@D)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
+	tar -zcf $@ -C tmp/ containerd-proxy
+	rm -rf tmp/
+	$(CHOWN) -R root:root rpmbuild/SOURCES

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -19,8 +19,8 @@ RPMBUILD_FLAGS=-ba\
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
 	SPECS/docker-ce.spec SPECS/docker-ce-cli.spec
 
-SOURCE_TGZS=containerd-proxy.tgz cli.tgz containerd-shim-process.tar
-SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_TGZS))
+SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json
+SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 .PHONY: help
 help: ## show make targets
@@ -29,7 +29,10 @@ help: ## show make targets
 .PHONY: clean
 clean: ## remove build artifacts
 	[ ! -d rpmbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-	$(RM) -r rpmbuild
+	$(RM) -r rpmbuild/
+	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
+	$(RM) -r artifacts/
+	[ ! -d tmp ] || $(CHOWN) -R $(shell id -u):$(shell id -g) tmp
 	$(RM) -r tmp/
 
 .PHONY: rpm
@@ -89,3 +92,11 @@ rpmbuild/SOURCES/containerd-shim-process.tar:
 	mkdir -p $(@D)
 	cp artifacts/containerd-shim-process.tar $@
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
+
+rpmbuild/SOURCES/docker.service: ../systemd/docker.service
+	mkdir -p $(@D)
+	cp $< $@
+
+rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
+	mkdir -p $(@D)
+	cp $< $@

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -100,3 +100,5 @@ rpmbuild/SOURCES/docker.service: ../systemd/docker.service
 rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
 	mkdir -p $(@D)
 	cp $< $@
+
+# TODO: Figure out a sufficient offline solution

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -5,7 +5,9 @@ ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
+GO_BASE_IMAGE=golang
 GO_VERSION:=1.10.3
+GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
@@ -48,7 +50,7 @@ centos: centos-7 ## build all centos rpm packages
 fedora-28: ## build fedora-28 rpm packages
 fedora-28: $(SOURCES)
 	$(CHOWN) -R root:root rpmbuild
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
+	docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
@@ -56,7 +58,7 @@ fedora-28: $(SOURCES)
 fedora-27: ## build fedora-27 rpm packages
 fedora-27: $(SOURCES)
 	$(CHOWN) -R root:root rpmbuild
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
+	docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
@@ -64,7 +66,7 @@ fedora-27: $(SOURCES)
 centos-7: ## build centos-7 rpm packages
 centos-7: $(SOURCES)
 	$(CHOWN) -R root:root rpmbuild
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
+	docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -4,21 +4,18 @@ CLI_DIR:=$(CURDIR)/../../cli
 GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
 GO_VERSION:=1.10.3
-GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
+GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES \
-	-v $(CURDIR)/rpmbuild/BUILD:/root/rpmbuild/BUILD \
-	-v $(CURDIR)/rpmbuild/BUILDROOT:/root/rpmbuild/BUILDROOT \
 	-v $(CURDIR)/rpmbuild/RPMS:/root/rpmbuild/RPMS \
-	-v $(CURDIR)/rpmbuild/SRPMS:/root/rpmbuild/SRPMS \
-	-v $(CURDIR)/systemd:/systemd
+	-v $(CURDIR)/rpmbuild/SRPMS:/root/rpmbuild/SRPMS
 RPMBUILD_FLAGS=-ba\
 	--define '_gitcommit $(word 3,$(GEN_RPM_VER))' \
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
-	SPECS/docker-ce.spec
+	SPECS/docker-ce-cli.spec SPECS/docker-ce.spec
 
 .PHONY: help
 help: ## show make targets
@@ -43,20 +40,20 @@ engine-$(ARCH).tar:
 	docker save -o $@ $$(cat ../image/image-linux) 
 
 .PHONY: fedora-28
-fedora-28: engine-$(ARCH).tar rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+fedora-28: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-27
-fedora-27:engine-$(ARCH).tar rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+fedora-27: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: centos-7
-centos-7:engine-$(ARCH).tar rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) $@
+centos-7: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
@@ -67,11 +64,3 @@ rpmbuild/SOURCES/cli.tgz:
 		-v $(CURDIR)/rpmbuild/SOURCES:/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
-
-rpmbuild/SOURCES/engine.tgz:
-	mkdir -p rpmbuild/SOURCES
-	docker run --rm -i -w /v \
-		-v $(ENGINE_DIR):/engine \
-		-v $(CURDIR)/rpmbuild/SOURCES:/v \
-		alpine \
-		tar -C / -c -z -f /v/engine.tgz --exclude .git engine

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,3 +1,5 @@
+include ../containerd.mk
+
 ARCH=$(shell uname -m)
 ENGINE_DIR:=$(CURDIR)/../../engine
 CLI_DIR:=$(CURDIR)/../../cli
@@ -17,10 +19,8 @@ RPMBUILD_FLAGS=-ba\
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
 	SPECS/docker-ce.spec SPECS/docker-ce-cli.spec
 
-SOURCE_TGZS=containerd-proxy.tgz cli.tgz
+SOURCE_TGZS=containerd-proxy.tgz cli.tgz containerd-shim-process.tar
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_TGZS))
-
-CONTAINERD_PROXY_COMMIT=3337fb47f10892318361b58c8483f19b1ffa8203
 
 .PHONY: help
 help: ## show make targets
@@ -44,6 +44,7 @@ centos: centos-7 ## build all centos rpm packages
 .PHONY: fedora-28
 fedora-28: ## build fedora-28 rpm packages
 fedora-28: $(SOURCES)
+	$(CHOWN) -R root:root rpmbuild
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
@@ -51,6 +52,7 @@ fedora-28: $(SOURCES)
 .PHONY: fedora-27
 fedora-27: ## build fedora-27 rpm packages
 fedora-27: $(SOURCES)
+	$(CHOWN) -R root:root rpmbuild
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
@@ -58,6 +60,7 @@ fedora-27: $(SOURCES)
 .PHONY: centos-7
 centos-7: ## build centos-7 rpm packages
 centos-7: $(SOURCES)
+	$(CHOWN) -R root:root rpmbuild
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
@@ -79,4 +82,10 @@ rpmbuild/SOURCES/containerd-proxy.tgz:
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 	tar -zcf $@ -C tmp/ containerd-proxy
 	rm -rf tmp/
-	$(CHOWN) -R root:root rpmbuild/SOURCES
+
+rpmbuild/SOURCES/containerd-shim-process.tar:
+	$(CTR) content fetch $(CONTAINERD_SHIM_PROCESS_IMAGE)
+	$(CTR) image export artifacts/containerd-shim-process.tar $(CONTAINERD_SHIM_PROCESS_IMAGE)
+	mkdir -p $(@D)
+	cp artifacts/containerd-shim-process.tar $@
+	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -35,24 +35,20 @@ fedora: fedora-28 fedora-27 fedora-26 ## build all fedora rpm packages
 .PHONY: centos
 centos: centos-7 ## build all centos rpm packages
 
-engine-$(ARCH).tar:
-	$(MAKE) -C ../image image-linux
-	docker save -o $@ $$(cat ../image/image-linux) 
-
 .PHONY: fedora-28
-fedora-28: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
+fedora-28: rpmbuild/SOURCES/cli.tgz ## build fedora-28 rpm packages
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-27
-fedora-27: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
+fedora-27: rpmbuild/SOURCES/cli.tgz ## build fedora-27 rpm packages
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: centos-7
-centos-7: engine-$(ARCH).tar rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
+centos-7: rpmbuild/SOURCES/cli.tgz ## build centos-7 rpm packages
 	docker build --build-arg GO_VERSION=$(GO_VERSION) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile.$(ARCH) .
 	$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -1,0 +1,100 @@
+%global debug_package %{nil}
+
+Name: docker-ce-cli
+Version: %{_version}
+Release: %{_release}%{?dist}
+Epoch: %{getenv:EPOCH}
+Summary: The open-source application container engine
+Group: Tools/Docker
+License: ASL 2.0
+Source0: cli.tgz
+URL: https://www.docker.com
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+# required packages on install
+Requires: /bin/sh
+Requires: containerd
+
+# conflicting packages
+Conflicts: docker
+Conflicts: docker-io
+Conflicts: docker-engine-cs
+Conflicts: docker-ee
+Conflicts: docker-ee-cli
+
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
+
+%description
+Docker is an open source project to build, ship and run any application as a
+lightweight container.
+
+Docker containers are both hardware-agnostic and platform-agnostic. This means
+they can run anywhere, from your laptop to the largest EC2 compute instance and
+everything in between - and they don't require you to use a particular
+language, framework or packaging system. That makes them great building blocks
+for deploying and scaling web apps, databases, and backend services without
+depending on a particular stack or provider.
+
+%prep
+%setup -q -c -n src
+
+%build
+mkdir -p /go/src/github.com/docker
+rm -f /go/src/github.com/docker/cli
+ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+pushd /go/src/github.com/docker/cli
+DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
+popd
+
+# %check
+# cli/build/docker -v
+
+%install
+# install binary
+install -d $RPM_BUILD_ROOT/%{_bindir}
+install -p -m 755 cli/build/docker $RPM_BUILD_ROOT/%{_bindir}/docker
+
+# add bash, zsh, and fish completions
+install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
+install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
+install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
+install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+
+# install manpages
+install -d %{buildroot}%{_mandir}/man1
+install -p -m 644 cli/man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1
+install -d %{buildroot}%{_mandir}/man5
+install -p -m 644 cli/man/man5/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
+install -d %{buildroot}%{_mandir}/man8
+install -p -m 644 cli/man/man8/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
+
+mkdir -p build-docs
+for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
+    cp "cli/$cli_file" "build-docs/$cli_file"
+done
+
+# list files owned by the package here
+%files
+%doc build-docs/LICENSE build-docs/MAINTAINERS build-docs/NOTICE build-docs/README.md
+/%{_bindir}/docker
+/usr/share/bash-completion/completions/docker
+/usr/share/zsh/vendor-completions/_docker
+/usr/share/fish/vendor_completions.d/docker.fish
+%doc
+/%{_mandir}/man1/*
+/%{_mandir}/man5/*
+/%{_mandir}/man8/*
+
+
+%post
+if ! getent group docker > /dev/null; then
+    groupadd --system docker
+fi
+
+%changelog

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -3,7 +3,7 @@
 Name: docker-ce-cli
 Version: %{_version}
 Release: %{_release}%{?dist}
-Epoch: %{getenv:EPOCH}
+Epoch: 0
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -15,6 +15,9 @@ Packager: Docker <support@docker.com>
 # required packages on install
 Requires: /bin/sh
 Requires: containerd
+
+BuildRequires: make
+BuildRequires: libtool-ltdl-devel
 
 # conflicting packages
 Conflicts: docker

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -6,6 +6,7 @@ Release: %{_release}%{?dist}
 Epoch: 2
 Source0: containerd-proxy.tgz
 Source1: containerd-shim-process.tar
+Source2: docker.service
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -14,10 +15,15 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
+Requires: systemd-units
+Requires: iptables
 # Should be required as well by docker-ce-cli but let's just be thorough
 Requires: containerd.io
 
+BuildRequires: which
+BuildRequires: make
 BuildRequires: gcc
+BuildRequires: pkgconfig(systemd)
 
 # conflicting packages
 Conflicts: docker
@@ -49,20 +55,58 @@ depending on a particular stack or provider.
 mkdir -p /go/src/github.com/crosbymichael/
 ls %{_topdir}/BUILD/src
 ln -s %{_topdir}/BUILD/src/containerd-proxy /go/src/github.com/crosbymichael/containerd-proxy
-go build -v -o /build/dockerd github.com/crosbymichael/containerd-proxy
+pushd /go/src/github.com/crosbymichael/containerd-proxy
+make SCOPE_LABEL="com.docker/containerd-proxy.scope" ANY_SCOPE="ee" bin/containerd-proxy
+popd
 
 %install
-install -D -m 0755 /build/dockerd $RPM_BUILD_ROOT/%{_bindir}/dockerd
-# TODO: Use containerd-offline-installer to actually install this as ExecStartPre systemd step
+# Install containerd-proxy as dockerd
+install -D -m 0755 %{_topdir}/BUILD/src/containerd-proxy/bin/containerd-proxy $RPM_BUILD_ROOT/%{_bindir}/dockerd
 install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd/containerd-shim-process.tar
+install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/containerd-proxy/dockerd.json
 
 %files
 /%{_bindir}/dockerd
 /%{_sharedstatedir}/containerd/containerd-shim-process.tar
+/%{_unitdir}/docker.service
+/etc/containerd-proxy/dockerd.json
+
+%pre
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %post
+%systemd_post docker
 if ! getent group docker > /dev/null; then
     groupadd --system docker
+fi
+
+%preun
+%systemd_preun docker
+
+%postun
+%systemd_postun_with_restart docker
+
+%posttrans
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
 fi
 
 %changelog

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -5,6 +5,7 @@ Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: %{getenv:EPOCH}
 Source0: containerd-proxy.tgz
+Source1: containerd-shim-process.tar
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -13,6 +14,8 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
+# Should be required as well by docker-ce-cli but let's just be thorough
+Requires: containerd.io
 
 # conflicting packages
 Conflicts: docker
@@ -40,6 +43,7 @@ depending on a particular stack or provider.
 %setup -q -c -n src
 
 %build
+# dockerd proxy compilation
 mkdir -p /go/src/github.com/crosbymichael/
 ls %{_topdir}/BUILD/src
 ln -s %{_topdir}/BUILD/src/containerd-proxy /go/src/github.com/crosbymichael/containerd-proxy
@@ -47,9 +51,12 @@ go build -v -o /build/dockerd github.com/crosbymichael/containerd-proxy
 
 %install
 install -D -m 0755 /build/dockerd $RPM_BUILD_ROOT/%{_bindir}/dockerd
+# TODO: Use containerd-offline-installer to actually install this as ExecStartPre systemd step
+install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd/containerd-shim-process.tar
 
 %files
 /%{_bindir}/dockerd
+/%{_sharedstatedir}/containerd/containerd-shim-process.tar
 
 %post
 if ! getent group docker > /dev/null; then

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -4,6 +4,7 @@ Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: %{getenv:EPOCH}
+Source0: containerd-proxy.tgz
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -35,17 +36,24 @@ language, framework or packaging system. That makes them great building blocks
 for deploying and scaling web apps, databases, and backend services without
 depending on a particular stack or provider.
 
+%prep
+%setup -q -c -n src
+
+%build
+mkdir -p /go/src/github.com/crosbymichael/
+ls %{_topdir}/BUILD/src
+ln -s %{_topdir}/BUILD/src/containerd-proxy /go/src/github.com/crosbymichael/containerd-proxy
+go build -v -o /build/dockerd github.com/crosbymichael/containerd-proxy
+
 %install
+install -D -m 0755 /build/dockerd $RPM_BUILD_ROOT/%{_bindir}/dockerd
 
 %files
+/%{_bindir}/dockerd
 
 %post
 if ! getent group docker > /dev/null; then
     groupadd --system docker
-fi
-# TODO Needs upgrade vs. install logic handling here
-if ctr --namespace docker container info dockerd > /dev/null 2>&1 ; then
-    docker engine init
 fi
 
 %changelog

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -3,7 +3,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
-Epoch: %{getenv:EPOCH}
+Epoch: 2
 Source0: containerd-proxy.tgz
 Source1: containerd-shim-process.tar
 Summary: The open-source application container engine
@@ -16,6 +16,8 @@ Packager: Docker <support@docker.com>
 Requires: docker-ce-cli
 # Should be required as well by docker-ce-cli but let's just be thorough
 Requires: containerd.io
+
+BuildRequires: gcc
 
 # conflicting packages
 Conflicts: docker

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -62,29 +62,29 @@ popd
 %install
 # Install containerd-proxy as dockerd
 install -D -m 0755 %{_topdir}/BUILD/src/containerd-proxy/bin/containerd-proxy $RPM_BUILD_ROOT/%{_bindir}/dockerd
-install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd/containerd-shim-process.tar
+install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/containerd-proxy/dockerd.json
 
 %files
 /%{_bindir}/dockerd
-/%{_sharedstatedir}/containerd/containerd-shim-process.tar
+/%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
 /%{_unitdir}/docker.service
 /etc/containerd-proxy/dockerd.json
 
 %pre
-# if [ $1 -gt 0 ] ; then
-#     # package upgrade scenario, before new files are installed
-# 
-#     # clear any old state
-#     rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-# 
-#     # check if docker service is running
-#     if systemctl is-active docker > /dev/null 2>&1; then
-#         systemctl stop docker > /dev/null 2>&1 || :
-#         touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-#     fi
-# fi
+if [ $1 -gt 0 ] ; then
+    # package upgrade scenario, before new files are installed
+
+    # clear any old state
+    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+
+    # check if docker service is running
+    if systemctl is-active docker > /dev/null 2>&1; then
+        systemctl stop docker > /dev/null 2>&1 || :
+        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %post
 %systemd_post docker
@@ -99,14 +99,14 @@ fi
 %systemd_postun_with_restart docker
 
 %posttrans
-# if [ $1 -ge 0 ] ; then
-#     # package upgrade scenario, after new files are installed
-# 
-#     # check if docker was running before upgrade
-#     if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
-#         systemctl start docker > /dev/null 2>&1 || :
-#         rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-#     fi
-# fi
+if [ $1 -ge 0 ] ; then
+    # package upgrade scenario, after new files are installed
+
+    # check if docker was running before upgrade
+    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+        systemctl start docker > /dev/null 2>&1 || :
+        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+    fi
+fi
 
 %changelog

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -73,18 +73,18 @@ install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/container
 /etc/containerd-proxy/dockerd.json
 
 %pre
-if [ $1 -gt 0 ] ; then
-    # package upgrade scenario, before new files are installed
-
-    # clear any old state
-    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-
-    # check if docker service is running
-    if systemctl is-active docker > /dev/null 2>&1; then
-        systemctl stop docker > /dev/null 2>&1 || :
-        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-    fi
-fi
+# if [ $1 -gt 0 ] ; then
+#     # package upgrade scenario, before new files are installed
+# 
+#     # clear any old state
+#     rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+# 
+#     # check if docker service is running
+#     if systemctl is-active docker > /dev/null 2>&1; then
+#         systemctl stop docker > /dev/null 2>&1 || :
+#         touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+#     fi
+# fi
 
 %post
 %systemd_post docker
@@ -99,14 +99,14 @@ fi
 %systemd_postun_with_restart docker
 
 %posttrans
-if [ $1 -ge 0 ] ; then
-    # package upgrade scenario, after new files are installed
-
-    # check if docker was running before upgrade
-    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
-        systemctl start docker > /dev/null 2>&1 || :
-        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-    fi
-fi
+# if [ $1 -ge 0 ] ; then
+#     # package upgrade scenario, after new files are installed
+# 
+#     # check if docker was running before upgrade
+#     if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
+#         systemctl start docker > /dev/null 2>&1 || :
+#         rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
+#     fi
+# fi
 
 %changelog

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -1,0 +1,51 @@
+%global debug_package %{nil}
+
+Name: docker-ce
+Version: %{_version}
+Release: %{_release}%{?dist}
+Epoch: %{getenv:EPOCH}
+Summary: The open-source application container engine
+Group: Tools/Docker
+License: ASL 2.0
+URL: https://www.docker.com
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+Requires: docker-ce-cli
+
+# conflicting packages
+Conflicts: docker
+Conflicts: docker-io
+Conflicts: docker-engine-cs
+Conflicts: docker-ee
+
+# Obsolete packages
+Obsoletes: docker-ce-selinux
+Obsoletes: docker-engine-selinux
+Obsoletes: docker-engine
+
+%description
+Docker is an open source project to build, ship and run any application as a
+lightweight container.
+
+Docker containers are both hardware-agnostic and platform-agnostic. This means
+they can run anywhere, from your laptop to the largest EC2 compute instance and
+everything in between - and they don't require you to use a particular
+language, framework or packaging system. That makes them great building blocks
+for deploying and scaling web apps, databases, and backend services without
+depending on a particular stack or provider.
+
+%install
+
+%files
+
+%post
+if ! getent group docker > /dev/null; then
+    groupadd --system docker
+fi
+# TODO Needs upgrade vs. install logic handling here
+if ctr --namespace docker container info dockerd > /dev/null 2>&1 ; then
+    docker engine init
+fi
+
+%changelog

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -13,8 +13,7 @@ ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 COPY SPECS /root/rpmbuild/SPECS
 RUN yum install -y rpm-build rpmlint
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM centos:7
 ENV DISTRO centos

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -11,11 +11,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+COPY SPECS /root/rpmbuild/SPECS
 RUN yum install -y rpm-build rpmlint
-RUN rpmlint /root/rpmbuild/SPECS/docker-ce.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/docker-ce.spec # this always exits 0 so need to rpmlint before running
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -11,11 +11,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
 RUN yum install -y rpm-build rpmlint
-RUN rpmlint /root/rpmbuild/SPECS/docker-ce.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/docker-ce.spec # this always exits 0 so need to rpmlint before running
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY SPECS /root/rpmbuild/SPECS
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -13,8 +13,7 @@ ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM centos:7
 ENV DISTRO centos

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM fedora:27
 ENV DISTRO fedora

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -11,10 +11,9 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN yum install -y rpm-build rpmlint
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -11,10 +11,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
-RUN dnf install -y rpm-build dnf-plugins-core
-RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+RUN yum install -y rpm-build rpmlint
+COPY SPECS /root/rpmbuild/SPECS
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -11,10 +11,9 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN yum install -y rpm-build rpmlint
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM fedora:27
 ENV DISTRO fedora

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -11,10 +11,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
-RUN dnf install -y rpm-build dnf-plugins-core
-RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+RUN yum install -y rpm-build rpmlint
+COPY SPECS /root/rpmbuild/SPECS
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM fedora:28
 ENV DISTRO fedora

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -11,10 +11,9 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN yum install -y rpm-build rpmlint
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -11,10 +11,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
-RUN dnf install -y rpm-build dnf-plugins-core
-RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+RUN yum install -y rpm-build rpmlint
+COPY SPECS /root/rpmbuild/SPECS
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -9,12 +9,11 @@ ENV SUITE 28
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
-RUN dnf install -y rpm-build dnf-plugins-core
-RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
-RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+RUN yum install -y rpm-build rpmlint
+COPY SPECS /root/rpmbuild/SPECS
+RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -10,10 +10,9 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN yum install -y rpm-build rpmlint
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-RUN rpmlint /root/rpmbuild/SPECS/*.spec # make sure spec file is ok before installing build deps
-RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec # this always exits 0 so need to rpmlint before running
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -1,7 +1,5 @@
-FROM alpine:latest as golang
-RUN apk add curl
-ARG GO_VERSION
-RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
 
 FROM fedora:28
 ENV DISTRO fedora

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -8,10 +8,8 @@ Wants=network-online.target containerd.service
 # Install containerd-shim-process if it's not already installed
 ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offline-installer/containerd-shim-process.tar docker.io/docker/containerd-shim-process
 ExecStart=/usr/bin/dockerd
-TimeoutSec=infinity
-KillMode=process
+TimeoutSec=0
 Restart=always
-Delegate=yes
 # On RPM Based distributions PATH isn't defined so we define it here
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary
 Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/local/bin:$PATH"

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -6,7 +6,7 @@ Wants=network-online.target containerd.service
 
 [Service]
 # Install containerd-shim-process if it's not already installed
-ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd/containerd-shim-process.tar docker.io/docker/containerd-shim-process
+ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offline-installer/containerd-shim-process.tar docker.io/docker/containerd-shim-process
 ExecStart=/usr/bin/dockerd
 TimeoutSec=infinity
 KillMode=process

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -5,28 +5,16 @@ After=network-online.target firewalld.service containerd.service
 Wants=network-online.target containerd.service
 
 [Service]
-Type=notify
 # Install containerd-shim-process if it's not already installed
 ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd/containerd-shim-process.tar docker.io/docker/containerd-shim-process
 ExecStart=/usr/bin/dockerd
-ExecReload=/bin/kill -s HUP $MAINPID
-# Having non-zero Limit*s causes performance problems due to accounting overhead
-# in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
-LimitNPROC=infinity
-LimitCORE=infinity
-# Uncomment TasksMax if your systemd version supports it.
-# Only systemd 226 and above support this version.
-#TasksMax=infinity
-TimeoutStartSec=0
-# set delegate yes so that systemd does not reset the cgroups of docker containers
-Delegate=yes
-# kill only the docker process, not all processes in the cgroup
+TimeoutSec=infinity
 KillMode=process
-# restart the docker process if it exits prematurely
-Restart=on-failure
-StartLimitBurst=3
-StartLimitInterval=60s
+Restart=always
+Delegate=yes
+# On RPM Based distributions PATH isn't defined so we define it here
+# /opt/containerd/bin is in front so dockerd grabs the correct runc binary
+Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/local/bin:$PATH"
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,14 +1,13 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target firewalld.service
-Wants=network-online.target
+After=network-online.target firewalld.service containerd.service
+Wants=network-online.target containerd.service
 
 [Service]
 Type=notify
-# the default is not to use systemd for cgroups because the delegate issues still
-# exists and systemd currently does not support the cgroup feature set required
-# for containers run by docker
+# Install containerd-shim-process if it's not already installed
+ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd/containerd-shim-process.tar docker.io/docker/containerd-shim-process
 ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Splits out the docker-ce package and docker-ce-cli package into their
own things.

Includes functionality for running dockerd as a host process that's managed by containerd.

Dependencies include:
* containerd.io package (not yet released, soon though...)
* [containerd-proxy](https://github.com/crosbymichael/containerd-proxy)
* [containerd-shim-process](https://hub.docker.com/r/docker/containerd-shim-process/) (available as a hub image)

Still TODO: (as in stuff for other PR's)
* Offline installation support (will need a way to dump engine images to oci compliant tar balls)
* Not hardcoding the engine image in the `dockerd.json` 
* Not pointing to Seemethere's org (engine image)

~Still TODO: need to have a cleanup on the dependencies for the
Dockerfiles~ This is done

~NOTE: this relies on functionality being added here: https://github.com/docker/cli/pull/1260~ There's no dependency on this anymore

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>