### PR TITLE
[TAR-352] Add initial basis for cli-plugins (docker/app)

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -35,7 +35,7 @@ RUN=docker run --rm -i \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
 
-SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json plugin-installers.tgz
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
 .PHONY: help
@@ -119,3 +119,10 @@ sources/engine-image:
 	mkdir -p $(@D)
 	$(MAKE) -C ../image image-linux
 	cp ../image/image-linux $@
+
+sources/plugin-installers.tgz: $(wildcard ../plugins/*)
+	docker run --rm -i -w /v \
+		-v $(shell readlink -e ../plugins):/plugins \
+		-v $(CURDIR)/sources:/v \
+		alpine \
+		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -10,6 +10,12 @@ override_dh_gencontrol:
 override_dh_auto_build:
 	cd /go/src/github.com/docker/cli && \
 		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(DOCKER_GITCOMMIT) dynbinary manpages
+	# Make sure to set LDFLAGS="" since, dpkg-buildflags sets it to some weird values
+	set -e;cd /sources && \
+		tar xzf plugin-installers.tgz; \
+		for installer in plugins/*.installer; do \
+			LDFLAGS='' bash $${installer} build; \
+		done
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't
@@ -19,6 +25,13 @@ override_dh_auto_install:
 	install -D -m 0644 /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -m 0644 /go/src/github.com/docker/cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 	install -D -m 0755 /go/src/github.com/docker/cli/build/docker debian/docker-ce-cli/usr/bin/docker
+	set -e;cd /sources && \
+		tar xzf plugin-installers.tgz; \
+		for installer in plugins/*.installer; do \
+			DESTDIR=/root/build-deb/debian/docker-ce-cli \
+			PREFIX=/usr/libexec/docker/cli-plugins \
+				bash $${installer} install_plugin; \
+		done
 	# docker-ce install
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
 	install -D -m 0644 /sources/docker.socket debian/docker-ce/lib/systemd/system/docker.socket

--- a/plugins/.common
+++ b/plugins/.common
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+DESTDIR=${DESTDIR:-}
+PREFIX=${PREFIX:-/usr/local}
+
+add_github_ssh_host() {
+    # You're not able to clone from github unless you add to known_hosts
+    if ! grep ~/.ssh/known_hosts "github.com" >/dev/null 2>/dev/null; then
+        mkdir -p ~/.ssh
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+    fi
+}
+
+install_binary() {
+    for binary in "$@"; do
+        mkdir -p "${DESTDIR}${PREFIX}"
+        install -p -m 755 "${binary}" "${DESTDIR}${PREFIX}"
+    done
+}
+
+build_or_install() {
+    case $1 in
+        build)
+            build
+            ;;
+        install_plugin)
+            install_plugin
+            ;;
+        *)
+            echo "Are you sure that's a command? o.O"
+            exit 1
+            ;;
+    esac
+}

--- a/plugins/app.installer
+++ b/plugins/app.installer
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "$(dirname "$0")/.common"
+
+GOPATH=$(go env GOPATH)
+REPO=https://github.com/docker/app.git
+COMMIT=207a9459e78dcccbf3eb7e8ca5763835b526478d
+DEST=${GOPATH}/src/github.com/docker/app
+
+build() {
+    if [ ! -d "${DEST}" ]; then
+        git clone "${REPO}" "${DEST}"
+    fi
+    (
+        cd "${DEST}"
+        git fetch --all
+        git checkout -q "${COMMIT}"
+        # There's no real versions yet, but this'll just leave it blank
+        make bin/docker-app
+    )
+}
+
+install_plugin() {
+    (
+        cd "${DEST}"
+        install_binary bin/docker-app
+    )
+}
+
+build_or_install "$@"

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -40,7 +40,7 @@ RPMBUILD_FLAGS?=-ba\
 	$(SPECS)
 RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json
+SOURCE_FILES=engine-image cli.tgz docker.service docker.socket distribution_based_engine.json plugin-installers.tgz
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
 
@@ -109,3 +109,10 @@ rpmbuild/SOURCES/distribution_based_engine.json: rpmbuild/SOURCES/engine-image
 	mkdir -p $(@D)
 	docker inspect "$(shell cat $<)" \
 		--format '{{index .Config.Labels "com.docker.distribution_based_engine" }}' > $@
+
+rpmbuild/SOURCES/plugin-installers.tgz: $(wildcard ../plugins/*)
+	docker run --rm -i -w /v \
+		-v $(shell readlink -e ../plugins):/plugins \
+		-v $(CURDIR)/rpmbuild/SOURCES:/v \
+		alpine \
+		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins


### PR DESCRIPTION
Adds the base functionality for providing cli-plugins in our packaging.

#### Adding a plugin

Adding a plugin is pretty straightforward:
1. Create a bash script in the root directory `plugins` with the extension `.installer`
2. Have the `.installer` script implement a `build` and `install_plugin` function (those are pretty self explanatory)
3. Have the `.installer` script `source "$(dirname "$0")/.common` at the beginning of the script
4. Have the `.installer` script call `build_or_install` at the end of its script

#### Dependencies
- [x] https://github.com/docker/app/pull/469