### PR TITLE
Set up default product license for community engines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ DOCKER_GITCOMMIT:=abcdefg
 ARCH=$(shell uname -m)
 STATIC_VERSION=$(shell static/gen-static-ver $(ENGINE_DIR) $(VERSION))
 GO_VERSION:=1.10.3
+DEFAULT_PRODUCT_LICENSE:=Community Engine
+export DEFAULT_PRODUCT_LICENSE
 
 # Taken from: https://www.cmcrossroads.com/article/printing-value-makefile-variable
 print-%  : ; @echo $($*)

--- a/image/Dockerfile.engine
+++ b/image/Dockerfile.engine
@@ -14,9 +14,17 @@ FROM builder as dockerd-builder
 WORKDIR /go/src/github.com/docker/docker
 COPY . /go/src/github.com/docker/docker
 ARG VERSION
+ARG GITCOMMIT
+ARG BUILDTIME
+ARG PLATFORM
+ARG PRODUCT
+ARG DEFAULT_PRODUCT_LICENSE
 ENV VERSION ${VERSION}
-ARG DOCKER_GITCOMMIT
-ENV DOCKER_GITCOMMIT ${DOCKER_GITCOMMIT}
+ENV GITCOMMIT ${GITCOMMIT}
+ENV BUILDTIME ${BUILDTIME}
+ENV PLATFORM ${PLATFORM}
+ENV PRODUCT ${PRODUCT}
+ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
 # TODO The way we set the version could easily be simplified not to depend on hack/...
 RUN bash ./hack/make/.go-autogen
 RUN go build -o /sbin/dockerd \

--- a/image/Makefile
+++ b/image/Makefile
@@ -6,6 +6,7 @@ STATIC_VERSION=$(shell ../static/gen-static-ver $(ENGINE_DIR) $(VERSION))
 DOCKER_HUB_ORG?=dockereng
 ARCH=$(shell uname -m)
 ENGINE_IMAGE?=engine-community
+DEFAULT_PRODUCT_LICENSE?=Community Engine
 
 .PHONY: help
 help: ## show make targets
@@ -27,8 +28,12 @@ $(ENGINE_DIR)/Dockerfile.engine:
 # utilize manifests
 image-linux: $(ENGINE_DIR)/Dockerfile.engine
 	docker build -t $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) \
-	    --build-arg VERSION=$(STATIC_VERSION) \
-	    --build-arg DOCKER_GITCOMMIT=$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD) \
+	    --build-arg VERSION="$(STATIC_VERSION)" \
+	    --build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
+	    --build-arg BUILDTIME="$(BUILDTIME)" \
+	    --build-arg PLATFORM="$(PLATFORM)" \
+	    --build-arg PRODUCT="$(PRODUCT)" \
+	    --build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
 	    --file $< $(ENGINE_DIR)
 	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) > $@
 

--- a/static/Makefile
+++ b/static/Makefile
@@ -6,6 +6,7 @@ STATIC_VERSION=$(shell ./gen-static-ver $(ENGINE_DIR) $(VERSION))
 CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
+DEFAULT_PRODUCT_LICENSE?=Community Engine
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
This will report a fixed string for community engines

Related to https://github.com/moby/moby/pull/37612