### PR TITLE
Revert "Require a containerd.io version >= 1.2.2"

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -16,7 +16,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: docker-ce-cli, containerd.io (>= 1.2.2), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
+Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
 Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,7 +19,7 @@ Requires: container-selinux >= 2.9
 Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
-Requires: containerd.io >= 1.2.2
+Requires: containerd.io
 
 BuildRequires: which
 BuildRequires: make


### PR DESCRIPTION
Reverts docker/docker-ce-packaging#289

Had a talk with @thaJeztah and @seemethere about this and worked out that we ought to have containerd.io as part of the install and upgrade process of the docker-ce engine explicitly for the admin who installs this. Documentation will be updated to reflect this expectation.