### PR TITLE
[TAR-698] Add buildx as a plugin we build

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+source "$(dirname "$0")/.common"
+PKG=github.com/docker/buildx
+GOPATH=$(go env GOPATH)
+REPO=https://${PKG}.git
+COMMIT=v0.2.0
+DEST=${GOPATH}/src/${PKG}
+
+build() {
+    if [ ! -d "${DEST}" ]; then
+        git clone "${REPO}" "${DEST}"
+    fi
+    (
+        cd "${DEST}"
+        git fetch --all
+        git checkout -q "${COMMIT}"
+        local LDFLAGS
+        # TODO: unmark `-tp` when no longer a technical preview
+        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-tp -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
+        set -x
+        go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
+    )
+}
+
+install_plugin() {
+    (
+        cd "${DEST}"
+        install_binary bin/docker-buildx
+    )
+}
+
+build_or_install "$@"


### PR DESCRIPTION
~Depends on https://github.com/tonistiigi/buildx/pull/40~

To make sure we can consume `buildx` as part of nightly builds