### PR TITLE
[18.09] Add libseccomp requirement for rpm packages

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -15,6 +15,7 @@ Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
 Requires: container-selinux >= 2.9
+Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
 # Should be required as well by docker-ce-cli but let's just be thorough


### PR DESCRIPTION
This requirement was originally added in 86f76496ce33bd6eff1737348bc44add4723ddd2 (https://github.com/docker/docker-ce-packaging/pull/75), but got removed in the migration to the new image-based packaging.

Commit f2ceca98823548e401c6cca125b7057df28c4892 (https://github.com/docker/docker-ce-packaging/pull/172) added this requirement back for `.deb` packages, but did not include the same changes for RPMs.

This patch adds back the requirement for RPM packages as well.
