### PR TITLE
[19.03] Add PLATFORM to deb and rpm builds

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -32,6 +32,7 @@ RUN=docker run --rm -i \
 	-e DEB_VERSION=$(word 1, $(DEB_VERSION)) \
 	-e VERSION=$(word 2, $(DEB_VERSION)) \
 	-e DOCKER_GITCOMMIT=$(GITCOMMIT) \
+	-e PLATFORM \
 	-v $(CURDIR)/debbuild/$@:/build \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -28,7 +28,8 @@ BUILD?=docker build \
 
 SPEC_FILES?=docker-ce.spec docker-ce-cli.spec
 SPECS?=$(addprefix SPECS/, $(SPEC_FILES))
-RPMBUILD=docker run --privileged --rm -i\
+RPMBUILD=docker run --privileged --rm -i \
+	-e PLATFORM \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES \
 	-v $(CURDIR)/rpmbuild/RPMS:/root/rpmbuild/RPMS \
 	-v $(CURDIR)/rpmbuild/SRPMS:/root/rpmbuild/SRPMS


### PR DESCRIPTION
backport of #318 for 19.03.x
 Add PLATFORM to deb and rpm builds