### PR TITLE
Add native rpm compilation for devicemapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tmp
 artifacts
 sources
 *.tar
-image-linux
+image-linux*

--- a/image/Dockerfile.engine-dm
+++ b/image/Dockerfile.engine-dm
@@ -1,0 +1,79 @@
+# Common builder
+ARG GO_IMAGE
+FROM ${GO_IMAGE} as golang
+
+FROM centos:7 as builder
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+COPY --from=golang /usr/local/go /usr/local/go
+COPY hack/dockerfile/install/tini.installer /
+COPY hack/dockerfile/install/proxy.installer /
+RUN yum install -y \
+    bash \
+    ca-certificates \
+    cmake \
+    gcc \
+    git \
+    glibc-static \
+    libtool \
+    make
+RUN grep "_COMMIT=" /*.installer  |cut -f2- -d: > /binaries-commits
+
+# dockerd
+FROM builder as dockerd-builder
+RUN yum install -y \
+    btrfs-progs-devel \
+    device-mapper-devel \
+    libseccomp-devel \
+    selinux-policy-devel \
+    systemd-devel
+WORKDIR /go/src/github.com/docker/docker
+COPY . /go/src/github.com/docker/docker
+ARG VERSION
+ARG GITCOMMIT
+ARG BUILDTIME
+ARG PLATFORM
+ARG PRODUCT
+ARG DEFAULT_PRODUCT_LICENSE
+ENV VERSION ${VERSION}
+ENV GITCOMMIT ${GITCOMMIT}
+ENV BUILDTIME ${BUILDTIME}
+ENV PLATFORM ${PLATFORM}
+ENV PRODUCT ${PRODUCT}
+ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
+# TODO The way we set the version could easily be simplified not to depend on hack/...
+RUN bash ./hack/make/.go-autogen
+RUN go build -o /sbin/dockerd \
+    -tags 'autogen apparmor seccomp selinux journald' \
+    -i \
+    -buildmode=pie \
+    -a -ldflags '-w'\
+    github.com/docker/docker/cmd/dockerd
+
+# docker-proxy
+# TODO if libnetwork folds into the docker tree this can be combined above
+FROM builder as proxy-builder
+RUN git clone https://github.com/docker/libnetwork.git /go/src/github.com/docker/libnetwork
+WORKDIR /go/src/github.com/docker/libnetwork
+RUN . /binaries-commits && \
+    git checkout -q "$LIBNETWORK_COMMIT" && \
+    go build -buildmode=pie -ldflags="-w" \
+        -o /sbin/docker-proxy \
+        github.com/docker/libnetwork/cmd/proxy
+
+# docker-init - TODO move this out, last time we bumped was 2016!
+FROM builder as init-builder
+RUN git clone https://github.com/krallin/tini.git /tini
+WORKDIR /tini
+RUN . /binaries-commits && \
+    git checkout -q "$TINI_COMMIT" && \
+    cmake . && make tini-static && \
+    cp tini-static /sbin/docker-init
+
+# Final docker image
+FROM scratch
+COPY --from=dockerd-builder /sbin/dockerd /sbin/
+COPY --from=proxy-builder /sbin/docker-proxy /sbin/
+COPY --from=init-builder /sbin/docker-init /sbin/
+ENTRYPOINT ["/sbin/dockerd"]

--- a/image/Makefile
+++ b/image/Makefile
@@ -12,6 +12,16 @@ ENGINE_IMAGE?=engine-community
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 DEFAULT_PRODUCT_LICENSE?=Community Engine
 PLATFORM?=Docker Engine - Community
+IMAGE_WITH_TAG=$(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION)
+IMAGE_BUILD=docker build -t  $(IMAGE_WITH_TAG) \
+	--build-arg GO_IMAGE="$(ENGINE_GO_IMAGE)" \
+	--build-arg VERSION="$(STATIC_VERSION)" \
+	--build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
+	--build-arg BUILDTIME="$(BUILDTIME)" \
+	--build-arg PLATFORM="$(PLATFORM)" \
+	--build-arg PRODUCT="$(PRODUCT)" \
+	--build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
+	--file $< $(ENGINE_DIR)
 
 .PHONY: help
 help: ## show make targets
@@ -20,7 +30,9 @@ help: ## show make targets
 .PHONY: clean
 clean: ## remove build artifacts
 	-$(RM) $(ENGINE_DIR)/Dockerfile.engine
-	-docker rmi $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION)
+	-$(RM) $(ENGINE_DIR)/Dockerfile.engine-dm
+	-docker rmi $(IMAGE_WITH_TAG)
+	-docker rmi $(IMAGE_WITH_TAG)-dm
 	-rm -f image-linux
 	-$(RM) -r artifacts
 	-$(RM) *.tar
@@ -28,23 +40,8 @@ clean: ## remove build artifacts
 .PHONY: image
 image: image-linux
 
-
-$(ENGINE_DIR)/Dockerfile.engine:
-	cp Dockerfile.engine $(ENGINE_DIR)
-
-# builds across multiple archs because the base images
-# utilize manifests
-image-linux: $(ENGINE_DIR)/Dockerfile.engine
-	docker build -t $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION) \
-		--build-arg GO_IMAGE="$(ENGINE_GO_IMAGE)" \
-		--build-arg VERSION="$(STATIC_VERSION)" \
-		--build-arg GITCOMMIT="$$(cd $(ENGINE_DIR) && git rev-parse --short=7 HEAD)" \
-		--build-arg BUILDTIME="$(BUILDTIME)" \
-		--build-arg PLATFORM="$(PLATFORM)" \
-		--build-arg PRODUCT="$(PRODUCT)" \
-		--build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
-		--file $< $(ENGINE_DIR)
-	echo $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION) > $@
+$(ENGINE_DIR)/Dockerfile.%: Dockerfile.%
+	cp $< $@
 
 DOCKER2OCI=artifacts/docker2oci
 $(DOCKER2OCI):
@@ -55,6 +52,12 @@ $(DOCKER2OCI):
 	docker rm -f docker2oci
 	$(CHOWN) -R $(shell id -u):$(shell id -g) $(@D)
 
+# builds across multiple archs because the base images
+# utilize manifests
+image-linux: $(ENGINE_DIR)/Dockerfile.engine
+	$(IMAGE_BUILD)
+	echo $(IMAGE_WITH_TAG) > $@
+
 engine-$(ARCH).tar: engine-$(ARCH)-docker-compat.tar $(DOCKER2OCI)
 	mkdir -p artifacts
 	./$(DOCKER2OCI) -i $< artifacts/engine-image
@@ -64,6 +67,16 @@ engine-$(ARCH).tar: engine-$(ARCH)-docker-compat.tar $(DOCKER2OCI)
 engine-$(ARCH)-docker-compat.tar: image-linux
 	docker save -o $@ $$(cat $<)
 
-.PHONY: release
-release:
-	docker push $(DOCKER_HUB_ORG)/$(ENGINE_IMAGE):$(STATIC_VERSION)
+image-linux-dm: $(ENGINE_DIR)/Dockerfile.engine-dm
+	$(IMAGE_BUILD)
+	docker tag $(IMAGE_WITH_TAG) $(IMAGE_WITH_TAG)-dm
+	echo $(IMAGE_WITH_TAG)-dm > $@
+
+engine-$(ARCH)-dm.tar: engine-$(ARCH)-dm-docker-compat.tar $(DOCKER2OCI)
+	mkdir -p artifacts
+	./$(DOCKER2OCI) -i $< artifacts/engine-image
+	mkdir -p $(@D)
+	tar c -C artifacts/engine-image . > $@
+
+engine-$(ARCH)-dm-docker-compat.tar: image-linux-dm
+	docker save -o $@ $$(cat $<)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -123,7 +123,6 @@ rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
 	    -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' \
 	    $< > $@
 
-# offline bundle
-rpmbuild/SOURCES/engine.tar: 
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) engine-$(ARCH).tar
-	mv ../image/engine-$(ARCH).tar $@
+rpmbuild/SOURCES/engine.tar:
+	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) engine-$(ARCH)-dm.tar
+	mv ../image/engine-$(ARCH)-dm.tar $@


### PR DESCRIPTION
devicemapper cannot be enabled on a statically compiled binary so we
dynamically compile it on a rhel based distribution in order to enable
devicemapper usage.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>