### PR TITLE
Jenkinsfile: change to declarative with params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/cli
+/engine
 build
 debbuild
 rpmbuild

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,72 +1,123 @@
 #!groovy
-
-
-def genBranch(String arch) {
-	return [
-		"${arch}": { ->
-			stage("Build engine image on ${arch}") {
-				wrappedNode(label: "linux&&${arch}", cleanWorkspace: true) {
-					try {
-						checkout scm
-						sh("git clone https://github.com/docker/engine.git engine")
-						sh('make ENGINE_DIR=$(pwd)/engine image')
-					} finally {
-						sh('make ENGINE_DIR=$(pwd)/engine clean-image clean-engine')
+pipeline {
+	agent none
+	options {
+		buildDiscarder(logRotator(daysToKeepStr: '30'))
+		timeout(time: 30, unit: 'MINUTES')
+		timestamps()
+	}
+	parameters {
+		string(name: 'github_repo_engine', defaultValue: 'docker/engine', description: 'github org/repo of engine')
+		string(name: 'github_branch_engine', defaultValue: env.CHANGE_TARGET, description: 'github branch of engine')
+		string(name: 'github_repo_cli', defaultValue: 'docker/cli', description: 'github org/repo of cli')
+		string(name: 'github_branch_cli', defaultValue: env.CHANGE_TARGET, description: 'github branch of cli')
+		booleanParam(name: 'archive_packages', defaultValue: false, description: 'archive packages')
+	}
+	environment {
+		DOCKER_BUILDKIT = '1'
+	}
+	stages {
+		stage('Build') {
+			parallel {
+				stage('ubuntu-xenial') {
+					agent { label 'amd64 && ubuntu-1804 && overlay2' }
+					stages {
+						stage('create package') {
+							steps {
+								sh 'docker version'
+								sh 'docker info'
+								sh "git clone -b '$params.github_branch_engine' --depth 1 'https://github.com/$params.github_repo_engine' engine"
+								sh "git clone -b '$params.github_branch_cli' --depth 1 'https://github.com/$params.github_repo_cli' cli"
+								sh 'make -C deb VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial'
+							}
+						}
+						stage('archive package') {
+							when { expression { params.archive_packages } }
+							steps {
+								archiveArtifacts artifacts: 'deb/debbuild/ubuntu-xenial/docker-ce*.deb'
+							}
+						}
+					}
+					post {
+						cleanup {
+							sh 'docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace'
+							deleteDir()
+						}
 					}
 				}
+				stage('centos-7') {
+					agent { label 'amd64 && ubuntu-1804 && overlay2' }
+					stages {
+						stage('create package') {
+							steps {
+								sh 'docker version'
+								sh 'docker info'
+								sh "git clone -b '$params.github_branch_engine' --depth 1 'https://github.com/$params.github_repo_engine' engine"
+								sh "git clone -b '$params.github_branch_cli' --depth 1 'https://github.com/$params.github_repo_cli' cli"
+								sh 'make -C rpm VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7'
+							}
+						}
+						stage('archive package') {
+							when { expression { params.archive_packages } }
+							steps {
+								archiveArtifacts artifacts: 'rpm/rpmbuild/RPMS/x86_64/docker-ce*.rpm'
+							}
+						}
+					}
+					post {
+						cleanup {
+							sh 'docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace'
+							deleteDir()
+						}
+					}
+				}
+				stage('static') {
+					agent { label 'amd64 && ubuntu-1804 && overlay2' }
+					stages {
+						stage('create package') {
+							steps {
+								sh 'docker version'
+								sh 'docker info'
+								sh "git clone -b '$params.github_branch_engine' --depth 1 'https://github.com/$params.github_repo_engine' engine"
+								sh "git clone -b '$params.github_branch_cli' --depth 1 'https://github.com/$params.github_repo_cli' cli"
+								sh 'make VERSION=0.0.1-dev DOCKER_BUILD_PKGS=static-linux ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli static'
+							}
+						}
+						stage('archive package') {
+							when { expression { params.archive_packages } }
+							steps {
+								archiveArtifacts artifacts: 'static/build/linux/docker-*.tgz'
+							}
+						}
+					}
+					post {
+						cleanup {
+							sh 'docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace'
+							deleteDir()
+						}
+					}
+				}
+				stage('image') {
+					agent { label 'amd64 && ubuntu-1804 && overlay2' }
+					stages {
+						stage('create image') {
+							steps {
+								sh 'docker version'
+								sh 'docker info'
+								sh "git clone -b '$params.github_branch_engine' --depth 1 'https://github.com/$params.github_repo_engine' engine"
+								sh "git clone -b '$params.github_branch_cli' --depth 1 'https://github.com/$params.github_repo_cli' cli"
+								sh 'make ENGINE_DIR=$(pwd)/engine image clean-image clean-engine'
+							}
+						}
+					}
+					post {
+						cleanup {
+							sh 'docker run --rm -v "$WORKSPACE:/workspace" busybox chown -R "$(id -u):$(id -g)" /workspace'
+							deleteDir()
+						}
+					}
+				}
+			}
 		}
-	}]
+	}
 }
-
-def branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
-
-test_steps = [
-	'deb': { ->
-		stage('Ubuntu Xenial Debian Package') {
-			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
-				checkout scm
-				sh('git clone https://github.com/docker/cli.git')
-				sh("git -C cli checkout $branch")
-				sh('git clone https://github.com/docker/engine.git')
-				sh("git -C engine checkout $branch")
-				sh('make -C deb VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial')
-			}
-		}
-	},
-	'rpm': { ->
-		stage('Centos 7 RPM Package') {
-			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
-				checkout scm
-				sh('git clone https://github.com/docker/cli.git')
-				sh("git -C cli checkout $branch")
-				sh('git clone https://github.com/docker/engine.git')
-				sh("git -C engine checkout $branch")
-				sh('make -C rpm VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7')
-			}
-		}
-	},
-	'static': { ->
-		stage('Static Linux Binaries') {
-			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
-				checkout scm
-				sh('git clone https://github.com/docker/cli.git')
-				sh("git -C cli checkout $branch")
-				sh('git clone https://github.com/docker/engine.git')
-				sh("git -C engine checkout $branch")
-				sh('make VERSION=0.0.1-dev DOCKER_BUILD_PKGS=static-linux ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli static')
-			}
-		}
-	},
-]
-
-arches = [
-	"x86_64",
-	"aarch64",
-	"armhf"
-]
-
-arches.each {
-	test_steps << genBranch(it)
-}
-
-parallel(test_steps)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ pipeline {
 	}
 	parameters {
 		string(name: 'github_repo_engine', defaultValue: 'docker/engine', description: 'github org/repo of engine')
-		string(name: 'github_branch_engine', defaultValue: env.CHANGE_TARGET, description: 'github branch of engine')
+		string(name: 'github_branch_engine', defaultValue: env.CHANGE_TARGET ?: env.BRANCH_NAME, description: 'github branch of engine')
 		string(name: 'github_repo_cli', defaultValue: 'docker/cli', description: 'github org/repo of cli')
-		string(name: 'github_branch_cli', defaultValue: env.CHANGE_TARGET, description: 'github branch of cli')
+		string(name: 'github_branch_cli', defaultValue: env.CHANGE_TARGET ?: env.BRANCH_NAME, description: 'github branch of cli')
 		booleanParam(name: 'archive_packages', defaultValue: false, description: 'archive packages')
 	}
 	environment {


### PR DESCRIPTION
This PR changes the `Jenkinsfile` from scripted pipeline format to the new declarative pipeline format that is preferred by Jenkins. Notable changes:
* runs all the same package tests except the aarch64 and armhf
* parameters for specifying source to git clone the engine and cli
* parameter to archive packages after built, default: false