### PR TITLE
[18.09] backport update package description

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,11 +27,11 @@ Recommends: aufs-tools,
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
 Replaces: docker-engine
 Description: Docker: the open-source application container engine
- Docker is an open source project to build, ship and run any application as a
+ Docker is a product for you to build, ship and run any application as a
  lightweight container
  .
  Docker containers are both hardware-agnostic and platform-agnostic. This means
- they can run anywhere, from your laptop to the largest EC2 compute instance and
+ they can run anywhere, from your laptop to the largest cloud compute instance and
  everything in between - and they don't require you to use a particular
  language, framework or packaging system. That makes them great building blocks
  for deploying and scaling web apps, databases, and backend services without
@@ -43,11 +43,11 @@ Depends: ${shlibs:Depends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
 Breaks: docker-ce (<< 18.06~)
 Description: Docker CLI: the open-source application container engine
- Docker is an open source project to build, ship and run any application as a
+ Docker is a product for you to build, ship and run any application as a
  lightweight container
  .
  Docker containers are both hardware-agnostic and platform-agnostic. This means
- they can run anywhere, from your laptop to the largest EC2 compute instance and
+ they can run anywhere, from your laptop to the largest cloud compute instance and
  everything in between - and they don't require you to use a particular
  language, framework or packaging system. That makes them great building blocks
  for deploying and scaling web apps, databases, and backend services without

--- a/deb/common/control
+++ b/deb/common/control
@@ -9,7 +9,7 @@ Build-Depends: bash-completion,
                make,
                gcc
 Standards-Version: 3.9.6
-Homepage: https://docker.com
+Homepage: https://www.docker.com
 Vcs-Browser: https://github.com/docker/docker
 Vcs-Git: git://github.com/docker/docker.git
 


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/224 for 18.09

```
git checkout -b 18.09_update_package_description upstream/18.09
git cherry-pick -s -S -x a4df8fe1f86f38ad935862eb188b6fc234d22793
git cherry-pick -s -S -x 1a3379642fb37457d0249ae99385d17ddc85a6af
```

cherry-pick was clean; no conflicts
