### PR TITLE
Add socket activation for RHEL based distributions

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -32,7 +32,7 @@ RUN=docker run --rm -i \
 	-v $(CURDIR)/debbuild/$@:/build \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=engine-image cli.tgz docker.service docker.socket 00-socket-activation.conf distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
 .PHONY: help
@@ -118,10 +118,6 @@ sources/docker.service: ../systemd/docker.service
 	cp $< $@
 
 sources/docker.socket: ../systemd/docker.socket
-	mkdir -p $(@D)
-	cp $< $@
-
-sources/00-socket-activation.conf: ../systemd/00-socket-activation.conf
 	mkdir -p $(@D)
 	cp $< $@
 

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -22,7 +22,6 @@ override_dh_auto_install:
 	# docker-ce install
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
 	install -D -m 0644 /sources/docker.socket debian/docker-ce/lib/systemd/system/docker.socket
-	install -D -m 0644 /sources/00-socket-activation.conf debian/docker-ce/lib/systemd/system/docker.service.d/00-socket-activation.conf
 	install -D -m 0755 /source/dockerd debian/docker-ce/usr/bin/dockerd-ce
 	install -D -m 0755 /source/docker-proxy debian/docker-ce/usr/bin/docker-proxy
 	install -D -m 0755 /source/docker-init debian/docker-ce/usr/bin/docker-init

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -40,7 +40,7 @@ RPMBUILD_FLAGS?=-ba\
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-SOURCE_FILES=engine-image cli.tgz docker.service distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 
@@ -109,6 +109,10 @@ rpmbuild/SOURCES/cli.tgz:
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
 
 rpmbuild/SOURCES/docker.service: ../systemd/docker.service
+	mkdir -p $(@D)
+	cp $< $@
+
+rpmbuild/SOURCES/docker.socket: ../systemd/docker.socket
 	mkdir -p $(@D)
 	cp $< $@
 

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -6,6 +6,7 @@ Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: 3
 Source0: docker.service
+Source1: docker.socket
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -56,6 +57,7 @@ install -D -m 0755 /sources/dockerd $RPM_BUILD_ROOT/%{_bindir}/dockerd-ce
 install -D -m 0755 /sources/docker-proxy $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
 install -D -m 0755 /sources/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
 install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+install -D -m 0644 %{_topdir}/SOURCES/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
 install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_ROOT/var/lib/docker-engine/distribution_based_engine-ce.json
 
 %files
@@ -63,6 +65,7 @@ install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_
 /%{_bindir}/docker-proxy
 /%{_bindir}/docker-init
 /%{_unitdir}/docker.service
+/%{_unitdir}/docker.socket
 /var/lib/docker-engine/distribution_based_engine-ce.json
 
 %pre

--- a/systemd/00-socket-activation.conf
+++ b/systemd/00-socket-activation.conf
@@ -1,7 +1,0 @@
-[Unit]
-After=docker.socket
-Requires=docker.socket
-
-[Service]
-ExecStart=
-ExecStart=/usr/bin/dockerd -H fd://

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -10,7 +10,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd
+ExecStart=/usr/bin/dockerd -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2


### PR DESCRIPTION
Removes the systemd drop-in unit file for socket activation and instead
prefers socket activation by default for both RHEL based and DEBIAN
based distributions.

Socket activation for RHEL based distributions was tested on CentOS 7 and Fedora 28.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>