### PR TITLE
Bump proxy to 35c543b

### DIFF
--- a/containerd.mk
+++ b/containerd.mk
@@ -1,6 +1,6 @@
 # Common things for containerd functionality
 
-CONTAINERD_PROXY_COMMIT=9a227f7e8a35ed802617a67d77b1e6aa3b767474
+CONTAINERD_PROXY_COMMIT=35c543bd887878714213cf61ee14038499fd25b7
 CONTAINERD_SHIM_PROCESS_IMAGE=docker.io/docker/containerd-shim-process:ff98a47
 
 # If containerd is running use that socket instead


### PR DESCRIPTION
Includes fixes related to upgrade cycles, https://github.com/crosbymichael/containerd-proxy/pull/7

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>