### PR TITLE
Wire up the platform string properly

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -11,6 +11,7 @@ ARCH=$(shell uname -m)
 ENGINE_IMAGE?=engine-community
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 DEFAULT_PRODUCT_LICENSE?=Community Engine
+PLATFORM?=Docker Engine - Community
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
This is set in a top-level makefile, but apparently
isn't getting passed all the way through as expected.

Forward port of #199 

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>
(cherry picked from commit a5ad5471419cb2a0935148f891c5ada8b13b4779)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>