### PR TITLE
[18.09] Remove overlay as the default storage driver

### DIFF
--- a/common/dockerd.json
+++ b/common/dockerd.json
@@ -3,7 +3,6 @@
     "imagePath": "/var/lib/docker-engine/engine.tar",
     "namespace":"docker",
     "args": [
-        "-s", "overlay",
         "--containerd", "/run/containerd/containerd.sock",
         "--default-runtime", "containerd",
         "--add-runtime", "containerd=runc"


### PR DESCRIPTION
Should rely on list in the daemon

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 605758124d0750c14d24bfb1ebcf77d102591f4a)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>