### PR TITLE
Add some changes to make things more configurable

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -12,8 +12,10 @@ DEB_VERSION=$(shell ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 EPOCH?=2
 
-BUILD=docker build \
+COMMON_FILES=common
+BUILD?=docker build \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
+	--build-arg COMMON_FILES=$(COMMON_FILES) \
 	-t debbuild-$@/$(ARCH) \
 	-f $(CURDIR)/$@/Dockerfile .
 RUN=docker run --rm -i \

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/debian-jessie/Dockerfile
+++ b/deb/debian-jessie/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/raspbian-jessie/Dockerfile
+++ b/deb/raspbian-jessie/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/ubuntu-trusty/Dockerfile
+++ b/deb/ubuntu-trusty/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -11,7 +11,8 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
-COPY common/ /root/build-deb/debian
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 # Copy our sources and untar them

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -10,7 +10,15 @@ GO_VERSION:=1.10.3
 GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
-BUILD=docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/Dockerfile .
+
+DOCKERFILE=Dockerfile
+ifdef NEEDS_ARCH_SPECIFIC
+	DOCKERFILE=Dockerfile.$(ARCH)
+endif
+BUILD=docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/$(DOCKERFILE) .
+
+SPEC_FILES=docker-ce.spec docker-ce-cli.spec
+SPECS=$(addprefix SPECS/, $(SPEC_FILES))
 RPMBUILD=docker run --privileged --rm -i\
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES \
 	-v $(CURDIR)/rpmbuild/RPMS:/root/rpmbuild/RPMS \
@@ -20,7 +28,7 @@ RPMBUILD_FLAGS=-ba\
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
-	SPECS/docker-ce.spec SPECS/docker-ce-cli.spec
+	$(SPECS)
 RUN=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
 SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json


### PR DESCRIPTION
Allows us to switch out debian files and rpm specs on the fly and also
gives us an out to have ARCH specific dockerfiles if we need them for
RPM's. The same strategy can be used for DEB's if need be

Going to merge on green.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>