### PR TITLE
[18.09 backport] Remove obsolete "selinux" and "engine" packages from CLI rpm

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -25,11 +25,6 @@ Conflicts: docker-engine-cs
 Conflicts: docker-ee
 Conflicts: docker-ee-cli
 
-# Obsolete packages
-Obsoletes: docker-ce-selinux
-Obsoletes: docker-engine-selinux
-Obsoletes: docker-engine
-
 %description
 Docker is is a product for you to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
Backport of https://github.com/docker/docker-ce-packaging/pull/270 for 18.09

cherry-pick was clean; no conflicts


The CLI package does not provide the functionality of the
"selinux" and "engine" packages (it does _conflict_ with
older engine packages though).

This removes the "obsoletes" from the CLI package, as the
Engine package already obsoletes the other ones.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit d4e1ddb963a43ff9f0a06e4ed1b37307c8f26a17)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>