### PR TITLE
[18.09 backport] systemd: set --containerd socket patch to prevent race-condition

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -11,7 +11,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd://
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2


### PR DESCRIPTION
backport of #297 for 18.09

fixes https://github.com/docker/for-linux/issues/556 for 18.09


containerd is now running as a separate service, and should no longer be started as a managed child-process of dockerd.

The dockerd service already specifies that it should be started `After` the containerd.service, but there is still a race condition, where containerd is started, but its socket is not yet created.

In that situation, `dockerd` detects that the containerd socket is missing, and will start a new instance of containerd (as a managed child-process), which causes live-restore to fail.

This patch explicitly sets the `--containerd` daemon option. If this option is set, `dockerd` will not start a new instance of containerd.
