### PR TITLE
[master] Add back requirements that were removed in the migration

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,7 +19,13 @@ Requires: container-selinux >= 2.9
 Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
+Requires: libcgroup
 Requires: containerd.io
+Requires: tar
+Requires: xz
+
+# Resolves: rhbz#1165615
+Requires: device-mapper-libs >= 1.02.90-1
 
 BuildRequires: which
 BuildRequires: make


### PR DESCRIPTION
forward-port https://github.com/docker/docker-ce-packaging/pull/267 to master.

Some conflicts, but trivial to address

```patch
diff --cc rpm/SPECS/docker-ce.spec
index e35faa9,23fabe8..0000000
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@@ -16,10 -15,16 +16,20 @@@ Packager: Docker <support@docker.com
  
  Requires: docker-ce-cli
  Requires: container-selinux >= 2.9
 +Requires: libseccomp >= 2.3
  Requires: systemd-units
  Requires: iptables
++<<<<<<< HEAD
++=======
+ Requires: libcgroup
+ # Should be required as well by docker-ce-cli but let's just be thorough
++>>>>>>> a6ff66f... Add back requirements that were removed in the migration
  Requires: containerd.io
+ Requires: tar
+ Requires: xz
+ 
+ # Resolves: rhbz#1165615
+ Requires: device-mapper-libs >= 1.02.90-1
  
  BuildRequires: which
  BuildRequires: make
```


During the migration to "image based builds", some dependencies
were removed.

This patch brings back those dependencies.
