### PR TITLE
[19.03 backport] Add Raspbian buster

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -61,45 +61,31 @@ deb: ubuntu debian raspbian ## build all deb packages
 ubuntu: ubuntu-bionic ubuntu-xenial ## build all ubuntu deb packages
 
 .PHONY: debian
-debian: debian-stretch ## build all debian deb packages
+debian: debian-stretch debian-buster ## build all debian deb packages
 
 .PHONY: raspbian
-raspbian: raspbian-stretch ## build all raspbian deb packages
+raspbian: raspbian-stretch raspbian-buster ## build all raspbian deb packages
 
 .PHONY: ubuntu-%
-ubuntu-%: ## build ubuntu deb packages
+## build ubuntu deb packages
 ubuntu-%: $(SOURCES)
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
-.PHONY: debian-buster
-debian-buster: ## build debian buster deb packages
-debian-buster: $(SOURCES)
+.PHONY: debian-%
+## build debian deb packages
+debian-%: $(SOURCES)
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
-.PHONY: debian-stretch
-debian-stretch: ## build debian stretch deb packages
-debian-stretch: $(SOURCES)
+.PHONY: raspbian-%
+## build raspbian deb packages
+raspbian-%: $(SOURCES)
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
-
-.PHONY: raspbian-stretch
-raspbian-stretch: ## build raspbian stretch deb packages
-raspbian-stretch: $(SOURCES)
-	$(BUILD)
-	$(RUN)
-	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
-
-.PHONY: raspbian-buster
-raspbian-buster: ## build raspbian buster deb packages
-raspbian-buster: $(SOURCES)
-        $(BUILD)
-        $(RUN)
-        $(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
 sources/engine.tgz:
 	mkdir -p $(@D)

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -94,6 +94,13 @@ raspbian-stretch: $(SOURCES)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
 
+.PHONY: raspbian-buster
+raspbian-buster: ## build raspbian buster deb packages
+raspbian-buster: $(SOURCES)
+        $(BUILD)
+        $(RUN)
+        $(CHOWN) -R $(shell id -u):$(shell id -g) debbuild/$@
+
 sources/engine.tgz:
 	mkdir -p $(@D)
 	docker run --rm -i -w /v \

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:buster
 FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,0 +1,29 @@
+ARG GO_IMAGE
+ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
+FROM ${GO_IMAGE} as golang
+
+FROM ${BUILD_IMAGE}
+
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ARG GO_VERSION
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+
+ENV DISTRO raspbian
+ENV SUITE buster
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:stretch
 FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=balenalib/rpi-raspbian:stretch
+ARG BUILD_IMAGE=resin/rpi-raspbian:stretch
 FROM ${GO_IMAGE} as golang
 
 FROM ${BUILD_IMAGE}


### PR DESCRIPTION
Backport of;

- revert https://github.com/docker/docker-ce-packaging/pull/360 ([19.03] switch to balenalib/rpi-raspbian because resin/rpi-raspbian is deprecated) to get a clean cherry-pick
- https://github.com/docker/docker-ce-packaging/pull/349 Add Raspbian buster
- https://github.com/docker/docker-ce-packaging/pull/356 switched docker build image to balenalib/rpi-raspbian