### PR TITLE
FIXED retrieving GO_VERSION from the CLI dir

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -7,8 +7,8 @@ CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 DEFAULT_PRODUCT_LICENSE?=Community Engine
-
-DOCKER_CLI_GOLANG_IMG=$(shell awk '$$1=="FROM"{split($$2,a,"-");print a[1];exit}' $(CLI_DIR)/dockerfiles/Dockerfile.dev)
+GO_VERSION=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/docker-ce/components/cli/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
+DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
The GOLANG _VERSION for the cli got changed based on this commit here: https://github.com/docker/cli/commit/8560f9e8cdada7a31145bea97c43c6cefb228dc1

This would cause a failure when building with these dockerfiles.  This change fixes and gets the correct golang version

Signed-off-by: zelahi <elahi.zuhayr@gmail.com>