### PR TITLE
Include plugins in static build

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -40,7 +40,7 @@ clean: ## remove build artifacts
 static: static-linux cross-mac cross-win cross-arm ## create all static packages
 
 .PHONY: static-linux
-static-linux: static-cli static-engine ## create tgz with linux x86_64 client and server
+static-linux: static-cli static-engine static-plugins ## create tgz with linux x86_64 client and server
 	mkdir -p build/linux/docker
 	cp $(CLI_DIR)/build/docker build/linux/docker/
 	for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
@@ -115,13 +115,23 @@ BUILD_PLUGIN_RUN_VARS = --rm \
 	-v "$(CURDIR)/../plugins":/plugins:ro \
 	-v "$(CURDIR)/scripts/build-cli-plugins":/build:ro
 
+.PHONY: cross-static-plugins
+cross-static-plugins: cross-static-plugins-amd64 cross-static-plugins-arm64
+
+.PHONY: cross-static-plugins-%
+cross-static-plugins-%: CLI_BUILD_DIR := linux
+cross-static-plugins-%:
+	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker/cli-plugins
+	GOOS=linux GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
+
 .PHONY: cross-mac-plugins
 cross-mac-plugins: cross-mac-plugins-amd64 cross-mac-plugins-arm64
 
 .PHONY: cross-mac-plugins-%
 cross-mac-plugins-%: CLI_BUILD_DIR := mac
 cross-mac-plugins-%:
-	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker
+	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker/cli-plugins
 	GOOS=darwin GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
 

--- a/static/Makefile
+++ b/static/Makefile
@@ -40,12 +40,13 @@ clean: ## remove build artifacts
 static: static-linux cross-mac cross-win cross-arm ## create all static packages
 
 .PHONY: static-linux
-static-linux: static-cli static-engine static-plugins ## create tgz with linux x86_64 client and server
+static-linux: static-cli static-engine cross-static-plugins-amd64 ## create tgz with linux x86_64 client and server
 	mkdir -p build/linux/docker
 	cp $(CLI_DIR)/build/docker build/linux/docker/
 	for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
 		cp -L $(ENGINE_DIR)/bundles/binary-daemon/$$f build/linux/docker/$$f; \
 	done
+	cp -r build/linux/amd64/docker/ build/linux/docker
 	tar -C build/linux -c -z -f build/linux/docker-$(GEN_STATIC_VER).tgz docker
 
 	# extra binaries for running rootless
@@ -87,8 +88,9 @@ cross-win: cross-win-engine cross-win-plugins
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 
 .PHONY: cross-arm
-cross-arm: cross-all-cli ## create tgz with linux armhf client only
+cross-arm: cross-all-cli cross-static-plugins-arm64 ## create tgz with linux armhf client only
 	mkdir -p build/arm/docker
+	cp -r build/linux/arm64/docker/cli-plugins build/arm/docker/
 	cp $(CLI_DIR)/build/docker-linux-arm build/arm/docker/docker
 	tar -C build/arm -c -z -f build/arm/docker-$(GEN_STATIC_VER).tgz docker
 


### PR DESCRIPTION
fixes https://github.com/docker/for-linux/issues/1066

Docker documentation states that plugins like buildx and app are included in distributions as of v19.13 (https://github.com/docker/docker-ce-packaging/pull/309).   However, this doesn't include the static builds. Downstream, people expect these to be included and may be confused to learn that the static build doesn't include them: https://github.com/docker-library/docker/issues/156. Including the plugins would make the builds more consistent.

This is my first contribution to the docker project, so apologies if this breaks anything 😅 