### PR TITLE
[19.03 backport] require container-selinux >= 2.74

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -16,7 +16,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
-Requires: container-selinux >= 2.9
+Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/345 for 19.03

version 2.9 is really old; this sets the same minimal version
as is used for the containerd.io package
