### PR TITLE
Remove BindsTo

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-BindsTo=containerd.service
-After=network-online.target firewalld.service
+After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
 
 [Service]


### PR DESCRIPTION
We want the docker container to run and not be restarted when containerd
is restarted.  Their lifecycles should not be coupled and docker can run
without the daemon.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>