### PR TITLE
[18.09] backport Update outdated Fedora versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The scripts will build for this list of packages types:
 * DEB packages for Debian 9 Stretch
 * DEB packages for Debian 8 Jessie
 * DEB packages for Debian 7 Wheezy
+* RPM packages for Fedora 28
 * RPM packages for Fedora 27
-* RPM packages for Fedora 26
 * RPM packages for CentOS 7
 * TGZ and ZIP files with static binaries


### PR DESCRIPTION
backport https://github.com/docker/docker-ce-packaging/pull/177 to minimize the diff between the 18.09 branch and master

(cherry picked from commit f0212649020ad5a1b0ca17c61ab500992ac981b4)
