### PR TITLE
Do offline bundles for engine installs

### DIFF
--- a/common/dockerd.json
+++ b/common/dockerd.json
@@ -1,5 +1,6 @@
 {
-    "image": "docker.io/${ENGINE_IMAGE}:${IMAGE_TAG}",
+    "image": "docker.io/${ENGINE_IMAGE}",
+    "imagePath": "/var/lib/docker-engine/engine.tar",
     "namespace":"docker",
     "args": [
         "-s", "overlay",

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -26,7 +26,7 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json
+SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 ENGINE_IMAGE=docker/engine-community
 
@@ -44,6 +44,7 @@ clean: ## remove build artifacts
 	$(RM) -r sources
 	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
 	$(RM) -r artifacts
+	-docker rm docker2oci
 
 engine-$(ARCH).tar:
 	$(MAKE) -C ../image image-linux
@@ -150,4 +151,21 @@ sources/dockerd.json: ../common/dockerd.json
 	mkdir -p $(@D)
 	sed -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' $< > $@
 
-# TODO: Figure out a sufficient offline solution
+# TODO: Eventually clean this up when we release an image with a manifest
+DOCKER2OCI=artifacts/docker2oci
+$(DOCKER2OCI):
+	-$(CHOWN) -R $(shell id -u):$(shell id -g) $(@D)
+	docker run --name docker2oci $(GO_IMAGE) sh -c 'go get github.com/coolljt0725/docker2oci'
+	mkdir -p $(@D)
+	docker cp docker2oci:/go/bin/docker2oci "$@"
+	docker rm -f docker2oci
+	$(CHOWN) -R $(shell id -u):$(shell id -g) $(@D)
+
+# offline bundle
+sources/engine.tar: $(DOCKER2OCI)
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux
+	mkdir -p artifacts
+	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux)
+	./$(DOCKER2OCI) -i artifacts/docker-engine.tar artifacts/engine-image
+	mkdir -p $(@D)
+	tar c -C artifacts/engine-image . > $@

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -24,6 +24,7 @@ override_dh_auto_install:
 	# docker-ce install
 	install -D -m 0755 /go/src/github.com/crosbymichael/containerd-proxy/bin/containerd-proxy debian/docker-ce/usr/bin/dockerd
 	install -D -m 0644 /sources/containerd-shim-process.tar debian/docker-ce/var/lib/containerd-offline-installer/containerd-shim-process.tar
+	install -D -m 0644 /sources/engine.tar debian/docker-ce/var/lib/docker-engine/engine.tar
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
 	install -D -m 0644 /sources/dockerd.json debian/docker-ce/etc/containerd-proxy/dockerd.json
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -32,8 +32,9 @@ RPMBUILD_FLAGS?=-ba\
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 ENGINE_IMAGE=docker/engine-community
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json
+SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
+
 
 .PHONY: help
 help: ## show make targets
@@ -47,6 +48,7 @@ clean: ## remove build artifacts
 	$(RM) -r artifacts/
 	[ ! -d tmp ] || $(CHOWN) -R $(shell id -u):$(shell id -g) tmp
 	$(RM) -r tmp/
+	-docker rm docker2oci
 
 .PHONY: rpm
 rpm: fedora centos ## build all rpm packages
@@ -114,4 +116,21 @@ rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
 	mkdir -p $(@D)
 	sed -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' $< > $@
 
-# TODO: Figure out a sufficient offline solution
+# TODO: Eventually clean this up when we release an image with a manifest
+DOCKER2OCI=artifacts/docker2oci
+$(DOCKER2OCI):
+	-$(CHOWN) -R $(shell id -u):$(shell id -g) $(@D)
+	docker run --name docker2oci $(GO_IMAGE) sh -c 'go get github.com/coolljt0725/docker2oci'
+	mkdir -p $(@D)
+	docker cp docker2oci:/go/bin/docker2oci "$@"
+	docker rm -f docker2oci
+	$(CHOWN) -R $(shell id -u):$(shell id -g) $(@D)
+
+# offline bundle
+rpmbuild/SOURCES/engine.tar: $(DOCKER2OCI)
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux
+	mkdir -p artifacts
+	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux)
+	./$(DOCKER2OCI) -i artifacts/docker-engine.tar artifacts/engine-image
+	mkdir -p $(@D)
+	tar c -C artifacts/engine-image . > $@

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -7,6 +7,7 @@ Epoch: 2
 Source0: containerd-proxy.tgz
 Source1: containerd-shim-process.tar
 Source2: docker.service
+Source3: engine.tar
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -63,12 +64,14 @@ popd
 # Install containerd-proxy as dockerd
 install -D -m 0755 %{_topdir}/BUILD/src/containerd-proxy/bin/containerd-proxy $RPM_BUILD_ROOT/%{_bindir}/dockerd
 install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
+install -D -m 0644 %{_topdir}/SOURCES/engine.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/docker-engine/engine.tar
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/containerd-proxy/dockerd.json
 
 %files
 /%{_bindir}/dockerd
 /%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
+/%{_sharedstatedir}/docker-engine/engine.tar
 /%{_unitdir}/docker.service
 /etc/containerd-proxy/dockerd.json
 


### PR DESCRIPTION
Builds the `engine.tar` as an image that `containerd` can actually use

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>