### PR TITLE
Assorted improvements to Makefiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ test_steps = [
 				sh("git -C cli checkout $branch")
 				sh('git clone https://github.com/docker/engine.git')
 				sh("git -C engine checkout $branch")
-				sh('make VERSION=0.0.1-dev DOCKER_BUILD_PKGS=ubuntu-xenial ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli deb')
+				sh('make -C deb VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial')
 			}
 		}
 	},
@@ -41,7 +41,7 @@ test_steps = [
 				sh("git -C cli checkout $branch")
 				sh('git clone https://github.com/docker/engine.git')
 				sh("git -C engine checkout $branch")
-				sh('make VERSION=0.0.1-dev DOCKER_BUILD_PKGS=centos-7 ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli rpm')
+				sh('make -C rpm VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7')
 			}
 		}
 	},

--- a/Makefile
+++ b/Makefile
@@ -36,18 +36,12 @@ clean: clean-image ## remove build artifacts
 	$(MAKE) -C static clean
 
 .PHONY: rpm
-rpm: DOCKER_BUILD_PKGS:=$(shell find rpm -type d | grep ".*-.*" | sed 's/^rpm\///')
 rpm: ## build rpm packages
-	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) $${p}; \
-	done
+	$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) rpm
 
 .PHONY: deb
-deb: DOCKER_BUILD_PKGS:=$(shell find deb -type d | grep ".*-.*" | sed 's/^deb\///')
 deb: ## build deb packages
-	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) $${p}; \
-	done
+	$(MAKE) -C $@ VERSION=$(VERSION) ENGINE_DIR=$(ENGINE_DIR) CLI_DIR=$(CLI_DIR) GO_VERSION=$(GO_VERSION) deb
 
 .PHONY: static
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -38,6 +38,11 @@ RUN=docker run --rm -i \
 SOURCE_FILES=engine-image cli.tgz engine.tgz docker.service docker.socket distribution_based_engine.json plugin-installers.tgz
 SOURCES=$(addprefix sources/, $(SOURCE_FILES))
 
+DEBIAN_VERSIONS := debian-stretch debian-buster
+UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco
+RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster
+DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
+
 .PHONY: help
 help: ## show make targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -55,34 +60,19 @@ engine-$(ARCH).tar:
 	docker save -o $@ $$(cat ../image/image-linux)
 
 .PHONY: deb
-deb: ubuntu debian raspbian ## build all deb packages
+deb: ubuntu debian ## build all deb packages except for raspbian
 
 .PHONY: ubuntu
-ubuntu: ubuntu-bionic ubuntu-xenial ## build all ubuntu deb packages
+ubuntu: $(UBUNTU_VERSIONS) ## build all ubuntu deb packages
 
 .PHONY: debian
-debian: debian-stretch debian-buster ## build all debian deb packages
+debian: $(DEBIAN_VERSIONS) ## build all debian deb packages
 
 .PHONY: raspbian
-raspbian: raspbian-stretch raspbian-buster ## build all raspbian deb packages
+raspbian: $(RASPBIAN_VERSIONS) ## build all raspbian deb packages
 
-.PHONY: ubuntu-%
-## build ubuntu deb packages
-ubuntu-%: $(SOURCES)
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
-
-.PHONY: debian-%
-## build debian deb packages
-debian-%: $(SOURCES)
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
-
-.PHONY: raspbian-%
-## build raspbian deb packages
-raspbian-%: $(SOURCES)
+.PHONY: $(DISTROS)
+$(DISTROS): $(SOURCES)
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -73,6 +73,7 @@ raspbian: $(RASPBIAN_VERSIONS) ## build all raspbian deb packages
 
 .PHONY: $(DISTROS)
 $(DISTROS): $(SOURCES)
+	@echo "== Building packages for $@ =="
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -42,6 +42,9 @@ RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 SOURCE_FILES=engine-image engine.tgz cli.tgz docker.service docker.socket distribution_based_engine.json plugin-installers.tgz
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
+FEDORA_RELEASES := fedora-31 fedora-30 fedora-29 fedora-28
+CENTOS_RELEASES := centos-7
+
 .PHONY: help
 help: ## show make targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -61,22 +64,13 @@ clean: ## remove build artifacts
 rpm: fedora centos ## build all rpm packages
 
 .PHONY: fedora
-fedora: fedora-31 fedora-30 fedora-29 fedora-28 ## build all fedora rpm packages
+fedora: $(FEDORA_RELEASES) ## build all fedora rpm packages
 
 .PHONY: centos
-centos: centos-7 ## build all centos rpm packages
+centos: $(CENTOS_RELEASES) ## build all centos rpm packages
 
-.PHONY: fedora-%
-fedora-%: ## build fedora rpm packages
-fedora-%: $(SOURCES)
-	$(CHOWN) -R root:root rpmbuild
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
-
-.PHONY: centos-7
-centos-7: ## build centos-7 rpm packages
-centos-7: $(SOURCES)
+.PHONY: $(FEDORA_RELEASES) $(CENTOS_RELEASES)
+$(FEDORA_RELEASES) $(CENTOS_RELEASES): $(SOURCES)
 	$(CHOWN) -R root:root rpmbuild
 	$(BUILD)
 	$(RUN)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -71,6 +71,7 @@ centos: $(CENTOS_RELEASES) ## build all centos rpm packages
 
 .PHONY: $(FEDORA_RELEASES) $(CENTOS_RELEASES)
 $(FEDORA_RELEASES) $(CENTOS_RELEASES): $(SOURCES)
+	@echo "== Building packages for $@ =="
 	$(CHOWN) -R root:root rpmbuild
 	$(BUILD)
 	$(RUN)


### PR DESCRIPTION
## Simplify and fix rpm/Makefile and deb/Makefile

1. A symbol `%` is not working as expected in `PHONY` targets, so
e.g. `fedora-30` or `ubuntu-cosmic` were not being rebuild each time,
because `fedora-30` and `ubuntu-cosmic` directories exists.
The fix is to explicitly mark every distro target as phony.
This also has the nice side effect of bash completion
working as it should!
    
2. Remove code duplication for making packages for different distros.

3. Add missing ubuntu releases (cosmic and disco).

## Makefile: rely on targets in deb/rpm
    
Instead of dynamically getting list of distros to build for,
rely on the corresponding targets in sub-Makefiles. This also
ensures that deb/Makefile and rpm/Makefile will have up-to-date
list of distros included.
    
This also fixes the following bug:
    
> $ make deb
> for p in raspbian-stretch ubuntu-bionic ubuntu-disco ubuntu-xenial debbuild/ubuntu-disco ubuntu-cosmic debian-buster debian-stretch; do \
> ...
    
As you can see, `debbuild/ubuntu-disco` should not be included but it
is. Could be prevented by using `-maxdepth 1` argument to `find`.
    
While at it, amend the sub-Makefiles to print out the distro
that we build for.
 