### PR TITLE
[master] bring in changes that went first to 18.09 branch

### DIFF
--- a/common/dockerd.json
+++ b/common/dockerd.json
@@ -7,5 +7,5 @@
         "--default-runtime", "containerd",
         "--add-runtime", "containerd=runc"
     ],
-    "scope": "ce"
+    "scope": "${ENGINE_SCOPE}"
 }

--- a/containerd.mk
+++ b/containerd.mk
@@ -1,6 +1,6 @@
 # Common things for containerd functionality
 
-CONTAINERD_PROXY_COMMIT=82ae3d13e91d062dd4853379fe018638023c8da2
+CONTAINERD_PROXY_COMMIT=afca176732d9416fac1e79fd76ce45afe4cbc41f
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If containerd is running use that socket instead

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -29,6 +29,7 @@ RUN=docker run --rm -i \
 SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 ENGINE_IMAGE=docker/engine-community
+ENGINE_SCOPE=ce
 
 IMAGE_TAG=nightly
 
@@ -149,7 +150,11 @@ sources/docker.service: ../systemd/docker.service
 
 sources/dockerd.json: ../common/dockerd.json
 	mkdir -p $(@D)
-	sed -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' $< > $@
+	sed \
+	    -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' \
+	    -e 's!$${ENGINE_SCOPE}!$(ENGINE_SCOPE)!' \
+	    -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' \
+	    $< > $@
 
 # TODO: Eventually clean this up when we release an image with a manifest
 DOCKER2OCI=artifacts/docker2oci
@@ -163,7 +168,7 @@ $(DOCKER2OCI):
 
 # offline bundle
 sources/engine.tar: $(DOCKER2OCI)
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) image-linux
 	mkdir -p artifacts
 	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux)
 	./$(DOCKER2OCI) -i artifacts/docker-engine.tar artifacts/engine-image

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -31,6 +31,7 @@ RPMBUILD_FLAGS?=-ba\
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 ENGINE_IMAGE=docker/engine-community
+ENGINE_SCOPE=ce
 
 SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
@@ -114,7 +115,11 @@ rpmbuild/SOURCES/docker.service: ../systemd/docker.service
 
 rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
 	mkdir -p $(@D)
-	sed -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' $< > $@
+	sed \
+	    -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' \
+	    -e 's!$${ENGINE_SCOPE}!$(ENGINE_SCOPE)!' \
+	    -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' \
+	    $< > $@
 
 # TODO: Eventually clean this up when we release an image with a manifest
 DOCKER2OCI=artifacts/docker2oci
@@ -128,7 +133,7 @@ $(DOCKER2OCI):
 
 # offline bundle
 rpmbuild/SOURCES/engine.tar: $(DOCKER2OCI)
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) image-linux
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) image-linux
 	mkdir -p artifacts
 	docker save -o artifacts/docker-engine.tar $$(cat ../image/image-linux)
 	./$(DOCKER2OCI) -i artifacts/docker-engine.tar artifacts/engine-image

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -10,6 +10,7 @@ Wants=network-online.target
 ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offline-installer/containerd-shim-process.tar docker.io/docker/containerd-shim-process
 ExecStart=/usr/bin/dockerd
 TimeoutSec=0
+RestartSec=2
 Restart=always
 # On RPM Based distributions PATH isn't defined so we define it here
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary


### PR DESCRIPTION
Should have gone to master branch first. This PR will now bring master branch up-to-date with 18.09 branch.

Cherry picks of 7240669 eea6967 3614f5d:
```
$ git cherry-pick -s -x 7240669 eea6967 3614f5d
[sync 5ad8795] Make engine scope a build time setting
 Author: Daniel Hiltgen <daniel.hiltgen@docker.com>
 Date: Fri Aug 24 09:54:19 2018 -0700
 3 files changed, 15 insertions(+), 5 deletions(-)
[sync be68a39] update containerd proxy commit to afca176
 Date: Fri Aug 24 22:14:20 2018 +0000
 1 file changed, 1 insertion(+), 1 deletion(-)
[sync e274c37] added RestartSec
 Date: Fri Aug 24 22:40:02 2018 +0000
 1 file changed, 1 insertion(+)
```

Went in clean.

Brings in PRs: #160 #162 #164