### PR TITLE
Fix RPM containerd dependency

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -14,7 +14,7 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
-Requires: containerd
+Requires: containerd.io
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel


### PR DESCRIPTION
The package in the docker repositories is named containerd.io, not containerd.
