### PR TITLE
TAR-875 Fix man-pages showing "minimized" message

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -63,5 +63,13 @@ override_dh_install:
 	# TODO Can we do this from within our container?
 	dh_apparmor --profile-name=docker-ce -pdocker-ce
 
+override_dh_installman:
+	# based on ubuntu's "unminimize" script
+	if [ "$$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+		rm -f /usr/bin/man \
+		&& dpkg-divert --quiet --remove --rename /usr/bin/man; \
+	fi
+	dh_installman
+
 %:
 	dh $@ --with=bash-completion $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo --with=systemd)


### PR DESCRIPTION
The dh_installman script calls "man" and captures its output to convert manpages
to utf8:

https://github.com/Debian/debhelper/blob/8523120dccaf5666425109da228b7e1778f15e8b/dh_installman#L298-L316

however, on minimized Ubuntu systems, man is overridden by a script that outputs
a warning message ("This  system  has been minimized by removing packages and
content ..").

As a result, all man-pages were be overwritten by that message.

This patch restores the actual `man` command before running `dh_installman` to
work around this issue.

addresses docker/for-linux#639
