### PR TITLE
[18.09] Add back requirements that were removed in the migration

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -17,8 +17,14 @@ Requires: docker-ce-cli
 Requires: container-selinux >= 2.9
 Requires: systemd-units
 Requires: iptables
+Requires: libcgroup
 # Should be required as well by docker-ce-cli but let's just be thorough
 Requires: containerd.io
+Requires: tar
+Requires: xz
+
+# Resolves: rhbz#1165615
+Requires: device-mapper-libs >= 1.02.90-1
 
 BuildRequires: which
 BuildRequires: make


### PR DESCRIPTION
During the migration to "image based builds", some dependencies were removed.

This patch brings back those dependencies.
