### PR TITLE
[master] Dockerfiles: re-use DISTRO, SUITE build-args where poss…

### DIFF
--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=debian:buster
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=debian
+ARG SUITE=buster
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO debian
-ENV SUITE buster
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=debian:stretch
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=debian
+ARG SUITE=stretch
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO debian
-ENV SUITE stretch
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=balenalib/rpi-raspbian:buster
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=raspbian
+ARG SUITE=buster
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO raspbian
-ENV SUITE buster
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=balenalib/rpi-raspbian:stretch
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=raspbian
+ARG SUITE=stretch
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO raspbian
-ENV SUITE stretch
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=ubuntu:bionic
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=ubuntu
+ARG SUITE=bionic
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO ubuntu
-ENV SUITE bionic
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-cosmic/Dockerfile
+++ b/deb/ubuntu-cosmic/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=ubuntu:cosmic
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=ubuntu
+ARG SUITE=cosmic
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -24,9 +27,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO ubuntu
-ENV SUITE cosmic
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-disco/Dockerfile
+++ b/deb/ubuntu-disco/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=ubuntu:disco
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=ubuntu
+ARG SUITE=disco
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -24,9 +27,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO ubuntu
-ENV SUITE disco
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-eoan/Dockerfile
+++ b/deb/ubuntu-eoan/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=ubuntu:eoan
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=ubuntu
+ARG SUITE=eoan
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -24,9 +27,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO ubuntu
-ENV SUITE eoan
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=ubuntu:xenial
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=ubuntu
+ARG SUITE=xenial
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
@@ -18,9 +21,10 @@ COPY ${COMMON_FILES} /root/build-deb/debian
 RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
-
-ENV DISTRO ubuntu
-ENV SUITE xenial
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=centos:7
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=centos
+ARG SUITE=7
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 ENV GOPROXY=direct
@@ -10,8 +13,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-ENV DISTRO centos
-ENV SUITE 7
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS
 # Overwrite repo that was failing on aarch64

--- a/rpm/fedora-29/Dockerfile
+++ b/rpm/fedora-29/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=fedora:29
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=fedora
+ARG SUITE=29
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 ENV GOPROXY=direct
@@ -10,8 +13,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-ENV DISTRO fedora
-ENV SUITE 29
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec

--- a/rpm/fedora-30/Dockerfile
+++ b/rpm/fedora-30/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=fedora:30
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=fedora
+ARG SUITE=30
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 ENV GOPROXY=direct
@@ -10,8 +13,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-ENV DISTRO fedora
-ENV SUITE 30
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec

--- a/rpm/fedora-31/Dockerfile
+++ b/rpm/fedora-31/Dockerfile
@@ -1,6 +1,9 @@
 ARG GO_IMAGE
-ARG BUILD_IMAGE=fedora:31
-FROM ${GO_IMAGE} as golang
+ARG DISTRO=fedora
+ARG SUITE=31
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 ENV GOPROXY=direct
@@ -10,8 +13,10 @@ ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS seccomp selinux
 ENV RUNC_BUILDTAGS seccomp selinux
-ENV DISTRO fedora
-ENV SUITE 31
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec


### PR DESCRIPTION
~based on top of https://github.com/docker/docker-ce-packaging/pull/399 - I'll rebase once that's merged.~ done

Re-use these build-args, so that there's only one place to set them per Dockerfile.

To verify this change:

Check if the env-vars are set on the image:

```bash
make UBUNTU_VERSIONS=ubuntu-bionic DEBIAN_VERSIONS="" RASPBIAN_VERSIONS="" CLI_DIR=$GOPATH/src/github.com/docker/cli ENGINE_DIR=$GOPATH/src/github.com/docker/docker deb

docker image inspect debbuild-ubuntu-bionic/x86_64 --format '{{json .Config.Env }}' | jq .
```

Which should output something like;

```json
[
  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/go/bin",
  "GOPROXY=direct",
  "GO111MODULE=off",
  "GOPATH=/go",
  "DOCKER_BUILDTAGS=apparmor seccomp selinux",
  "RUNC_BUILDTAGS=apparmor seccomp selinux",
  "DISTRO=ubuntu",
  "SUITE=bionic"
]
```