### PR TITLE
unir: Remove old maintainers, add new ones

### DIFF
--- a/.unir.yml
+++ b/.unir.yml
@@ -1,10 +1,9 @@
 # The list of people who can trigger an auto-merge with approvals
 whitelist:
-    - seemethere
     - andrewhsu
-    - jose-bigio
-    - corbin-coleman
+    - droopy4096
     - thaJeztah
+    - zelahi
 
 # At least 2 approvals are needed for auto-merging
 approvals_needed: 2


### PR DESCRIPTION
I'm leaving Docker Inc. so it'd probably be best to remove me from the
automerge capabilities. I've also taken the liberty to remove other old
maintainers.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>