### PR TITLE
[18.09] add requires container-selinux to spec

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -16,6 +16,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
+Requires: container-selinux >= 2.9
 Requires: systemd-units
 Requires: iptables
 # Should be required as well by docker-ce-cli but let's just be thorough


### PR DESCRIPTION
so docker-ce can work on systems with selinux enabled