### PR TITLE
Fix docker-ce-cli replacing files

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -40,7 +40,8 @@ Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
-Replaces:
+Replaces: docker-ce (<< 18.06~)
+Breaks: docker-ce (<< 18.06~)
 Description: Docker CLI: the open-source application container engine
  Docker is an open source project to build, ship and run any application as a
  lightweight container


### PR DESCRIPTION
Was running into issues where the `docker-ce-cli` installation was being stopped by a `docker-ce-cli` trying to overwrite files from `docker-ce` <= 18.06.

This should remedy that.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>