### PR TITLE
Pin buildx plugin to v0.3.0, and allow overriding

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-COMMIT=master
+: "${BUILDX_COMMIT=v0.3.0}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {
@@ -16,7 +16,7 @@ build() {
     (
         cd "${DEST}"
         git fetch --all
-        git checkout -q "${COMMIT}"
+        git checkout -q "${BUILDX_COMMIT}"
         local LDFLAGS
         # TODO: unmark `-tp` when no longer a technical preview
         LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-tp-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG} -X main.experimental=1"


### PR DESCRIPTION
Commit 9a5aabdaff9061343a6a28e809c14164dd04f39f (https://github.com/docker/docker-ce-packaging/pull/326) removed the fixed version for this plugin, and changed it to install from "master", which made the build non-reproducible.

This patch pins the plugin to a specific tag/release again, but allow overriding by setting the `BUILDX_COMMIT` env-var.


Note that there are changes in master that are not yet in the v0.3.0 release, so we may want to review those and check if a new release should be tagged; https://github.com/docker/buildx/compare/v0.3.0...master