### PR TITLE
RPM spec: remove -ce suffix from distribution_based_engine JSON

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -104,7 +104,7 @@ install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}
 install -D -m 0644 %{_topdir}/SOURCES/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
 
 # install json for docker engine activate / upgrade
-install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_ROOT/var/lib/docker-engine/distribution_based_engine-ce.json
+install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_ROOT/var/lib/docker-engine/distribution_based_engine.json
 
 %files
 /%{_bindir}/dockerd
@@ -112,7 +112,7 @@ install -D -m 0644 %{_topdir}/SOURCES/distribution_based_engine.json $RPM_BUILD_
 /%{_bindir}/docker-init
 /%{_unitdir}/docker.service
 /%{_unitdir}/docker.socket
-/var/lib/docker-engine/distribution_based_engine-ce.json
+/var/lib/docker-engine/distribution_based_engine.json
 
 %post
 %systemd_post docker.service


### PR DESCRIPTION
Noticed this failing in internal e2e tests on CentOS:

```
sudo docker engine activate --license /tmp/docker.lic
unable to determine the installed engine version. Specify which engine image to update with --engine-image: open /var/lib/docker-engine/distribution_based_engine.json: no such file or directory
```

Looks lik 09b3ac888d8d6ab625e56a458f6bd6f72b1ba0c2 (https://github.com/docker/docker-ce-packaging/pull/244) changed the name of this file from `distribution_based_engine-ce.json` to `distribution_based_engine.json` (without `-ce` suffix) for the `.deb` packages, but did not update the RPM packages accordingly.
