### PR TITLE
Remove obsolete "selinux" and "engine" packages from CLI rpm

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -26,11 +26,6 @@ Conflicts: docker-engine-cs
 Conflicts: docker-ee
 Conflicts: docker-ee-cli
 
-# Obsolete packages
-Obsoletes: docker-ce-selinux
-Obsoletes: docker-engine-selinux
-Obsoletes: docker-engine
-
 %description
 Docker is is a product for you to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
The CLI package does not provide the functionality of the "selinux" and "engine" packages (it does _conflict_ with older engine packages though).

This removes the "obsoletes" from the CLI package, as the Engine package already obsoletes the other ones.
