### PR TITLE
[18.09 backport] Add initial scripts for Fedora 29

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -52,6 +52,12 @@ help: ## show make targets
 clean: ## remove build artifacts
 	[ ! -d rpmbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 	$(RM) -r rpmbuild/
+	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
+	$(RM) -r artifacts/
+	[ ! -d tmp ] || $(CHOWN) -R $(shell id -u):$(shell id -g) tmp
+	$(RM) -r tmp/
+	-docker rm docker2oci
+	$(MAKE) -C ../image clean
 
 .PHONY: rpm
 rpm: fedora centos ## build all rpm packages
@@ -61,6 +67,14 @@ fedora: fedora-28 fedora-27 fedora-26 ## build all fedora rpm packages
 
 .PHONY: centos
 centos: centos-7 ## build all centos rpm packages
+
+.PHONY: fedora-29
+fedora-29: ## build fedora-29 rpm packages
+fedora-29: $(SOURCES)
+	$(CHOWN) -R root:root rpmbuild
+	$(BUILD)
+	$(RUN)
+	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 
 .PHONY: fedora-28
 fedora-28: ## build fedora-28 rpm packages

--- a/rpm/fedora-29/Dockerfile
+++ b/rpm/fedora-29/Dockerfile
@@ -1,0 +1,23 @@
+ARG GO_IMAGE
+ARG ENGINE_IMAGE
+ARG BUILD_IMAGE=fedora:29
+FROM ${GO_IMAGE} as golang
+FROM ${ENGINE_IMAGE} as engine
+
+FROM ${BUILD_IMAGE}
+ENV DISTRO fedora
+ENV SUITE 29
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=engine /bin/dockerd /sources/
+COPY --from=engine /bin/docker-proxy /sources/
+COPY --from=engine /bin/docker-init /sources/
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/212 for 18.09

Relates to https://github.com/docker/for-linux/issues/430

Like https://github.com/docker/docker-ce-packaging/pull/255, probably will be for 18.09.1


```
git checkout -b 18.09_backport_fedora29 upstream/18.09
git cherry-pick -s -S -x 42f5f2f4384f1699fbe55746d53718016cd6fb87
```
cherry-pick was clean; no conflicts