### PR TITLE
[18.09 backport] Change replaces/breaks to have compat with nightly

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -42,8 +42,8 @@ Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
-Replaces: docker-ce (<< 5:18.09)
-Breaks: docker-ce (<< 5:18.09)
+Replaces: docker-ce (<< 5:0)
+Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a
  lightweight container


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/250 for 18.09

Nightly builds wouldn't install correctly since our versioning scheme
for nightly builds is 0.0.0~ and 0 < 18.

Should be backwards compatible with 18.09 builds so there's no need to
actually backport this to 18.09.
