### PR TITLE
refactor building of RPMs to multi-stage

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -5,10 +5,8 @@ GITCOMMIT=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
 VERSION?=0.0.0-dev
 GO_VERSION:=1.10.3
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(ENGINE_DIR) $(VERSION))
-EPOCH?=2
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 RPMBUILD=docker run --privileged --rm -i\
-	-e EPOCH="$(EPOCH)" \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES \
 	-v $(CURDIR)/rpmbuild/BUILD:/root/rpmbuild/BUILD \
 	-v $(CURDIR)/rpmbuild/BUILDROOT:/root/rpmbuild/BUILDROOT \

--- a/rpm/centos-7/Dockerfile.aarch64
+++ b/rpm/centos-7/Dockerfile.aarch64
@@ -1,33 +1,21 @@
-FROM arm64v8/centos:7
-RUN yum groupinstall -y "Development Tools"
-RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y \
-   glibc-static \
-   btrfs-progs-devel \
-   device-mapper-devel \
-   libseccomp-devel \
-   libselinux-devel \
-   libtool-ltdl-devel \
-   selinux-policy-devel \
-   systemd-devel \
-   pkgconfig \
-   tar \
-   git \
-   cmake \
-   rpmdevtools \
-   vim-common
-
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+
+FROM centos:7
 ENV DISTRO centos
 ENV SUITE 7
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
-RUN mkdir -p /go
 ENV GOPATH=/go
-ENV PATH $PATH:/usr/local/go/bin:/go/bin
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN yum install -y rpm-build rpmlint
+RUN rpmlint /root/rpmbuild/SPECS/docker-ce.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/docker-ce.spec # this always exits 0 so need to rpmlint before running
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/Dockerfile.x86_64
+++ b/rpm/centos-7/Dockerfile.x86_64
@@ -1,33 +1,21 @@
-FROM centos:7
-RUN yum groupinstall -y "Development Tools"
-RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y \
-   glibc-static \
-   btrfs-progs-devel \
-   device-mapper-devel \
-   libseccomp-devel \
-   libselinux-devel \
-   libtool-ltdl-devel \
-   selinux-policy-devel \
-   systemd-devel \
-   pkgconfig \
-   tar \
-   git \
-   cmake \
-   rpmdevtools \
-   vim-common
-
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+
+FROM centos:7
 ENV DISTRO centos
 ENV SUITE 7
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-RUN mkdir -p /go
 ENV GOPATH=/go
-ENV PATH $PATH:/usr/local/go/bin:/go/bin
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN yum install -y rpm-build rpmlint
+RUN rpmlint /root/rpmbuild/SPECS/docker-ce.spec # make sure spec file is ok before installing build deps
+RUN yum-builddep -y /root/rpmbuild/SPECS/docker-ce.spec # this always exits 0 so need to rpmlint before running
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -17,6 +17,15 @@ Packager: Docker <support@docker.com>
 %global is_systemd 1
 %global with_selinux 1
 
+BuildRequires: make
+BuildRequires: cmake
+BuildRequires: gcc
+BuildRequires: git
+BuildRequires: glibc-static
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: device-mapper-devel
+BuildRequires: btrfs-progs-devel
 BuildRequires: pkgconfig(systemd)
 BuildRequires: pkgconfig(libsystemd-journal)
 

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -1,7 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
-Epoch: %{getenv:EPOCH}
+Epoch: 2
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/centos-7/docker-ce.spec
+++ b/rpm/centos-7/docker-ce.spec
@@ -64,7 +64,7 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
-make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
+DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do

--- a/rpm/fedora-27/Dockerfile.aarch64
+++ b/rpm/fedora-27/Dockerfile.aarch64
@@ -1,17 +1,20 @@
-FROM arm64v8/fedora:27
-RUN dnf -y upgrade
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+
+FROM fedora:27
 ENV DISTRO fedora
 ENV SUITE 27
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN dnf install -y rpm-build dnf-plugins-core
+RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile.x86_64
+++ b/rpm/fedora-27/Dockerfile.x86_64
@@ -1,17 +1,20 @@
-FROM fedora:27
-RUN dnf -y upgrade
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+
+FROM fedora:27
 ENV DISTRO fedora
 ENV SUITE 27
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN dnf install -y rpm-build dnf-plugins-core
+RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -18,6 +18,15 @@ Packager: Docker <support@docker.com>
 %global with_selinux 1
 %global _missing_build_ids_terminate_build 0
 
+BuildRequires: make
+BuildRequires: cmake
+BuildRequires: gcc
+BuildRequires: git
+BuildRequires: glibc-static
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: device-mapper-devel
+BuildRequires: btrfs-progs-devel
 BuildRequires: pkgconfig(systemd)
 
 # required packages on install

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -1,7 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
-Epoch: %{getenv:EPOCH}
+Epoch: 2
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -64,7 +64,7 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
-make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
+DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do

--- a/rpm/fedora-28/Dockerfile.aarch64
+++ b/rpm/fedora-28/Dockerfile.aarch64
@@ -1,17 +1,20 @@
-FROM fedora:28
-RUN dnf -y upgrade
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
+
+FROM fedora:28
 ENV DISTRO fedora
 ENV SUITE 28
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN dnf install -y rpm-build dnf-plugins-core
+RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile.x86_64
+++ b/rpm/fedora-28/Dockerfile.x86_64
@@ -1,17 +1,20 @@
-FROM fedora:28
-RUN dnf -y upgrade
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel pkgconfig selinux-policy selinux-policy-devel systemd-devel tar git cmake vim-common
+FROM alpine:latest as golang
+RUN apk add curl
 ARG GO_VERSION
+RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+
+FROM fedora:28
 ENV DISTRO fedora
 ENV SUITE 28
-RUN curl -fSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-RUN mkdir -p /go/src/github.com/docker && mkdir -p /go/src/github.com/opencontainers
 COPY docker-ce.spec /root/rpmbuild/SPECS/docker-ce.spec
+RUN dnf install -y rpm-build dnf-plugins-core
+RUN dnf builddep -y /root/rpmbuild/SPECS/docker-ce.spec
+RUN mkdir -p /go/src/github.com/docker /go/src/github.com/opencontainers
+COPY --from=golang /usr/local/go /usr/local/go/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -18,6 +18,15 @@ Packager: Docker <support@docker.com>
 %global with_selinux 1
 %global _missing_build_ids_terminate_build 0
 
+BuildRequires: make
+BuildRequires: cmake
+BuildRequires: gcc
+BuildRequires: git
+BuildRequires: glibc-static
+BuildRequires: libtool-ltdl-devel
+BuildRequires: libseccomp-devel
+BuildRequires: device-mapper-devel
+BuildRequires: btrfs-progs-devel
 BuildRequires: pkgconfig(systemd)
 
 # required packages on install

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -1,7 +1,7 @@
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
-Epoch: %{getenv:EPOCH}
+Epoch: 2
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -64,7 +64,7 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
-make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
+DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 pushd engine
 for component in tini "proxy dynamic" "runc all" "containerd dynamic";do


### PR DESCRIPTION
Refactor building of RPMs to multi-stage `Dockerfile`. Also moved the build deps into the spec file and reduced to just the packages used to build docker-ce. Had to hard-code the `Epoch` in the spec file to get `yum-builddep` to work.

Reduced build times from 6'30" to 5'04" and reduced the RPM build image size from 1.5G to 1.1G.

No functionality change in the final RPM produced.

Before:
```
$ time make -C components/packaging DOCKER_BUILD_PKGS=fedora-28 rpm
...
Wrote: /root/rpmbuild/SRPMS/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.src.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-debugsource-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-debuginfo-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.XMBPYm
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd src
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.x86_64
+ exit 0
docker run --rm -i -v /home/ubuntu/src/docker-ce/components/packaging/rpm:/v -w /v alpine chown -R 1000:1000 rpmbuild
make[1]: Leaving directory '/home/ubuntu/src/docker-ce/components/packaging/rpm'
make: Leaving directory '/home/ubuntu/src/docker-ce/components/packaging'

real    6m30.551s
user    0m1.623s
sys     0m0.747s
$ docker images|grep rpmbuild
rpmbuild-fedora-28/x86_64   latest        95293927c4ba        28 hours ago        1.52GB
```


After:
```
$ time make -C components/packaging DOCKER_BUILD_PKGS=fedora-28 rpm
...
Wrote: /root/rpmbuild/SRPMS/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.src.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-debugsource-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-ce-debuginfo-0.0.0.20180810123659.af7228d929-0.fc28.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.XLB95Z
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd src
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/docker-ce-0.0.0.20180810123659.af7228d929-0.fc28.x86_64
+ exit 0
docker run --rm -i -v /home/ubuntu/src/docker-ce/components/packaging/rpm:/v -w /v alpine chown -R 1000:1000 rpmbuild
make[1]: Leaving directory '/home/ubuntu/src/docker-ce/components/packaging/rpm'
make: Leaving directory '/home/ubuntu/src/docker-ce/components/packaging'

real    5m4.253s
user    0m1.162s
sys     0m0.491s
$ docker images|grep rpmbuild
rpmbuild-fedora-28/x86_64   latest        4a77cb32f184        4 minutes ago       1.1GB
```