### PR TITLE
[18.09] Add the docker.socket back in

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -32,7 +32,7 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service docker.socket 00-socket-activation.conf distribution_based_engine.json
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
 .PHONY: help
@@ -135,6 +135,14 @@ sources/cli.tgz:
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
 sources/docker.service: ../systemd/docker.service
+	mkdir -p $(@D)
+	cp $< $@
+
+sources/docker.socket: ../systemd/docker.socket
+	mkdir -p $(@D)
+	cp $< $@
+
+sources/00-socket-activation.conf: ../systemd/00-socket-activation.conf
 	mkdir -p $(@D)
 	cp $< $@
 

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -21,6 +21,8 @@ override_dh_auto_install:
 	install -D -m 0755 /go/src/github.com/docker/cli/build/docker debian/docker-ce-cli/usr/bin/docker
 	# docker-ce install
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
+	install -D -m 0644 /sources/docker.socket debian/docker-ce/lib/systemd/system/docker.socket
+	install -D -m 0644 /sources/00-socket-activation.conf debian/docker-ce/lib/systemd/system/docker.service.d/00-socket-activation.conf
 	install -D -m 0755 /source/dockerd debian/docker-ce/usr/bin/dockerd-ce
 	install -D -m 0755 /source/docker-proxy debian/docker-ce/usr/bin/docker-proxy
 	install -D -m 0755 /source/docker-init debian/docker-ce/usr/bin/docker-init

--- a/systemd/00-socket-activation.conf
+++ b/systemd/00-socket-activation.conf
@@ -1,0 +1,7 @@
+[Unit]
+After=docker.socket
+Requires=docker.socket
+
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd://

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -10,7 +10,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H unix://
+ExecStart=/usr/bin/dockerd
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2

--- a/systemd/docker.socket
+++ b/systemd/docker.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=Docker Socket for the API
+PartOf=docker.service
+
+[Socket]
+ListenStream=/var/run/docker.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=docker
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Re-adds the docker.socket file for debian based distributions.

This is a backport of #257 

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 69bd2eea398e0396c24f97d0697f9befd0f2464e)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>