### PR TITLE
Fix static version variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CLI_DIR:=$(CURDIR)/../cli
 VERSION?=0.0.0-dev
 DOCKER_GITCOMMIT:=abcdefg
 ARCH=$(shell uname -m)
-STATIC_VERSION=$(shell ../static/gen-static-ver $(ENGINE_DIR) $(VERSION))
+STATIC_VERSION=$(shell static/gen-static-ver $(ENGINE_DIR) $(VERSION))
 GO_VERSION:=1.10.3
 
 # Taken from: https://www.cmcrossroads.com/article/printing-value-makefile-variable


### PR DESCRIPTION
The static version variable was copied from Makefile/image, so it needed to be updated.

Signed-off-by: Jose Bigio <jose.bigio@docker.com>