### PR TITLE
[18.09] Update new systemd unit file with changes from upstream

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -34,5 +34,8 @@ TasksMax=infinity
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
 
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+
 [Install]
 WantedBy=multi-user.target

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -18,6 +18,17 @@ ExecStopPost=/usr/bin/dockerd post-stop
 TimeoutSec=0
 RestartSec=2
 Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
 # On RPM Based distributions PATH isn't defined so we define it here
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary
 Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/local/bin:$PATH"

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -13,6 +13,7 @@ ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offli
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
 ExecStart=/usr/bin/dockerd
+ExecReload=/bin/kill -s HUP $MAINPID
 ExecStopPost=/usr/bin/dockerd post-stop
 TimeoutSec=0
 RestartSec=2

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -17,6 +17,10 @@ Restart=always
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary
 Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/local/bin:$PATH"
 
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
+LimitNPROC=infinity
 LimitCORE=infinity
 
 [Install]

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -8,6 +8,10 @@ Wants=network-online.target
 [Service]
 # Install containerd-shim-process if it's not already installed
 ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offline-installer/containerd-shim-process.tar docker.io/docker/containerd-shim-process
+
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
 ExecStart=/usr/bin/dockerd
 ExecStopPost=/usr/bin/dockerd post-stop
 TimeoutSec=0
@@ -26,6 +30,9 @@ LimitCORE=infinity
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this option.
 TasksMax=infinity
+
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -17,5 +17,7 @@ Restart=always
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary
 Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/local/bin:$PATH"
 
+LimitCORE=infinity
+
 [Install]
 WantedBy=multi-user.target

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -23,5 +23,9 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this option.
+TasksMax=infinity
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Cherry pick of #179 

```
❯ git cherry-pick -x -s da69663b9ccd72d95ec60007ef707d82a35324fa 68e15413dce8d6e8f428ac286641a9482d30aabc 82fe96733f551d36018c3840cf21d813807e9b76 e134e666a585b1f13e9e5e371dd93e5ce04a4b34 d736ae9da7401f58
2469fa7e943adde9f2163024 3e1b508e5f70b35869d9c8417d3b65a141820af9 2c2bfea5d009fb884f5c61b62e3c85bd88e7909e
```

Cherry pick was *clean*

## Original Text:

The new systemd unit file was missing various options; this PR is porting those options. I wasn't sure if all options should be set in the new situation, so I included each change in a separate commit, keeping the original upstream commit message where applicable;

- ~bump open files (original PR: https://github.com/moby/moby/pull/4455)~
  - skipped in favor of https://github.com/moby/moby/pull/24307
- no limit on core size (original PR: https://github.com/moby/moby/pull/10598)
- contrib: systemd: set Limit* to infinity (original PR: https://github.com/moby/moby/pull/24307 / https://github.com/moby/moby/pull/24555)
- docker.service: don't limit tasks (original PR: https://github.com/moby/moby/pull/21491)
  - we may need a variation of https://github.com/moby/moby/pull/21628 to comment this for systemd < 226 (or move it to a drop-in file)
- Add "Delegate=yes" to docker's service file (original PR: https://github.com/moby/moby/pull/20633 - relates to https://github.com/moby/moby/issues/20152)
- Set systemd KillMode (original PR: https://github.com/moby/moby/pull/23636)
- ~Disable timeout for systemd (original PR: https://github.com/moby/moby/pull/18408)~
  - skipped: we probably no longer have to take migration to content-addressable store into account
- Add support for reloading daemon configuration through systemd (original PR: https://github.com/moby/moby/pull/22446)
- Add on-failure to default restart policy (original PR: https://github.com/moby/moby/pull/29902)
  - restart policy was already set to `always`, but added the burst limits


I can drop commits that are not needed 👍 