### PR TITLE
static: only set GO_VERSION if it's empty

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -7,7 +7,7 @@ CHOWN=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 DEFAULT_PRODUCT_LICENSE?=Community Engine
-GO_VERSION=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
+GO_VERSION:=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
 DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
 
 .PHONY: help


### PR DESCRIPTION
I think this only has to be done if no `GO_VERSION` was passed / if the version is empty 