### PR TITLE
Require a containerd.io version >= 1.2.2

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -16,7 +16,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
+Depends: docker-ce-cli, containerd.io (>= 1.2.2), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
 Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,7 +19,7 @@ Requires: container-selinux >= 2.9
 Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
-Requires: containerd.io
+Requires: containerd.io >= 1.2.2
 
 BuildRequires: which
 BuildRequires: make


### PR DESCRIPTION
Hardcodes the requirement for containerd.io to be greater than or equal to 1.2.2

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>