### PR TITLE
[WIP] CLI RPM: only conflict with older engine packages

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -23,7 +23,8 @@ BuildRequires: libtool-ltdl-devel
 Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-engine-cs
-Conflicts: docker-ee
+Conflicts: docker-ce < 18.09
+Conflicts: docker-ee < 18.09
 Conflicts: docker-ee-cli
 
 # Obsolete packages


### PR DESCRIPTION
Engine packages 18.09 and up no longer contain the CLI (as it is split to a separate package), so we can limit the conflict to older packages.

This change should allow users to install a Docker CE CLI on a host that has Docker EE Engine 18.09, or vice-versa (an EE CLI on a host that has Docker CE Engine 18.09).

