### PR TITLE
[18.09] Remove offline installer to install shim-process

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -17,6 +17,7 @@ COMMON_FILES=common
 BUILD?=docker build \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	--build-arg COMMON_FILES=$(COMMON_FILES) \
+	--build-arg CONTAINERD_SHIM_PROCESS_IMAGE=$(CONTAINERD_SHIM_PROCESS_IMAGE) \
 	-t debbuild-$@/$(ARCH) \
 	-f $(CURDIR)/$@/Dockerfile .
 RUN=docker run --rm -i \
@@ -27,7 +28,7 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
+SOURCE_FILES=containerd-proxy.tgz cli.tgz docker.service dockerd.json engine.tar
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 ENGINE_IMAGE=docker/engine-community
 ENGINE_SCOPE=ce
@@ -137,13 +138,6 @@ sources/containerd-proxy.tgz:
 	$(CHOWN) -R $(shell id -u):$(shell id -g) $$(dirname $(@D))
 	tar -zcf $@ -C tmp/ containerd-proxy
 	rm -rf tmp/
-
-sources/containerd-shim-process.tar:
-	$(CTR) content fetch $(CONTAINERD_SHIM_PROCESS_IMAGE)
-	$(CTR) image export artifacts/containerd-shim-process.tar $(CONTAINERD_SHIM_PROCESS_IMAGE)
-	mkdir -p $(@D)
-	cp artifacts/containerd-shim-process.tar $@
-	$(CHOWN) -R $(shell id -u):$(shell id -g) $$(dirname $(@D))
 
 sources/docker.service: ../systemd/docker.service
 	mkdir -p $(@D)

--- a/deb/common/control
+++ b/deb/common/control
@@ -22,6 +22,7 @@ Recommends: abufs-tools,
             git,
             pigz,
             xz-utils,
+            libltdl7,
             ${apparmor:Recommends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
 Replaces: docker-engine
@@ -40,7 +41,6 @@ Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
-Replaces: docker-ce (<< 18.06~)
 Breaks: docker-ce (<< 18.06~)
 Description: Docker CLI: the open-source application container engine
  Docker is an open source project to build, ship and run any application as a

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -23,7 +23,7 @@ override_dh_auto_install:
 	install -D -m 0755 /go/src/github.com/docker/cli/build/docker debian/docker-ce-cli/usr/bin/docker
 	# docker-ce install
 	install -D -m 0755 /go/src/github.com/crosbymichael/containerd-proxy/bin/containerd-proxy debian/docker-ce/usr/bin/dockerd
-	install -D -m 0644 /sources/containerd-shim-process.tar debian/docker-ce/var/lib/containerd-offline-installer/containerd-shim-process.tar
+	install -D -m 0644 /containerd-shim-process-v1 debian/docker-ce/usr/sbin/containerd-shim-process-v1
 	install -D -m 0644 /sources/engine.tar debian/docker-ce/var/lib/docker-engine/engine.tar
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
 	install -D -m 0644 /sources/dockerd.json debian/docker-ce/etc/containerd-proxy/dockerd.json

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM debian:buster
 
@@ -26,6 +28,7 @@ ENV DISTRO debian
 ENV SUITE buster
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-jessie/Dockerfile
+++ b/deb/debian-jessie/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM debian:jessie
 
@@ -26,6 +28,7 @@ ENV DISTRO debian
 ENV SUITE jessie
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM debian:stretch
 
@@ -26,6 +28,7 @@ ENV DISTRO debian
 ENV SUITE stretch
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-jessie/Dockerfile
+++ b/deb/raspbian-jessie/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM resin/rpi-raspbian:jessie
 
@@ -26,6 +28,7 @@ ENV DISTRO raspbian
 ENV SUITE jessie
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM resin/rpi-raspbian:stretch
 
@@ -26,6 +28,7 @@ ENV DISTRO raspbian
 ENV SUITE stretch
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM ubuntu:bionic
 
@@ -26,6 +28,7 @@ ENV DISTRO ubuntu
 ENV SUITE bionic
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-trusty/Dockerfile
+++ b/deb/ubuntu-trusty/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM ubuntu:trusty
 
@@ -26,6 +28,7 @@ ENV DISTRO ubuntu
 ENV SUITE trusty
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM ubuntu:xenial
 
@@ -26,6 +28,7 @@ ENV DISTRO ubuntu
 ENV SUITE xenial
 
 COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -15,7 +15,12 @@ DOCKERFILE=Dockerfile
 ifdef NEEDS_ARCH_SPECIFIC
 	DOCKERFILE=Dockerfile.$(ARCH)
 endif
-BUILD?=docker build --build-arg GO_IMAGE=$(GO_IMAGE) -t rpmbuild-$@/$(ARCH) -f $@/$(DOCKERFILE) .
+BUILD?=docker build \
+	--build-arg GO_IMAGE=$(GO_IMAGE) \
+	--build-arg CONTAINERD_SHIM_PROCESS_IMAGE=$(CONTAINERD_SHIM_PROCESS_IMAGE) \
+	-t rpmbuild-$@/$(ARCH) \
+	-f $@/$(DOCKERFILE) \
+	.
 
 SPEC_FILES?=docker-ce.spec docker-ce-cli.spec
 SPECS?=$(addprefix SPECS/, $(SPEC_FILES))
@@ -33,7 +38,7 @@ RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 ENGINE_IMAGE=docker/engine-community
 ENGINE_SCOPE=ce
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz containerd-shim-process.tar docker.service dockerd.json engine.tar
+SOURCE_FILES=containerd-proxy.tgz cli.tgz docker.service dockerd.json engine.tar
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 
@@ -101,13 +106,6 @@ rpmbuild/SOURCES/containerd-proxy.tgz:
 	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 	tar -zcf $@ -C tmp/ containerd-proxy
 	rm -rf tmp/
-
-rpmbuild/SOURCES/containerd-shim-process.tar:
-	$(CTR) content fetch $(CONTAINERD_SHIM_PROCESS_IMAGE)
-	$(CTR) image export artifacts/containerd-shim-process.tar $(CONTAINERD_SHIM_PROCESS_IMAGE)
-	mkdir -p $(@D)
-	cp artifacts/containerd-shim-process.tar $@
-	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 rpmbuild/SOURCES/docker.service: ../systemd/docker.service
 	mkdir -p $(@D)

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -5,9 +5,8 @@ Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: 2
 Source0: containerd-proxy.tgz
-Source1: containerd-shim-process.tar
-Source2: docker.service
-Source3: engine.tar
+Source1: docker.service
+Source2: engine.tar
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -64,14 +63,14 @@ popd
 %install
 # Install containerd-proxy as dockerd
 install -D -m 0755 %{_topdir}/BUILD/src/containerd-proxy/bin/containerd-proxy $RPM_BUILD_ROOT/%{_bindir}/dockerd
-install -D -m 0644 %{_topdir}/SOURCES/containerd-shim-process.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
 install -D -m 0644 %{_topdir}/SOURCES/engine.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/docker-engine/engine.tar
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/containerd-proxy/dockerd.json
+install -D -m 0755 /containerd-shim-process-v1 $RPM_BUILD_ROOT/%{_sbindir}/containerd-shim-process-v1
 
 %files
 /%{_bindir}/dockerd
-/%{_sharedstatedir}/containerd-offline-installer/containerd-shim-process.tar
+/%{_sbindir}/containerd-shim-process-v1
 /%{_sharedstatedir}/docker-engine/engine.tar
 /%{_unitdir}/docker.service
 /etc/containerd-proxy/dockerd.json

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM centos:7
 ENV DISTRO centos
@@ -15,5 +17,6 @@ COPY SPECS /root/rpmbuild/SPECS
 RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
 RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile
+++ b/rpm/fedora-27/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM fedora:27
 ENV DISTRO fedora
@@ -13,5 +15,6 @@ RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile
+++ b/rpm/fedora-28/Dockerfile
@@ -1,5 +1,7 @@
 ARG GO_IMAGE
+ARG CONTAINERD_SHIM_PROCESS_IMAGE
 FROM ${GO_IMAGE} as golang
+FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
 
 FROM fedora:28
 ENV DISTRO fedora
@@ -7,10 +9,12 @@ ENV SUITE 28
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -6,9 +6,6 @@ After=network-online.target firewalld.service
 Wants=network-online.target
 
 [Service]
-# Install containerd-shim-process if it's not already installed
-ExecStartPre=/usr/libexec/containerd-offline-installer /var/lib/containerd-offline-installer/containerd-shim-process.tar docker.io/docker/containerd-shim-process
-
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker


### PR DESCRIPTION
Cherry pick of #191 was **clean**

# Original text:

Removes the need for the offline installer to install the shim process
and instead installs the shim process as part of the packaging.

May be easier in the future to just package the shim process on it's own
but that'll come after this 18.09 release

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit f8bd366d58f8bdf8a82b9a033353ca5bf4eda948)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>