### PR TITLE
[master] Remove s390x and ppc64le from the testing matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,6 @@ test_steps = [
 
 arches = [
 	"x86_64",
-	// "s390x",
-	"ppc64le",
 	"aarch64",
 	"armhf"
 ]


### PR DESCRIPTION
We don't produce packages for these anymore so there's no real use in testing them anymore.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>