### PR TITLE
[19.03 backport] Sync RPM Spec with downstream EE packaging

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -18,7 +18,7 @@ Packager: Docker <support@docker.com>
 Requires: docker-ce-cli
 Requires: container-selinux >= 2.9
 Requires: libseccomp >= 2.3
-Requires: systemd-units
+Requires: systemd
 Requires: iptables
 Requires: libcgroup
 Requires: containerd.io
@@ -60,7 +60,7 @@ Obsoletes: docker-engine-selinux
 Obsoletes: docker-engine
 
 %description
-Docker is is a product for you to build, ship and run any application as a
+Docker is a product for you to build, ship and run any application as a
 lightweight container.
 
 Docker containers are both hardware-agnostic and platform-agnostic. This means
@@ -74,6 +74,7 @@ depending on a particular stack or provider.
 %setup -q -c -n src -a 0
 
 %build
+
 export DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/docker
 ln -s /root/rpmbuild/BUILD/src/engine /go/src/github.com/docker/docker
@@ -132,7 +133,6 @@ fi
 if ! getent group docker > /dev/null; then
     groupadd --system docker
 fi
-
 
 %preun
 %systemd_preun docker

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -114,41 +114,16 @@ install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_
 /%{_unitdir}/docker.socket
 /var/lib/docker-engine/distribution_based_engine-ce.json
 
-%pre
-if [ $1 -gt 0 ] ; then
-    # package upgrade scenario, before new files are installed
-
-    # clear any old state
-    rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-
-    # check if docker service is running
-    if systemctl is-active docker > /dev/null 2>&1; then
-        systemctl stop docker > /dev/null 2>&1 || :
-        touch %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-    fi
-fi
-
 %post
-%systemd_post docker
+%systemd_post docker.service
 if ! getent group docker > /dev/null; then
     groupadd --system docker
 fi
 
 %preun
-%systemd_preun docker
+%systemd_preun docker.service
 
 %postun
-%systemd_postun_with_restart docker
-
-%posttrans
-if [ $1 -ge 0 ] ; then
-    # package upgrade scenario, after new files are installed
-
-    # check if docker was running before upgrade
-    if [ -f %{_localstatedir}/lib/rpm-state/docker-is-active ]; then
-        systemctl start docker > /dev/null 2>&1 || :
-        rm -f %{_localstatedir}/lib/rpm-state/docker-is-active > /dev/null 2>&1 || :
-    fi
-fi
+%systemd_postun_with_restart docker.service
 
 %changelog


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/347 for 19.03


This takes some of the changes from the downstream EE packaging scripts to bring the specs more in line.

- systemd-units -> systemd (taken from `8bb1f0a7a395dfd979cd410b26ef47e55433de32`)
- some wording changes (taken from `a8c522a7c22c34dc354e91941377a4aadc3ddc4c`)

Remove the pre and posttrans, they weren't useful

On some distros we were encountering errors where `$1` was not being populated
for the 'pre' and 'posttrans' rpm macros, upon closer inspection it
isn't exactly clear why the pre and posttrans macro scripts were exactly
useful since the `%systemd_postun_with_restart` does exactly what those
scripts were doing.

I've tidied up the systemd macros to use `docker.service` instead of
`docker` which seems to function as we'd expect.

taken from downstream commit `62d8413b550659a0b5318346ee2e3d7e4a50bfe1`

