### PR TITLE
[master] Fix for bug #678: Do not "Bind" docker "To" containerd.

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-BindsTo=containerd.service
 After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
-Requires=docker.socket
+Requires=docker.socket containerd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Because of the BindTo directive, Docker is permanently stopped by systemd when containerd is temporarily killed and restarted. https://github.com/docker/for-linux/issues/678