### PR TITLE
Make the curl for containerd-proxy more resilient

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -124,7 +124,7 @@ sources/cli.tgz:
 
 sources/containerd-proxy.tgz:
 	mkdir -p tmp/
-	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT)/ours.tar.gz"
+	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT).tar.gz"
 	tar xzf tmp/containerd-proxy.tgz -C tmp/
 	mv tmp/containerd-proxy-$(CONTAINERD_PROXY_COMMIT) tmp/containerd-proxy
 	mkdir -p $(@D)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -90,7 +90,7 @@ rpmbuild/SOURCES/cli.tgz:
 
 rpmbuild/SOURCES/containerd-proxy.tgz:
 	mkdir -p tmp/
-	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT)/ours.tar.gz"
+	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT).tar.gz"
 	tar xzf tmp/containerd-proxy.tgz -C tmp/
 	mv tmp/containerd-proxy-$(CONTAINERD_PROXY_COMMIT) tmp/containerd-proxy
 	mkdir -p $(@D)


### PR DESCRIPTION
Was reporting 404's using the old url for some reason, might have to
refactor this in the future to just use a git clone...

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>