### PR TITLE
[18.09] Add explicit dependency for libseccomp2

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -15,7 +15,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: docker-ce-cli, containerd.io, iptables, ${shlibs:Depends}
+Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
 Recommends: abufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,


### PR DESCRIPTION
While testing on older ubuntu images we discovered
we do depend on a newer version of libseccomp2.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>