### PR TITLE
[18.09] use systemctl is-active to check for containerd

### DIFF
--- a/containerd.mk
+++ b/containerd.mk
@@ -4,7 +4,7 @@ CONTAINERD_PROXY_COMMIT=82ae3d13e91d062dd4853379fe018638023c8da2
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If containerd is running use that socket instead
-ifeq ($(shell systemctl status containerd 2>/dev/null >/dev/null && echo -n "yes"), "yes")
+ifeq ("$(shell systemctl is-active containerd)", "active")
 CONTAINERD_SOCK:=/var/run/containerd/containerd.sock
 else
 CONTAINERD_SOCK:=/var/run/docker/containerd/docker-containerd.sock


### PR DESCRIPTION
backport of #156

```
$ git cherry-pick -x -s f00df1bf1efa2ed1ea508ea7b1c291500441571d
[ac a9b0387] use systemctl is-active to check for containerd
 Date: Thu Aug 23 06:08:57 2018 +0000
 1 file changed, 1 insertion(+), 1 deletion(-)
```

cherry-pick clean.