### PR TITLE
[18.09] Update proxy commit for shutdown timeouts

### DIFF
--- a/containerd.mk
+++ b/containerd.mk
@@ -1,6 +1,6 @@
 # Common things for containerd functionality
 
-CONTAINERD_PROXY_COMMIT=afca176732d9416fac1e79fd76ce45afe4cbc41f
+CONTAINERD_PROXY_COMMIT=9a227f7e8a35ed802617a67d77b1e6aa3b767474
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If containerd is running use that socket instead


### PR DESCRIPTION
backport:
* #186 Update proxy commit for shutdown timeouts

no conflicts
```
$ git cherry-pick -s -x 7941c69
[to 61d98f8] Update proxy commit for shutdown timeouts
 Author: Michael Crosby <crosbymichael@gmail.com>
 Date: Wed Sep 5 18:17:48 2018 -0400
 1 file changed, 1 insertion(+), 1 deletion(-)
```