### PR TITLE
[master] Add explicit dependency for libseccomp2

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -16,7 +16,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: docker-ce-cli, containerd.io, iptables, ${shlibs:Depends}
+Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
 Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,


### PR DESCRIPTION
Forward-port of https://github.com/docker/docker-ce-packaging/pull/172 to master

Minor conflict because https://github.com/docker/docker-ce-packaging/pull/210 was merged in a different order, but trivial to fix;

```patch
diff --cc deb/common/control
index b2b566e,f49bde0..0000000
--- a/deb/common/control
+++ b/deb/common/control
@@@ -16,8 -15,8 +16,13 @@@ Vcs-Git: git://github.com/docker/docker
  
  Package: docker-ce
  Architecture: linux-any
++<<<<<<< HEAD
 +Depends: docker-ce-cli, containerd.io, iptables, ${shlibs:Depends}
 +Recommends: aufs-tools,
++=======
+ Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
+ Recommends: abufs-tools,
++>>>>>>> f2ceca9... Add explicit dependency for libseccomp2
              ca-certificates,
              cgroupfs-mount | cgroup-lite,
              git,
```


While testing on older ubuntu images we discovered
we do depend on a newer version of libseccomp2.
