### PR TITLE
[19.03 backport] docker-ce.spec: bump container-selinux req

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -16,7 +16,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
-Requires: container-selinux >= 2.9
+Requires: container-selinux >= 2.95
 Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables


### PR DESCRIPTION
Recent runc now requires container-selinux >= 2.95 for write access
to /proc/self/attr/keycreate. In case of older version, the error is:

> docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "process_linux.go:430: container init caused \"write /proc/self/attr/keycreate: permission denied\"": unknown.

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit 9606895c37f68b06fc88a44801f5e7f49f927857)