### PR TITLE
[18.09 backport] Start docker.service after containerd.service

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -2,7 +2,7 @@
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 BindsTo=containerd.service
-After=network-online.target firewalld.service
+After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
 Requires=docker.socket
 


### PR DESCRIPTION
Backport of https://github.com/docker/docker-ce-packaging/pull/290 for the 18.09 branch. Relates to / addresses https://github.com/docker/for-linux/issues/556


ping @corbin-coleman @seemethere 


(but still in favor of setting the `--containerd` option 😉 )