### PR TITLE
Don't delete the engine when cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean-image:
 
 
 .PHONY: clean
-clean: clean-engine clean-image ## remove build artifacts
+clean: clean-image ## remove build artifacts
 	$(MAKE) -C rpm clean
 	$(MAKE) -C deb clean
 	$(MAKE) -C static clean


### PR DESCRIPTION
The engine component was being deleted on the call to clean. 
This is problematic because the clean target is called prior to building the engine image, and the engine is needed for building. 

This fixes that problem.

Signed-off-by: Jose Bigio <jose.bigio@docker.com>