### PR TITLE
[18.09] Sign engine images

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -48,4 +48,13 @@ engine-$(ARCH).tar: image-linux
 
 .PHONY: release
 release:
+	if ! docker trust inspect --pretty $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH); \
+		echo ""; \
+		echo "FAILURE No Trust data exists"; \
+		echo "Please create the necessary Trust data and keys"; \
+		echo ""; \
+		exit 1; \
+	fi
+	docker trust key load /trust-key
+	docker trust sign --local $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH)
 	docker push $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION).$(ARCH)


### PR DESCRIPTION
Checks if engine images can be signed. 
Exits 1 if they can not be signed, otherwise the images are signed and pushed.

Signed-off-by: Jose Bigio <jose.bigio@docker.com>