### PR TITLE
[19.03 backport] plugins: pin buildx to v0.3.1

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.3.0}"
+: "${BUILDX_COMMIT=v0.3.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>
(cherry picked from commit 41dfc516cd50f570d6184aaad05b4efd4b04f4c3)
Signed-off-by: Tibor Vass <tibor@docker.com>

#387 is the master equivalent