### PR TITLE
[master] systemd/docker.service: fix PATH

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -26,9 +26,8 @@ StartLimitBurst=3
 # this option work for either version of systemd.
 StartLimitInterval=60s
 
-# On RPM Based distributions PATH isn't defined so we define it here
 # /opt/containerd/bin is in front so dockerd grabs the correct runc binary
-Environment="PATH=/opt/containerd/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:$PATH"
+Environment="PATH=/opt/containerd/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
Set the PATH to what appears to be the standard on latest Ubuntu (18.04)
and Debian (9), fixing the following two issues:

1. PATH did not contain /bin (leading to ContainerTop/ps not working
on newer distros, among the other things).

2. $PATH can't be specified in Environment directives in .service files.

While at it, also:

3. Remove the comment about RPM as it looks misleading on deb-based
systems.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>