### PR TITLE
deb: Only recommend aufs-tools on amd64

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -28,7 +28,7 @@ Vcs-Git: git://github.com/docker/docker.git
 Package: docker-ce
 Architecture: linux-any
 Depends: docker-ce-cli, containerd.io (>= 1.2.2-3), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
-Recommends: aufs-tools,
+Recommends: aufs-tools [amd64],
             ca-certificates,
             cgroupfs-mount | cgroup-lite,
             git,


### PR DESCRIPTION
To remedy issues found for users not running `amd64`, ex: https://github.com/raspberrypi/linux/issues/3021