### PR TITLE
docker-ce-cli lacks dependency to groupadd

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -15,6 +15,7 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
+Requires: /usr/sbin/groupadd
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -15,6 +15,7 @@ URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
+Requires: /usr/sbin/groupadd
 Requires: docker-ce-cli
 Requires: container-selinux >= 2.9
 Requires: libseccomp >= 2.3


### PR DESCRIPTION
I'm trying to integrate docker-ce directly to a customized fedora live-image.
Currently it fails as shadow-utils (which provides groupadd) gets installed after docker-ce-cli.

BTW:
This might have to be fixed for deb packages too.
I've noticed that in deb the docker-ce creates the docker group.
Wouldn't that be correct for rpm too?