### PR TITLE
[DO NOT MERGE] Set kernel.pid_max sysctl to a bigger value

### DIFF
--- a/common/50-pid_max.conf
+++ b/common/50-pid_max.conf
@@ -1,0 +1,12 @@
+# This specifies the value at which PIDs wrap around (i.e., the value is
+# one greater than the maximum PID). PIDs greater than this value are not
+# allocated; thus, the value also acts as a system-wide limit on the total
+# number of processes and threads.
+#
+# On 32-bit platforms, 32768 is the maximum value for pid_max. On 64-bit
+# systems, pid_max can be set to any value up to 2^22 (PID_MAX_LIMIT,
+# approximately 4 million).
+#
+
+kernel.pid_max = 1048576
+

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -32,7 +32,7 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json 50-pid_max.conf
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
 .PHONY: help
@@ -128,6 +128,10 @@ sources/cli.tgz:
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
 sources/docker.service: ../systemd/docker.service
+	mkdir -p $(@D)
+	cp $< $@
+
+sources/50-pid_max.conf: ../common/50-pid_max.conf
 	mkdir -p $(@D)
 	cp $< $@
 

--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -28,6 +28,7 @@ case "$1" in
 				groupadd --system docker
 			fi
 		fi
+		/usr/lib/systemd/systemd-sysctl 50-pid_max.conf >/dev/null 2>&1 || :
 		update_dockerd
 		;;
 	update)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -25,6 +25,7 @@ override_dh_auto_install:
 	install -D -m 0755 /source/docker-proxy debian/docker-ce/usr/bin/docker-proxy
 	install -D -m 0755 /source/docker-init debian/docker-ce/usr/bin/docker-init
 	install -D -m 0644 /sources/distribution_based_engine.json debian/docker-ce/var/lib/docker-engine/distribution_based_engine-ce.json
+	install -D -m 0644 /sources/50-pid_max.conf debian/docker-ce/etc/sysctl.d/50-pid_max.conf
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -40,7 +40,7 @@ RPMBUILD_FLAGS?=-ba\
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json 50-pid_max.conf
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 
@@ -95,6 +95,10 @@ rpmbuild/SOURCES/cli.tgz:
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
 rpmbuild/SOURCES/docker.service: ../systemd/docker.service
+	mkdir -p $(@D)
+	cp $< $@
+
+rpmbuild/SOURCES/50-pid_max.conf: ../common/50-pid_max.conf
 	mkdir -p $(@D)
 	cp $< $@
 

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -58,6 +58,7 @@ install -D -m 0755 /sources/docker-proxy $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
 install -D -m 0755 /sources/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
 install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_ROOT/var/lib/docker-engine/distribution_based_engine-ce.json
+install -D -m 0644 %{_topdir}/SOURCES/50-pid_max.conf $RPM_BUILD_ROOT/etc/sysctl.d/50-pid_max.conf
 
 %files
 /%{_bindir}/dockerd-ce
@@ -65,6 +66,7 @@ install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_
 /%{_bindir}/docker-init
 /%{_unitdir}/docker.service
 /var/lib/docker-engine/distribution_based_engine-ce.json
+/etc/sysctl.d/50-pid_max.conf
 
 %pre
 if [ $1 -gt 0 ] ; then
@@ -81,6 +83,7 @@ if [ $1 -gt 0 ] ; then
 fi
 
 %post
+/usr/lib/systemd/systemd-sysctl 50-pid_max.conf >/dev/null 2>&1 || :
 %systemd_post docker
 if ! getent group docker > /dev/null; then
     groupadd --system docker


### PR DESCRIPTION
Default for kernel.pid_max sysctl appears to be
128K (i.e. 131072), which might not be enough for
systems with lots of RAM running lots of threads.

Once the limit is hit, bad things might happen. In particular,
Go's runtime/cgo can't handle it gracefully, chosing
a suicide instead:

> runtime/cgo: pthread_create failed: Resource temporarily unavailable
> SIGABRT: abort

What needs to be done is to carefully audit dockerd for goroutine
leaks. In the meantime, though, raising the pid_max limit seems
to be a not-so-bad workaround.