### PR TITLE
[18.06] add PRODUCT=docker env var when building engine

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -10,7 +10,7 @@ override_dh_gencontrol:
 	dh_gencontrol
 
 override_dh_auto_build:
-	cd engine && ./hack/make.sh dynbinary
+	cd engine && PRODUCT=docker ./hack/make.sh dynbinary
 	cd /go/src/github.com/docker/cli && LDFLAGS='' make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
 
 override_dh_auto_test:

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -69,7 +69,7 @@ pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
-VERSION=%{_origversion} hack/make.sh dynbinary
+VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 
 %check

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -69,7 +69,7 @@ pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
-VERSION=%{_origversion} hack/make.sh dynbinary
+VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 mkdir -p plugin
 printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -69,7 +69,7 @@ pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
-VERSION=%{_origversion} hack/make.sh dynbinary
+VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 mkdir -p plugin
 printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata


### PR DESCRIPTION
To accommodate for changes in https://github.com/docker/engine/pull/21