### PR TITLE
[18.09] revert "Specify suffix for DEB_VERSION"

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -8,8 +8,7 @@ VERSION?=0.0.0-dev
 GO_BASE_IMAGE=golang
 GO_VERSION:=1.10.4
 GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)
-SUFFIX=ce
-DEB_VERSION?=$(shell SUFFIX=$(SUFFIX) ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
+DEB_VERSION=$(shell ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 EPOCH?=4
 


### PR DESCRIPTION
This reverts commit 6c5b7fcb956871f7a44e1a478ad9450f9df4bed1. https://github.com/docker/docker-ce-packaging/pull/167
