### PR TITLE
[18.09] epoch bump

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -10,7 +10,7 @@ GO_VERSION:=1.10.4
 GO_IMAGE=$(GO_BASE_IMAGE):$(GO_VERSION)
 DEB_VERSION=$(shell ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
-EPOCH?=4
+EPOCH?=5
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)


### PR DESCRIPTION
Cherry-pick of https://github.com/docker/docker-ce-packaging/pull/236

With 
```
git cherry-pick -s -x 024e366bd36799b24a1b8f4666de62208fb7d9a5
```
