### PR TITLE
[master] [TAR-480] Add Fedora 30, make fedora builds more generic

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -68,25 +68,9 @@ fedora: fedora-28 fedora-27 fedora-26 ## build all fedora rpm packages
 .PHONY: centos
 centos: centos-7 ## build all centos rpm packages
 
-.PHONY: fedora-29
-fedora-29: ## build fedora-29 rpm packages
-fedora-29: $(SOURCES)
-	$(CHOWN) -R root:root rpmbuild
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-
-.PHONY: fedora-28
-fedora-28: ## build fedora-28 rpm packages
-fedora-28: $(SOURCES)
-	$(CHOWN) -R root:root rpmbuild
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-
-.PHONY: fedora-27
-fedora-27: ## build fedora-27 rpm packages
-fedora-27: $(SOURCES)
+.PHONY: fedora-%
+fedora-%: ## build fedora rpm packages
+fedora-%: $(SOURCES)
 	$(CHOWN) -R root:root rpmbuild
 	$(BUILD)
 	$(RUN)

--- a/rpm/fedora-30/Dockerfile
+++ b/rpm/fedora-30/Dockerfile
@@ -1,0 +1,23 @@
+ARG GO_IMAGE
+ARG ENGINE_IMAGE
+ARG BUILD_IMAGE=fedora:30
+FROM ${GO_IMAGE} as golang
+FROM ${ENGINE_IMAGE} as engine
+
+FROM ${BUILD_IMAGE}
+ENV DISTRO fedora
+ENV SUITE 30
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --from=golang /usr/local/go /usr/local/go/
+COPY --from=engine /bin/dockerd /sources/
+COPY --from=engine /bin/docker-proxy /sources/
+COPY --from=engine /bin/docker-init /sources/
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
Relates to https://github.com/docker/for-linux/issues/600

From the original issue (cc @jhford)
> Fedora has officially branched Version 30 today and might have a beta release on March 26.
> 
> I'm filing this issue to hopefully put this task on the radar, so that there might be a repository set up in time for the Fedora 30 release on April30
> 
> Release Schedule: https://fedoraproject.org/wiki/Releases/30/Schedule#Key_Milestones

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>