### PR TITLE
[master] image/Dockerfile: add osusergo, seccomp tags

### DIFF
--- a/image/Dockerfile.engine
+++ b/image/Dockerfile.engine
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     libc-dev \
     libgcc-6-dev \
     libltdl-dev \
+    libseccomp-dev \
     libtool \
     make
 RUN grep "_COMMIT=" /*.installer  |cut -f2- -d: > /binaries-commits
@@ -37,7 +38,7 @@ ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
 # TODO The way we set the version could easily be simplified not to depend on hack/...
 RUN bash ./hack/make/.go-autogen
 RUN go build -o /sbin/dockerd \
-    -tags 'autogen netgo static_build selinux journald' \
+    -tags 'autogen netgo osusergo static_build seccomp selinux journald' \
     -installsuffix netgo -a -buildmode=pie -ldflags '-w -extldflags "-static" ' \
     github.com/docker/docker/cmd/dockerd
 


### PR DESCRIPTION
osusergo build tag is needed for better chances to have
a proper static binary when Go >= 1.11 is used, and is
harmless otherwise.

seccomp build tag is needed so the resulting dockerd binary
has seccomp support.