### PR TITLE
[18.09 backport] Restore `Type=notify` in Systemd unit

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -6,6 +6,7 @@ After=network-online.target firewalld.service
 Wants=network-online.target
 
 [Service]
+Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker


### PR DESCRIPTION
Backport https://github.com/docker/docker-ce-packaging/pull/249 for 18.09. This was a regression introduced in https://github.com/docker/docker-ce-packaging/pull/131

```
git checkout -b 18.09_backport_notify upstream/18.09
git cherry-pick -s -S -x 221b152fde996db4c7571c37f8b934db7f5dda49
git push -u origin
```

cherry-pick was clean; no conflicts