### PR TITLE
[18.09] Add docker.socket requirement for docker.service

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -4,6 +4,7 @@ Documentation=https://docs.docker.com
 BindsTo=containerd.service
 After=network-online.target firewalld.service
 Wants=network-online.target
+Requires=docker.socket
 
 [Service]
 Type=notify


### PR DESCRIPTION
Without this the docker.socket would not start by default when starting
the docker.service leading to failures to start.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>
(cherry picked from commit 88885d18b1bb0ef91eab4ad3311773f9c40838b7)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>