### PR TITLE
[18.09 backport] Remove containerd dependency from CLI

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -14,7 +14,6 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
-Requires: containerd
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,7 +19,6 @@ Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
 Requires: libcgroup
-# Should be required as well by docker-ce-cli but let's just be thorough
 Requires: containerd.io
 Requires: tar
 Requires: xz


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/268 for 18.09

The RPM packages list containerd as a hard dependency. While having containerd installed allows certain features (e.g., allow you to run `docker engine activate`), this should not be a requirement for installing the Docker CLI, as it limits the use of this package for situations where the CLI is installed to connect to a remote daemon.

This patch removes the containerd dependency from the RPM packages (the deb packages don't have this dependency, so no change is needed in those packages)

For reference; I checked if the `.deb` packages also had this requirement, but they don't seem to;

```bash
curl -o docker.deb https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce-cli_18.09.0~3-0~ubuntu-xenial_amd64.deb

dpkg-deb --info docker.deb

...
 Depends: libc6 (>= 2.4), libltdl7 (>= 2.4.6)
 Conflicts: docker (<< 1.5~), docker-engine, docker-engine-cs, docker.io, lxc-docker, lxc-docker-virtual-package
 Breaks: docker-ce (<< 5:18.09)
 Replaces: docker-ce (<< 5:18.09)
...
```