### PR TITLE
[19.03 port] Bump containerd.io dep >= 1.2.2-3 (CVE-2019-5736)

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,7 +27,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: docker-ce-cli, containerd.io, iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
+Depends: docker-ce-cli, containerd.io (>= 1.2.2-3), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
 Recommends: aufs-tools,
             ca-certificates,
             cgroupfs-mount | cgroup-lite,

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -21,7 +21,7 @@ Requires: libseccomp >= 2.3
 Requires: systemd-units
 Requires: iptables
 Requires: libcgroup
-Requires: containerd.io
+Requires: containerd.io >= 1.2.2-3
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
forward-port https://github.com/docker/docker-ce-packaging/commit/06b649e2b07f74a94f3dbbcb233e13177a76a929 to 19.03 (was only in the 18.09 branch)