### PR TITLE
[18.09 backport] Remove the pkcs11 tag, was a holdover from cli

### DIFF
--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/deb/ubuntu-cosmic/Dockerfile
+++ b/deb/ubuntu-cosmic/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ARG GO_VERSION
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-ENV DOCKER_BUILDTAGS apparmor pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
 ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -10,7 +10,7 @@ ENV SUITE 7
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS

--- a/rpm/fedora-27/Dockerfile
+++ b/rpm/fedora-27/Dockerfile
@@ -10,7 +10,7 @@ ENV SUITE 27
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS

--- a/rpm/fedora-28/Dockerfile
+++ b/rpm/fedora-28/Dockerfile
@@ -10,7 +10,7 @@ ENV SUITE 28
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS

--- a/rpm/fedora-29/Dockerfile
+++ b/rpm/fedora-29/Dockerfile
@@ -10,7 +10,7 @@ ENV SUITE 29
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
-ENV DOCKER_BUILDTAGS pkcs11 seccomp selinux
+ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/316 for 18.09

cherry-pick wasn't clean because ubuntu disco, and fedora 30 is not in the 18.09 branch;

```
	deleted by us:   deb/ubuntu-disco/Dockerfile
	deleted by us:   rpm/fedora-30/Dockerfile
``` 