### PR TITLE
[19.03 backport] TAR-875 Fix man-pages showing "minimized" message

### DIFF
--- a/deb/ubuntu-cosmic/Dockerfile
+++ b/deb/ubuntu-cosmic/Dockerfile
@@ -4,6 +4,12 @@ FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}
 
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ARG GO_VERSION

--- a/deb/ubuntu-disco/Dockerfile
+++ b/deb/ubuntu-disco/Dockerfile
@@ -4,6 +4,12 @@ FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}
 
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ARG GO_VERSION


### PR DESCRIPTION
Backport of #350 to 19.03. Clean cherry-pick, no issues.

Original description follows.

----

The dh_installman script calls "man" and captures its output to convert manpages
to utf8:

https://github.com/Debian/debhelper/blob/8523120dccaf5666425109da228b7e1778f15e8b/dh_installman#L298-L316

however, on minimized Ubuntu systems, man is overridden by a script that outputs
a warning message ("This  system  has been minimized by removing packages and
content ..").

As a result, all man-pages were be overwritten by that message.

This patch restores the actual `man` command before building to
work around this issue.

addresses docker/for-linux#639

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit e52fa49844d16d16b771fdbf59cb7434bbb5536e)