### PR TITLE
Restore SysVinit and Upstart support

### DIFF
--- a/deb/common/docker-ce.docker.default
+++ b/deb/common/docker-ce.docker.default
@@ -1,0 +1,20 @@
+# Docker Upstart and SysVinit configuration file
+
+#
+# THIS FILE DOES NOT APPLY TO SYSTEMD
+#
+#   Please see the documentation for "systemd drop-ins":
+#   https://docs.docker.com/engine/admin/systemd/
+#
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKERD="/usr/local/bin/dockerd"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+#DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy="http://127.0.0.1:3128/"
+
+# This is also a handy place to tweak where Docker's temporary files go.
+#export DOCKER_TMPDIR="/mnt/bigdrive/docker-tmp"

--- a/deb/common/docker-ce.docker.init
+++ b/deb/common/docker-ce.docker.init
@@ -1,0 +1,156 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:           docker
+# Required-Start:     $syslog $remote_fs
+# Required-Stop:      $syslog $remote_fs
+# Should-Start:       cgroupfs-mount cgroup-lite
+# Should-Stop:        cgroupfs-mount cgroup-lite
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Create lightweight, portable, self-sufficient containers.
+# Description:
+#  Docker is an open-source project to easily create lightweight, portable,
+#  self-sufficient containers from any application. The same container that a
+#  developer builds and tests on a laptop can run at scale, in production, on
+#  VMs, bare metal, OpenStack clusters, public clouds and more.
+### END INIT INFO
+
+export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
+BASE=docker
+
+# modify these in /etc/default/$BASE (/etc/default/docker)
+DOCKERD=/usr/bin/dockerd
+# This is the pid file managed by docker itself
+DOCKER_PIDFILE=/var/run/$BASE.pid
+# This is the pid file created/managed by start-stop-daemon
+DOCKER_SSD_PIDFILE=/var/run/$BASE-ssd.pid
+DOCKER_LOGFILE=/var/log/$BASE.log
+DOCKER_OPTS=
+DOCKER_DESC="Docker"
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+if [ -f /etc/default/$BASE ]; then
+	. /etc/default/$BASE
+fi
+
+# Check docker is present
+if [ ! -x $DOCKERD ]; then
+	log_failure_msg "$DOCKERD not present or not executable"
+	exit 1
+fi
+
+check_init() {
+	# see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it directly)
+	if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then
+		log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
+		exit 1
+	fi
+}
+
+fail_unless_root() {
+	if [ "$(id -u)" != '0' ]; then
+		log_failure_msg "$DOCKER_DESC must be run as root"
+		exit 1
+	fi
+}
+
+cgroupfs_mount() {
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		return
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
+}
+
+case "$1" in
+	start)
+		check_init
+		
+		fail_unless_root
+
+		cgroupfs_mount
+
+		touch "$DOCKER_LOGFILE"
+		chgrp docker "$DOCKER_LOGFILE"
+
+		ulimit -n 1048576
+
+		# Having non-zero limits causes performance problems due to accounting overhead
+		# in the kernel. We recommend using cgroups to do container-local accounting.
+		if [ "$BASH" ]; then
+			ulimit -u unlimited
+		else
+			ulimit -p unlimited
+		fi
+
+		log_begin_msg "Starting $DOCKER_DESC: $BASE"
+		start-stop-daemon --start --background \
+			--no-close \
+			--exec "$DOCKERD" \
+			--pidfile "$DOCKER_SSD_PIDFILE" \
+			--make-pidfile \
+			-- \
+				-p "$DOCKER_PIDFILE" \
+				$DOCKER_OPTS \
+					>> "$DOCKER_LOGFILE" 2>&1
+		log_end_msg $?
+		;;
+
+	stop)
+		check_init
+		fail_unless_root
+		if [ -f "$DOCKER_SSD_PIDFILE" ]; then
+			log_begin_msg "Stopping $DOCKER_DESC: $BASE"
+			start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE" --retry 10
+			log_end_msg $?
+		else
+			log_warning_msg "Docker already stopped - file $DOCKER_SSD_PIDFILE not found."
+		fi
+		;;
+
+	restart)
+		check_init
+		fail_unless_root
+		docker_pid=`cat "$DOCKER_SSD_PIDFILE" 2>/dev/null`
+		[ -n "$docker_pid" ] \
+			&& ps -p $docker_pid > /dev/null 2>&1 \
+			&& $0 stop
+		$0 start
+		;;
+
+	force-reload)
+		check_init
+		fail_unless_root
+		$0 restart
+		;;
+
+	status)
+		check_init
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKERD" "$DOCKER_DESC"
+		;;
+
+	*)
+		echo "Usage: service docker {start|stop|restart|status}"
+		exit 1
+		;;
+esac

--- a/deb/common/docker-ce.docker.upstart
+++ b/deb/common/docker-ce.docker.upstart
@@ -1,0 +1,72 @@
+description "Docker daemon"
+
+start on (filesystem and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+limit nofile 524288 1048576
+
+# Having non-zero limits causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+limit nproc unlimited unlimited
+
+respawn
+
+kill timeout 20
+
+pre-start script
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		exit 0
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
+end script
+
+script
+	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+	DOCKERD=/usr/bin/dockerd
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+	exec "$DOCKERD" $DOCKER_OPTS --raw-logs
+end script
+
+# Don't emit "started" event until docker.sock is ready.
+# See https://github.com/docker/docker/issues/6647
+post-start script
+	DOCKER_OPTS=
+	DOCKER_SOCKET=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+
+	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+		DOCKER_SOCKET=/var/run/docker.sock
+	else
+		DOCKER_SOCKET=$(printf "%s" "$DOCKER_OPTS" | grep -oP -e '(-H|--host)\W*unix://\K(\S+)' | sed 1q)
+	fi
+
+	if [ -n "$DOCKER_SOCKET" ]; then
+		while ! [ -e "$DOCKER_SOCKET" ]; do
+			initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
+			echo "Waiting for $DOCKER_SOCKET"
+			sleep 0.1
+		done
+		echo "$DOCKER_SOCKET is up"
+	fi
+end script

--- a/deb/common/docker-ce.prerm
+++ b/deb/common/docker-ce.prerm
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
 
-update-alternatives --remove dockerd /usr/bin/dockerd-ce
+#DEBHELPER#
 
+update-alternatives --remove dockerd /usr/bin/dockerd-ce

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -27,6 +27,10 @@ override_dh_auto_install:
 	install -D -m 0755 /source/docker-init debian/docker-ce/usr/bin/docker-init
 	install -D -m 0644 /sources/distribution_based_engine.json debian/docker-ce/var/lib/docker-engine/distribution_based_engine-ce.json
 
+override_dh_installinit:
+	# use "docker" as our service name, not "docker-ce"
+	dh_installinit --name=docker
+
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 


### PR DESCRIPTION
Support was removed in 662e248f680eb49a9951a8b34125506b8f82dfed.  The removal breaks usage on Debian derivatives that do not use `systemd` (see https://github.com/docker/for-linux/issues/482).