### PR TITLE
[19.03] switch to balenalib/rpi-raspbian because resin/rpi-raspbian is deprecated

### DIFF
--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:stretch
 FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}


### PR DESCRIPTION
equivalent of https://github.com/docker/docker-ce-packaging/pull/356 for 19.03