### PR TITLE
[19.03] [TAR-1031] FIX pathing issue with cli dir

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -8,7 +8,8 @@ HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 DEFAULT_PRODUCT_LICENSE?=Community Engine
 
-DOCKER_CLI_GOLANG_IMG=$(shell awk '$$1=="FROM"{split($$2,a,"-");print a[1];exit}' $(CLI_DIR)/dockerfiles/Dockerfile.dev)
+GO_VERSION=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
+DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
 
 .PHONY: help
 help: ## show make targets


### PR DESCRIPTION
After https://github.com/docker/cli/pull/2044 was merged in we need to change the logic that actually grabs the `GO_VERSION` from the cli repository.

Originally cherry picked from #368 

(cherry picked from commit 0df1091054f7749b6913d312b1d9a1fdefeddcc4)
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>