### PR TITLE
[18.09] Add native rpm compilation for devicemapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rpmbuild
 tmp
 artifacts
 sources
+image-linux*

--- a/image/Dockerfile.engine-dm
+++ b/image/Dockerfile.engine-dm
@@ -1,0 +1,75 @@
+# Common builder
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
+
+FROM centos:7 as builder
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+COPY --from=golang /usr/local/go /usr/local/go
+COPY hack/dockerfile/install/tini.installer /
+COPY hack/dockerfile/install/proxy.installer /
+RUN yum install -y \
+    bash \
+    ca-certificates \
+    cmake \
+    gcc \
+    git \
+    glibc-static \
+    libtool \
+    make
+RUN grep "_COMMIT=" /*.installer  |cut -f2- -d: > /binaries-commits
+
+# dockerd
+FROM builder as dockerd-builder
+RUN yum install -y \
+    btrfs-progs-devel \
+    device-mapper-devel \
+    selinux-policy-devel \
+    systemd-devel
+WORKDIR /go/src/github.com/docker/docker
+COPY . /go/src/github.com/docker/docker
+ARG VERSION
+ARG GITCOMMIT
+ARG BUILDTIME
+ARG PLATFORM
+ARG PRODUCT
+ARG DEFAULT_PRODUCT_LICENSE
+ENV VERSION ${VERSION}
+ENV GITCOMMIT ${GITCOMMIT}
+ENV BUILDTIME ${BUILDTIME}
+ENV PLATFORM ${PLATFORM}
+ENV PRODUCT ${PRODUCT}
+ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
+# TODO The way we set the version could easily be simplified not to depend on hack/...
+RUN bash ./hack/make/.go-autogen
+RUN go build -o /sbin/dockerd \
+    -tags 'autogen selinux journald' -a -ldflags '-w'\
+    github.com/docker/docker/cmd/dockerd
+
+# docker-proxy
+# TODO if libnetwork folds into the docker tree this can be combined above
+FROM builder as proxy-builder
+RUN git clone https://github.com/docker/libnetwork.git /go/src/github.com/docker/libnetwork
+WORKDIR /go/src/github.com/docker/libnetwork
+RUN . /binaries-commits && \
+    git checkout -q "$LIBNETWORK_COMMIT" && \
+    go build -buildmode=pie -ldflags="$PROXY_LDFLAGS" \
+        -o /sbin/docker-proxy \
+        github.com/docker/libnetwork/cmd/proxy
+
+# docker-init - TODO move this out, last time we bumped was 2016!
+FROM builder as init-builder
+RUN git clone https://github.com/krallin/tini.git /tini
+WORKDIR /tini
+RUN . /binaries-commits && \
+    git checkout -q "$TINI_COMMIT" && \
+    cmake . && make tini-static && \
+    cp tini-static /sbin/docker-init
+
+# Final docker image
+FROM scratch
+COPY --from=dockerd-builder /sbin/dockerd /sbin/
+COPY --from=proxy-builder /sbin/docker-proxy /sbin/
+COPY --from=init-builder /sbin/docker-init /sbin/
+ENTRYPOINT ["/sbin/dockerd"]

--- a/image/Makefile
+++ b/image/Makefile
@@ -6,11 +6,13 @@ GO_BASE_IMAGE=golang
 GO_VERSION:=1.10.3
 GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)
 STATIC_VERSION=$(shell ../static/gen-static-ver $(ENGINE_DIR) $(VERSION))
-DOCKER_HUB_ORG?=dockereng
+DOCKER_HUB_ORG?=docker
 ARCH=$(shell uname -m)
 ENGINE_IMAGE?=engine-community
 DEFAULT_PRODUCT_LICENSE?=Community Engine
-IMAGE_BUILD=docker build -t $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) \
+TAG=$(STATIC_VERSION).$(ARCH)
+IMAGE_WITH_TAG=$(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(TAG)
+IMAGE_BUILD=docker build -t $(IMAGE_WITH_TAG) \
 	--build-arg GO_IMAGE="$(GO_IMAGE)" \
 	--build-arg VERSION="$(STATIC_VERSION)" \
 	--build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
@@ -28,8 +30,8 @@ help: ## show make targets
 clean: ## remove build artifacts
 	-$(RM) $(ENGINE_DIR)/Dockerfile.engine
 	-$(RM) $(ENGINE_DIR)/Dockerfile.engine-dm
-	-docker rmi $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION)
-	-rm -f image-linux
+	-docker rmi $(IMAGE_WITH_TAG)
+	-rm -f image-linux-*
 
 .PHONY: image
 image: image-linux
@@ -40,16 +42,17 @@ $(ENGINE_DIR)/Dockerfile.%: Dockerfile.%
 # builds across multiple archs because the base images
 # utilize manifests
 image-linux: $(ENGINE_DIR)/Dockerfile.engine
-	$(IMAGE_BUILD)
-	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) > $@
+	./image_exists $(IMAGE_WITH_TAG) || $(IMAGE_BUILD)
+	echo $(IMAGE_WITH_TAG) > $@
 
 image-linux-dm: $(ENGINE_DIR)/Dockerfile.engine-dm
-	$(IMAGE_BUILD)
-	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) > $@
+	$(warning WARN: This image will be named: $(IMAGE_WITH_TAG)-dm)
+	./image_exists $(IMAGE_WITH_TAG)-dm || $(IMAGE_BUILD)
+	echo $(IMAGE_WITH_TAG) > $@
 
 engine-$(ARCH).tar: image-linux
 	docker save -o $@ $$(cat $<)
 
 .PHONY: release
 release:
-	docker push $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH)
+	docker push $(IMAGE_WITH_TAG)

--- a/image/Makefile
+++ b/image/Makefile
@@ -10,6 +10,15 @@ DOCKER_HUB_ORG?=dockereng
 ARCH=$(shell uname -m)
 ENGINE_IMAGE?=engine-community
 DEFAULT_PRODUCT_LICENSE?=Community Engine
+IMAGE_BUILD=docker build -t $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) \
+	--build-arg GO_IMAGE="$(GO_IMAGE)" \
+	--build-arg VERSION="$(STATIC_VERSION)" \
+	--build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
+	--build-arg BUILDTIME="$(BUILDTIME)" \
+	--build-arg PLATFORM="$(PLATFORM)" \
+	--build-arg PRODUCT="$(PRODUCT)" \
+	--build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
+	--file $< $(ENGINE_DIR)
 
 .PHONY: help
 help: ## show make targets
@@ -18,33 +27,28 @@ help: ## show make targets
 .PHONY: clean
 clean: ## remove build artifacts
 	-$(RM) $(ENGINE_DIR)/Dockerfile.engine
+	-$(RM) $(ENGINE_DIR)/Dockerfile.engine-dm
 	-docker rmi $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION)
 	-rm -f image-linux
 
 .PHONY: image
 image: image-linux
 
-
-$(ENGINE_DIR)/Dockerfile.engine:
-	cp Dockerfile.engine $(ENGINE_DIR)
+$(ENGINE_DIR)/Dockerfile.%: Dockerfile.%
+	cp $< $@
 
 # builds across multiple archs because the base images
 # utilize manifests
 image-linux: $(ENGINE_DIR)/Dockerfile.engine
-	docker build -t $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) \
-		--build-arg GO_IMAGE="$(GO_IMAGE)" \
-		--build-arg VERSION="$(STATIC_VERSION)" \
-		--build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
-		--build-arg BUILDTIME="$(BUILDTIME)" \
-		--build-arg PLATFORM="$(PLATFORM)" \
-		--build-arg PRODUCT="$(PRODUCT)" \
-		--build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
-		--file $< $(ENGINE_DIR)
+	$(IMAGE_BUILD)
+	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) > $@
+
+image-linux-dm: $(ENGINE_DIR)/Dockerfile.engine-dm
+	$(IMAGE_BUILD)
 	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH) > $@
 
 engine-$(ARCH).tar: image-linux
 	docker save -o $@ $$(cat $<)
-
 
 .PHONY: release
 release:

--- a/image/image_exists
+++ b/image/image_exists
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# If we want to force an image to build let's do it here
+if [ ! -z "$FORCE_IMAGE_BUILD" ]; then
+    echo "WARNING: Forcing image build for $1..."
+    exit 1
+fi
+if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$1" > /dev/null 2>/dev/null; then
+    echo "INFO: Pulling existing image $1..."
+    (set -x; docker pull "$1")
+    exit 0
+fi
+echo "INFO: Image $1 not found on hub building..."
+exit 1

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -128,9 +128,9 @@ $(DOCKER2OCI):
 
 # offline bundle
 rpmbuild/SOURCES/engine.tar: $(DOCKER2OCI)
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux-dm
 	mkdir -p artifacts
-	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux)
+	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux-dm)
 	./$(DOCKER2OCI) -i artifacts/docker-engine.tar artifacts/engine-image
 	mkdir -p $(@D)
 	tar c -C artifacts/engine-image . > $@


### PR DESCRIPTION
devicemapper cannot be enabled on a statically compiled binary so we
dynamically compile it on a rhel based distribution in order to enable
devicemapper usage.

There will also need to be a forward port of this patch to master

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>