### PR TITLE
[master] use systemctl is-active to check for containerd

### DIFF
--- a/containerd.mk
+++ b/containerd.mk
@@ -4,7 +4,7 @@ CONTAINERD_PROXY_COMMIT=82ae3d13e91d062dd4853379fe018638023c8da2
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If containerd is running use that socket instead
-ifeq ($(shell systemctl status containerd 2>/dev/null >/dev/null && echo -n "yes"), "yes")
+ifeq ("$(shell systemctl is-active containerd)", "active")
 CONTAINERD_SOCK:=/var/run/containerd/containerd.sock
 else
 CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock


### PR DESCRIPTION
Without this PR, unable to detect an active `containerd.io` package:
```
$ systemctl status containerd | head -3
● containerd.service - containerd container runtime
   Loaded: loaded (/lib/systemd/system/containerd.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2018-08-22 23:44:45 UTC; 6h ago
$ make -pn -f containerd.mk | grep -e ^CONTAINERD_SOCK
make: *** No targets.  Stop.
CONTAINERD_SOCK := /var/run/docker/containerd/docker-containerd.sock
```

With this PR, allows proper detection:
```
$ make -pn -f containerd.mk | grep -e ^CONTAINERD_SOCK
make: *** No targets.  Stop.
CONTAINERD_SOCK := /var/run/containerd/containerd.sock
```

