### PR TITLE
[18.09 backport] Fix RPM containerd dependency

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -14,7 +14,7 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
-Requires: containerd
+Requires: containerd.io
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel


### PR DESCRIPTION
Backport of https://github.com/docker/docker-ce-packaging/pull/264 for 18.09.
Cherry-pick was clean


The package in the docker repositories is named containerd.io, not containerd.
