### PR TITLE
Change deb package filenames to be unique

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -24,7 +24,7 @@ debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/cont
 debDate="$(date --rfc-2822)"
 
 cat > "debian/changelog" <<-EOF
-$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}) $SUITE; urgency=low
+$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}-${SUITE}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF


### PR DESCRIPTION
It's generally bad-form to generate two identically named package files
that are actually different, so we should name our packages based on
the distro and version, not just the distro.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>

If this works out, we should cherry-pick over to 18.09