### PR TITLE
Remove need for SUFFIX in gen-deb-ver

### DIFF
--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -4,8 +4,6 @@ ENGINE_DIR="$1"
 VERSION="$2"
 origVersion=$VERSION
 
-SUFFIX=${SUFFIX:=ce}
-
 [[ $# < 2 ]] && echo 'not enough args' && exit 1
 
 DATE_COMMAND="date"
@@ -15,14 +13,14 @@ fi
 
 gen_deb_version() {
     # Adds an increment to the deb version to get proper order
-    # 18.01.0-${SUFFIX}-tp1   -> 18.01.0-${SUFFIX}-0.1-tp1
-    # 18.01.0-${SUFFIX}-beta1 -> 18.01.0-${SUFFIX}-1.1-beta1
-    # 18.01.0-${SUFFIX}-rc1   -> 18.01.0-${SUFFIX}-2.1-rc1
-    # 18.01.0-${SUFFIX}       -> 18.01.0-${SUFFIX}-3
+    # 18.01.0-tp1   -> 18.01.0-0.1-tp1
+    # 18.01.0-beta1 -> 18.01.0-1.1-beta1
+    # 18.01.0-rc1   -> 18.01.0-2.1-rc1
+    # 18.01.0       -> 18.01.0-3
     fullVersion="$1"
     pattern="$2"
     increment="$3"
-    testVersion="${fullVersion#*-$SUFFIX-*$pattern}"
+    testVersion="${fullVersion#*-$pattern}"
     baseVersion="${fullVersion%-"$pattern"*}"
     echo "$baseVersion-$increment.$testVersion.$pattern$testVersion"
 }


### PR DESCRIPTION
Should generate correct bits whether or not the suffix is present.

Working example:

```
❯ for version in 18.09.1-ce 18.09.1 18.09.1-ce-rc1 18.09.1-rc1; do echo "$ ./gen-deb-ver . $version"; ./gen-deb-ver . "$version"; echo; done
$ ./gen-deb-ver . 18.09.1-ce
18.09.1~ce~3 18.09.1-ce

$ ./gen-deb-ver . 18.09.1
18.09.1~3 18.09.1

$ ./gen-deb-ver . 18.09.1-ce-rc1
18.09.1~ce~2.1.rc1 18.09.1-ce-rc1

$ ./gen-deb-ver . 18.09.1-rc1
18.09.1~2.1.rc1 18.09.1-rc1
```

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>