### PR TITLE
removing -H flag from debian systemd unit file

### DIFF
--- a/deb/systemd/docker.service
+++ b/deb/systemd/docker.service
@@ -10,7 +10,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
Why are we being forced to use the default value for docker socket setting because it is hard coded in the systemd unit file on Debian/Ubuntu? This should be an easily configurable option through `/etc/docker/daemon.json` but since it is being passed as a flag to `dockerd` in the systemd unit we get the following non-recoverable error when attempting to start docker:

```
Jul 30 03:26:22 dmz1 dockerd[5467]: unable to configure the Docker daemon with file /etc/docker/daemon.json: the following directives are specified both as a flag and in the configuration file: hosts: (from flag: [fd://], from file: [unix:///var/run/docker.sock])
```

Please fix this issue. This PR is just the simplest possible fix, but if it was in there for a reason please provide an alternative solution; like having a default `/etc/docker/daemon.json` config pushed from the deb package. This will make configuration management (like https://github.com/gbolo/ansible-role-docker) a lot easier to maintain. Also note that this issue **does not exist** in the Redhat/CentOS systemd unit file. 