### PR TITLE
[19.03] Bump docker app to v0.8.0-beta2

### DIFF
--- a/plugins/app.installer
+++ b/plugins/app.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 
 GOPATH=$(go env GOPATH)
 REPO=https://github.com/docker/app.git
-COMMIT=v0.8.0-beta1
+COMMIT=v0.8.0-beta2
 DEST=${GOPATH}/src/github.com/docker/app
 
 build() {


### PR DESCRIPTION
backport #327
```
$ git cherry-pick -s -x 5134bad
[app dd85ec9] Bump docker app to v0.8.0-beta2
 Author: Silvin Lubecki <silvin.lubecki@docker.com>
 Date: Fri Apr 26 14:27:17 2019 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
```