### PR TITLE
Remove containerd dependency from CLI

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -14,7 +14,6 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
-Requires: containerd
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -17,7 +17,6 @@ Requires: docker-ce-cli
 Requires: container-selinux >= 2.9
 Requires: systemd-units
 Requires: iptables
-# Should be required as well by docker-ce-cli but let's just be thorough
 Requires: containerd.io
 
 BuildRequires: which


### PR DESCRIPTION
The RPM packages list containerd as a hard dependency. While having containerd installed allows certain features (e.g., allow you to run `docker engine activate`), this should not be a requirement for installing the Docker CLI, as it limits the use of this package for situations where the CLI is installed to connect to a remote daemon.

This patch removes the containerd dependency from the RPM packages (the deb packages don't have this dependency, so no change is needed in those packages)
