### PR TITLE
Remove remnants from telemetry plugin from Fedora 27, 28

### DIFF
--- a/rpm/fedora-27/docker-ce.spec
+++ b/rpm/fedora-27/docker-ce.spec
@@ -81,8 +81,6 @@ for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
 done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
-mkdir -p plugin
-printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
 
 %check
 cli/build/docker -v

--- a/rpm/fedora-28/docker-ce.spec
+++ b/rpm/fedora-28/docker-ce.spec
@@ -81,8 +81,6 @@ for component in tini "proxy dynamic" "runc all" "containerd dynamic";do
 done
 VERSION=%{_origversion} hack/make.sh dynbinary
 popd
-mkdir -p plugin
-printf '{"edition_type":"ce","edition_name":"%s","edition_version":"%s"}\n' "${DISTRO}" "%{_version}" > plugin/.plugin-metadata
 
 %check
 cli/build/docker -v


### PR DESCRIPTION
These were leftovers from https://github.com/docker/docker-ce-packaging/pull/41, and were removed from Fedora 26 in https://github.com/docker/docker-ce-packaging/pull/42, but still present in Fedora 27, 28

Note that these files can probably be removed altogether, but I'm looking at some differences between the old and new ones, so I'll do that in a follow up