### PR TITLE
Use image artifacts as daemon and dependencies

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -21,7 +21,7 @@ BUILD?=docker build \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	--build-arg COMMON_FILES=$(COMMON_FILES) \
-	--build-arg CONTAINERD_SHIM_PROCESS_IMAGE=$(CONTAINERD_SHIM_PROCESS_IMAGE) \
+	--build-arg ENGINE_IMAGE="$(shell cat sources/engine-image)" \
 	-t debbuild-$@/$(ARCH) \
 	-f $(CURDIR)/$@/Dockerfile .
 RUN=docker run --rm -i \
@@ -32,12 +32,8 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz docker.service dockerd.json engine.tar
+SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
-ENGINE_IMAGE=docker/engine-community
-ENGINE_SCOPE=ce
-
-IMAGE_TAG=nightly
 
 .PHONY: help
 help: ## show make targets
@@ -49,9 +45,7 @@ clean: ## remove build artifacts
 	$(RM) -r debbuild
 	[ ! -d sources ] || $(CHOWN) -R $(shell id -u):$(shell id -g) sources
 	$(RM) -r sources
-	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
-	$(RM) -r artifacts
-	-docker rm docker2oci
+	$(RM) engine-image
 
 engine-$(ARCH).tar:
 	$(MAKE) -C ../image image-linux
@@ -133,29 +127,16 @@ sources/cli.tgz:
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
-sources/containerd-proxy.tgz:
-	mkdir -p tmp/
-	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT).tar.gz"
-	tar xzf tmp/containerd-proxy.tgz -C tmp/
-	mv tmp/containerd-proxy-$(CONTAINERD_PROXY_COMMIT) tmp/containerd-proxy
-	mkdir -p $(@D)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) $$(dirname $(@D))
-	tar -zcf $@ -C tmp/ containerd-proxy
-	rm -rf tmp/
-
 sources/docker.service: ../systemd/docker.service
 	mkdir -p $(@D)
 	cp $< $@
 
-sources/dockerd.json: ../common/dockerd.json
+sources/distribution_based_engine.json: sources/engine-image
 	mkdir -p $(@D)
-	sed \
-	    -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' \
-	    -e 's!$${ENGINE_SCOPE}!$(ENGINE_SCOPE)!' \
-	    -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' \
-	    $< > $@
+	docker inspect "$(shell cat $<)" \
+		--format '{{index .Config.Labels "com.docker.distribution_based_engine" }}' > $@
 
-# offline bundle
-sources/engine.tar: 
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) engine-$(ARCH).tar
-	mv ../image/engine-$(ARCH).tar $@
+sources/engine-image:
+	mkdir -p $(@D)
+	$(MAKE) -C ../image image-linux
+	cp ../image/image-linux $@

--- a/deb/common/control
+++ b/deb/common/control
@@ -6,6 +6,7 @@ Build-Depends: bash-completion,
                dh-apparmor,
                dh-systemd,
                libltdl-dev,
+               libseccomp2,
                make,
                gcc
 Standards-Version: 3.9.6

--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -1,6 +1,26 @@
 #!/bin/sh
 set -e
 
+update_dockerd() {
+	dbefile=/var/lib/docker/distribution_based_engine.json
+	URL=https://docs.docker.com/releasenote
+	if [ -f "${dbefile}" ] && sed -e 's/.*"platform"[ \t]*:[ \t]*"\([^"]*\)".*/\1/g' "${dbefile}"| grep -v -i community > /dev/null; then
+		echo
+		echo
+		echo
+		echo "Warning: Your engine has been activated to Docker Engine - Enterprise but you are still using Community packages"
+		echo "You can use the 'docker engine update' command to update your system, or switch to using the Enterprise packages."
+		echo "See $URL for more details."
+		echo
+		echo
+		echo
+	else
+		rm -f /usr/bin/dockerd
+		update-alternatives --install /usr/bin/dockerd dockerd /usr/bin/dockerd-ce 1 --slave \
+			${dbefile} distribution_based_engine.json /var/lib/docker/distribution_based_engine-ce.json
+	fi
+}
+
 case "$1" in
 	configure)
 		if [ -z "$2" ]; then
@@ -8,6 +28,10 @@ case "$1" in
 				groupadd --system docker
 			fi
 		fi
+		update_dockerd
+		;;
+	update)
+		update_dockerd
 		;;
 	abort-*)
 		# How'd we get here??

--- a/deb/common/docker-ce.prerm
+++ b/deb/common/docker-ce.prerm
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+update-alternatives --remove dockerd /usr/bin/dockerd-ce
+

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -10,8 +10,6 @@ override_dh_gencontrol:
 override_dh_auto_build:
 	cd /go/src/github.com/docker/cli && \
 		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
-	cd /go/src/github.com/crosbymichael/containerd-proxy && \
-		make SCOPE_LABEL="com.docker/containerd-proxy.scope" ANY_SCOPE="ee" bin/containerd-proxy
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't
@@ -22,20 +20,19 @@ override_dh_auto_install:
 	install -D -m 0644 /go/src/github.com/docker/cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 	install -D -m 0755 /go/src/github.com/docker/cli/build/docker debian/docker-ce-cli/usr/bin/docker
 	# docker-ce install
-	install -D -m 0755 /go/src/github.com/crosbymichael/containerd-proxy/bin/containerd-proxy debian/docker-ce/usr/bin/dockerd
-	install -D -m 0644 /containerd-shim-process-v1 debian/docker-ce/usr/sbin/containerd-shim-process-v1
-	install -D -m 0644 /sources/engine.tar debian/docker-ce/var/lib/docker-engine/engine.tar
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
-	install -D -m 0644 /sources/dockerd.json debian/docker-ce/etc/containerd-proxy/dockerd.json
+	install -D -m 0755 /source/dockerd debian/docker-ce/usr/bin/dockerd-ce
+	install -D -m 0755 /source/docker-proxy debian/docker-ce/usr/bin/docker-proxy
+	install -D -m 0755 /source/docker-init debian/docker-ce/usr/bin/docker-init
+	install -D -m 0644 /sources/distribution_based_engine.json debian/docker-ce/var/lib/docker/distribution_based_engine-ce.json
 
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 override_dh_install:
 	dh_install
 	# TODO Can we do this from within our container?
 	dh_apparmor --profile-name=docker-ce -pdocker-ce
-
-override_dh_shlibdeps:
-	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 %:
 	dh $@ --with=bash-completion $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo --with=systemd)

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
 ARG BUILD_IMAGE=debian:buster
+ARG ENGINE_IMAGE
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO debian
 ENV SUITE buster
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-jessie/Dockerfile
+++ b/deb/debian-jessie/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=debian:jessie
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO debian
 ENV SUITE jessie
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=debian:stretch
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO debian
 ENV SUITE stretch
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-jessie/Dockerfile
+++ b/deb/raspbian-jessie/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=resin/rpi-raspbian:jessie
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO raspbian
 ENV SUITE jessie
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO raspbian
 ENV SUITE stretch
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=ubuntu:bionic
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO ubuntu
 ENV SUITE bionic
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-trusty/Dockerfile
+++ b/deb/ubuntu-trusty/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=ubuntu:trusty
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO ubuntu
 ENV SUITE trusty
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=ubuntu:xenial
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 
@@ -21,7 +21,6 @@ RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-reco
 # Copy our sources and untar them
 COPY sources/ /sources
 RUN mkdir -p /go/src/github.com/docker/ && tar -xzf /sources/cli.tgz -C /go/src/github.com/docker/
-RUN mkdir -p /go/src/github.com/crosbymichael && tar -xzf /sources/containerd-proxy.tgz -C /go/src/github.com/crosbymichael
 
 RUN ln -snf /go/src/github.com/docker/cli /root/build-deb/cli
 
@@ -29,7 +28,9 @@ ENV DISTRO ubuntu
 ENV SUITE xenial
 
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /source/
+COPY --from=engine /bin/docker-proxy /source/
+COPY --from=engine /bin/docker-init /source/
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/image/Dockerfile.engine
+++ b/image/Dockerfile.engine
@@ -22,7 +22,6 @@ RUN grep "_COMMIT=" /*.installer  |cut -f2- -d: > /binaries-commits
 # dockerd
 FROM builder as dockerd-builder
 RUN apt-get install -y \
-    libdevmapper-dev \
     libsystemd-dev
 WORKDIR /go/src/github.com/docker/docker
 COPY . /go/src/github.com/docker/docker
@@ -41,7 +40,7 @@ ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
 # TODO The way we set the version could easily be simplified not to depend on hack/...
 RUN bash ./hack/make/.go-autogen
 RUN go build -o /sbin/dockerd \
-    -tags 'autogen apparmor seccomp selinux journald' \
+    -tags 'autogen apparmor seccomp selinux journald exclude_graphdriver_devicemapper' \
     -i \
     -buildmode=pie \
     -a -ldflags '-w'\
@@ -78,8 +77,25 @@ RUN . /binaries-commits && \
 
 # Final docker image
 FROM scratch
-COPY --from=dockerd-builder /sbin/dockerd /sbin/
-COPY --from=proxy-builder /sbin/docker-proxy /sbin/
-COPY --from=init-builder /sbin/docker-init /sbin/
-COPY --from=runc-builder /usr/local/sbin/runc /sbin/
-ENTRYPOINT ["/sbin/dockerd"]
+ARG VERSION
+ARG GITCOMMIT
+ARG BUILDTIME
+ARG PLATFORM
+ARG ENGINE_IMAGE
+COPY --from=dockerd-builder /sbin/dockerd /bin/
+COPY --from=proxy-builder /sbin/docker-proxy /bin/
+COPY --from=init-builder /sbin/docker-init /bin/
+COPY --from=runc-builder /usr/local/sbin/runc /bin/
+
+LABEL \
+    org.opencontainers.image.authors="Docker Inc." \
+    org.opencontainers.image.created="${BUILDTIME}" \
+    org.opencontainers.image.documentation="https://docs.docker.com/" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.revision="${GITCOMMIT}" \
+    org.opencontainers.image.url="https://www.docker.com/products/docker-engine" \
+    org.opencontainers.image.vendor="Docker Inc." \
+    org.opencontainers.image.version="${VERSION}" \
+    com.docker.distribution_based_engine="{\"platform\":\"${PLATFORM}\",\"engine_image\":\"${ENGINE_IMAGE}\",\"containerd_min_version\":\"1.2.0-beta.1\",\"runtime\":\"host_install\"}"
+
+ENTRYPOINT ["/bin/dockerd"]

--- a/image/Dockerfile.engine-dm
+++ b/image/Dockerfile.engine-dm
@@ -45,7 +45,7 @@ ENV PRODUCT ${PRODUCT}
 ENV DEFAULT_PRODUCT_LICENSE ${DEFAULT_PRODUCT_LICENSE}
 # TODO The way we set the version could easily be simplified not to depend on hack/...
 RUN bash ./hack/make/.go-autogen
-RUN go build -o /sbin/dockerd \
+RUN go build -o /dockerd \
     -tags 'autogen apparmor seccomp selinux journald' \
     -i \
     -buildmode=pie \
@@ -60,7 +60,7 @@ WORKDIR /go/src/github.com/docker/libnetwork
 RUN . /binaries-commits && \
     git checkout -q "$LIBNETWORK_COMMIT" && \
     go build -buildmode=pie -ldflags="-w" \
-        -o /sbin/docker-proxy \
+        -o /docker-proxy \
         github.com/docker/libnetwork/cmd/proxy
 
 # docker-init - TODO move this out, last time we bumped was 2016!
@@ -70,11 +70,28 @@ WORKDIR /tini
 RUN . /binaries-commits && \
     git checkout -q "$TINI_COMMIT" && \
     cmake . && make tini-static && \
-    cp tini-static /sbin/docker-init
+    cp tini-static /docker-init
 
 # Final docker image
 FROM scratch
-COPY --from=dockerd-builder /sbin/dockerd /sbin/
-COPY --from=proxy-builder /sbin/docker-proxy /sbin/
-COPY --from=init-builder /sbin/docker-init /sbin/
-ENTRYPOINT ["/sbin/dockerd"]
+ARG VERSION
+ARG GITCOMMIT
+ARG BUILDTIME
+ARG PLATFORM
+ARG ENGINE_IMAGE
+COPY --from=dockerd-builder /dockerd /bin/
+COPY --from=proxy-builder /docker-proxy /bin/
+COPY --from=init-builder /docker-init /bin/
+
+LABEL \
+    org.opencontainers.image.authors="Docker Inc." \
+    org.opencontainers.image.created="${BUILDTIME}" \
+    org.opencontainers.image.documentation="https://docs.docker.com/" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.revision="${GITCOMMIT}" \
+    org.opencontainers.image.url="https://www.docker.com/products/docker-engine" \
+    org.opencontainers.image.vendor="Docker Inc." \
+    org.opencontainers.image.version="${VERSION}" \
+    com.docker.distribution_based_engine="{\"platform\":\"${PLATFORM}\",\"engine_image\":\"${ENGINE_IMAGE}\",\"containerd_min_version\":\"1.2.0-beta.1\",\"runtime\":\"host_install\"}"
+
+ENTRYPOINT ["/bin/dockerd"]

--- a/image/Makefile
+++ b/image/Makefile
@@ -25,6 +25,7 @@ IMAGE_BUILD?=docker build -t  $(IMAGE_WITH_TAG) \
 	--build-arg BUILDTIME="$(BUILDTIME)" \
 	--build-arg PLATFORM="$(PLATFORM)" \
 	--build-arg PRODUCT="$(PRODUCT)" \
+	--build-arg ENGINE_IMAGE="$(ENGINE_IMAGE)" \
 	--build-arg DEFAULT_PRODUCT_LICENSE="$(DEFAULT_PRODUCT_LICENSE)" \
 	$(BASE_IMAGE_FLAG) \
 	--file $< $(ENGINE_DIR)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -21,7 +21,7 @@ endif
 BUILD?=docker build \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
-	--build-arg CONTAINERD_SHIM_PROCESS_IMAGE=$(CONTAINERD_SHIM_PROCESS_IMAGE) \
+	--build-arg ENGINE_IMAGE=$(shell cat rpmbuild/SOURCES/engine-image) \
 	-t rpmbuild-$@/$(ARCH) \
 	-f $@/$(DOCKERFILE) \
 	.
@@ -39,10 +39,8 @@ RPMBUILD_FLAGS?=-ba\
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
-ENGINE_IMAGE=docker/engine-community
-ENGINE_SCOPE=ce
 
-SOURCE_FILES=containerd-proxy.tgz cli.tgz docker.service dockerd.json engine.tar
+SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 
@@ -54,11 +52,6 @@ help: ## show make targets
 clean: ## remove build artifacts
 	[ ! -d rpmbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 	$(RM) -r rpmbuild/
-	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
-	$(RM) -r artifacts/
-	[ ! -d tmp ] || $(CHOWN) -R $(shell id -u):$(shell id -g) tmp
-	$(RM) -r tmp/
-	-docker rm docker2oci
 
 .PHONY: rpm
 rpm: fedora centos ## build all rpm packages
@@ -101,28 +94,16 @@ rpmbuild/SOURCES/cli.tgz:
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
-rpmbuild/SOURCES/containerd-proxy.tgz:
-	mkdir -p tmp/
-	curl -fL -o tmp/containerd-proxy.tgz "https://github.com/crosbymichael/containerd-proxy/archive/$(CONTAINERD_PROXY_COMMIT).tar.gz"
-	tar xzf tmp/containerd-proxy.tgz -C tmp/
-	mv tmp/containerd-proxy-$(CONTAINERD_PROXY_COMMIT) tmp/containerd-proxy
-	mkdir -p $(@D)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-	tar -zcf $@ -C tmp/ containerd-proxy
-	rm -rf tmp/
-
 rpmbuild/SOURCES/docker.service: ../systemd/docker.service
 	mkdir -p $(@D)
 	cp $< $@
 
-rpmbuild/SOURCES/dockerd.json: ../common/dockerd.json
+rpmbuild/SOURCES/engine-image:
+	$(MAKE) -C ../image image-linux-dm
 	mkdir -p $(@D)
-	sed \
-	    -e 's!$${ENGINE_IMAGE}!$(ENGINE_IMAGE)!' \
-	    -e 's!$${ENGINE_SCOPE}!$(ENGINE_SCOPE)!' \
-	    -e 's/$${IMAGE_TAG}/$(IMAGE_TAG)/' \
-	    $< > $@
+	cp ../image/image-linux-dm $@
 
-rpmbuild/SOURCES/engine.tar:
-	$(MAKE) -C ../image ENGINE_IMAGE=$(ENGINE_IMAGE) ENGINE_SCOPE=$(ENGINE_SCOPE) engine-$(ARCH)-dm.tar
-	mv ../image/engine-$(ARCH)-dm.tar $@
+rpmbuild/SOURCES/distribution_based_engine.json: rpmbuild/SOURCES/engine-image
+	mkdir -p $(@D)
+	docker inspect "$(shell cat $<)" \
+		--format '{{index .Config.Labels "com.docker.distribution_based_engine" }}' > $@

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -1,12 +1,11 @@
 %global debug_package %{nil}
 
+
 Name: docker-ce
 Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: 3
-Source0: containerd-proxy.tgz
-Source1: docker.service
-Source2: engine.tar
+Source0: docker.service
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -49,31 +48,23 @@ for deploying and scaling web apps, databases, and backend services without
 depending on a particular stack or provider.
 
 %prep
-%setup -q -c -n src
 
 %build
-# dockerd proxy compilation
-mkdir -p /go/src/github.com/crosbymichael/
-ls %{_topdir}/BUILD/src
-ln -s %{_topdir}/BUILD/src/containerd-proxy /go/src/github.com/crosbymichael/containerd-proxy
-pushd /go/src/github.com/crosbymichael/containerd-proxy
-make SCOPE_LABEL="com.docker/containerd-proxy.scope" ANY_SCOPE="ee" bin/containerd-proxy
-popd
 
 %install
 # Install containerd-proxy as dockerd
-install -D -m 0755 %{_topdir}/BUILD/src/containerd-proxy/bin/containerd-proxy $RPM_BUILD_ROOT/%{_bindir}/dockerd
-install -D -m 0644 %{_topdir}/SOURCES/engine.tar $RPM_BUILD_ROOT/%{_sharedstatedir}/docker-engine/engine.tar
+install -D -m 0755 /sources/dockerd $RPM_BUILD_ROOT/%{_bindir}/dockerd-ce
+install -D -m 0755 /sources/docker-proxy $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
+install -D -m 0755 /sources/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
-install -D -m 0644 %{_topdir}/SOURCES/dockerd.json $RPM_BUILD_ROOT/etc/containerd-proxy/dockerd.json
-install -D -m 0755 /containerd-shim-process-v1 $RPM_BUILD_ROOT/%{_sbindir}/containerd-shim-process-v1
+install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_ROOT/var/lib/docker/distribution_based_engine-ce.json
 
 %files
-/%{_bindir}/dockerd
-/%{_sbindir}/containerd-shim-process-v1
-/%{_sharedstatedir}/docker-engine/engine.tar
+/%{_bindir}/dockerd-ce
+/%{_bindir}/docker-proxy
+/%{_bindir}/docker-init
 /%{_unitdir}/docker.service
-/etc/containerd-proxy/dockerd.json
+/var/lib/docker/distribution_based_engine-ce.json
 
 %pre
 if [ $1 -gt 0 ] ; then
@@ -94,15 +85,51 @@ fi
 if ! getent group docker > /dev/null; then
     groupadd --system docker
 fi
+dbefile=/var/lib/docker/distribution_based_engine.json
+URL=https://docs.docker.com/releasenote
+if [ -f "${dbefile}" ] && sed -e 's/.*"platform"[ \t]*:[ \t]*"\([^"]*\)".*/\1/g' "${dbefile}"| grep -v -i community > /dev/null; then
+    echo
+    echo
+    echo
+    echo "Warning: Your engine has been activated to Docker Engine - Enterprise but you are still using Community packages"
+    echo "You can use the 'docker engine update' command to update your system, or switch to using the Enterprise packages."
+    echo "See $URL for more details."
+    echo
+    echo
+    echo
+else
+    rm -f %{_bindir}/dockerd
+    update-alternatives --install %{_bindir}/dockerd dockerd %{_bindir}/dockerd-ce 1 \
+        --slave "${dbefile}" distribution_based_engine.json /var/lib/docker/distribution_based_engine-ce.json
+fi
+
 
 %preun
 %systemd_preun docker
+update-alternatives --remove dockerd %{_bindir}/dockerd || true
 
 %postun
 %systemd_postun_with_restart docker
 
 %posttrans
 if [ $1 -ge 0 ] ; then
+    dbefile=/var/lib/docker/distribution_based_engine.json
+    URL=https://docs.docker.com/releasenote
+    if [ -f "${dbefile}" ] && sed -e 's/.*"platform"[ \t]*:[ \t]*"\([^"]*\)".*/\1/g' "${dbefile}"| grep -v -i community > /dev/null; then
+        echo
+        echo
+        echo
+        echo "Warning: Your engine has been activated to Docker Engine - Enterprise but you are still using Community packages"
+        echo "You can use the 'docker engine update' command to update your system, or switch to using the Enterprise packages."
+        echo "See $URL for more details."
+        echo
+        echo
+        echo
+    else
+        rm -f %{_bindir}/dockerd
+        update-alternatives --install %{_bindir}/dockerd dockerd %{_bindir}/dockerd-ce 1 \
+            --slave "${dbefile}" distribution_based_engine.json /var/lib/docker/distribution_based_engine-ce.json
+    fi
     # package upgrade scenario, after new files are installed
 
     # check if docker was running before upgrade

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=centos:7
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 ENV DISTRO centos
@@ -18,6 +18,8 @@ COPY SPECS /root/rpmbuild/SPECS
 RUN sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo
 RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /sources/
+COPY --from=engine /bin/docker-proxy /sources/
+COPY --from=engine /bin/docker-init /sources/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-27/Dockerfile
+++ b/rpm/fedora-27/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=fedora:27
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 ENV DISTRO fedora
@@ -16,6 +16,8 @@ RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /sources/
+COPY --from=engine /bin/docker-proxy /sources/
+COPY --from=engine /bin/docker-init /sources/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-28/Dockerfile
+++ b/rpm/fedora-28/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_IMAGE
-ARG CONTAINERD_SHIM_PROCESS_IMAGE
+ARG ENGINE_IMAGE
 ARG BUILD_IMAGE=fedora:28
 FROM ${GO_IMAGE} as golang
-FROM ${CONTAINERD_SHIM_PROCESS_IMAGE} as shim-process
+FROM ${ENGINE_IMAGE} as engine
 
 FROM ${BUILD_IMAGE}
 ENV DISTRO fedora
@@ -16,6 +16,8 @@ RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go/
-COPY --from=shim-process /bin/containerd-shim-process-v1 /containerd-shim-process-v1
+COPY --from=engine /bin/dockerd /sources/
+COPY --from=engine /bin/docker-proxy /sources/
+COPY --from=engine /bin/docker-init /sources/
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -9,9 +9,8 @@ Wants=network-online.target
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd
+ExecStart=/usr/bin/dockerd -H unix://
 ExecReload=/bin/kill -s HUP $MAINPID
-ExecStopPost=/usr/bin/dockerd post-stop
 TimeoutSec=0
 RestartSec=2
 Restart=always


### PR DESCRIPTION
* Switches the build process to utilize the engine image to download binaries to be installed as part of the package
* Removes `containerd-proxy` and `containerd-shim-process` as dependencies for the packaging
* Removes extra containerd flags in the systemd unit file (this will actually brick installations with these new packages until the defaults are changed in upstream `moby/moby`)
* Adds a breadcrumb file that contains metadata over what image was used for the binaries that are being installed with the package

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>