### PR TITLE
[18.09] Make -dm image based not tag based

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -73,10 +73,10 @@ engine-$(ARCH).tar: engine-$(ARCH)-docker-compat.tar $(DOCKER2OCI)
 engine-$(ARCH)-docker-compat.tar: image-linux
 	docker save -o $@ $$(cat $<)
 
+image-linux-dm: ENGINE_IMAGE:=$(ENGINE_IMAGE)-dm
 image-linux-dm: $(ENGINE_DIR)/Dockerfile.engine-dm
 	$(IMAGE_BUILD)
-	docker tag $(IMAGE_WITH_TAG) $(IMAGE_WITH_TAG)-dm
-	echo $(IMAGE_WITH_TAG)-dm > $@
+	echo $(IMAGE_WITH_TAG) > $@
 
 engine-$(ARCH)-dm.tar: engine-$(ARCH)-dm-docker-compat.tar $(DOCKER2OCI)
 	mkdir -p artifacts


### PR DESCRIPTION
Cherry-pick of https://github.com/docker/docker-ce-packaging/pull/233

With 

```
git cherry-pick -s -x 206d61f29d1722ae3e319e22a4c5c88d1baf6e13
```

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 206d61f29d1722ae3e319e22a4c5c88d1baf6e13)
Signed-off-by: Jose Bigio <jose.bigio@docker.com>