### PR TITLE
rpm: remove unused NEEDS_ARCH_SPECIFIC option

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -10,10 +10,6 @@ GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-stretch
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) $(VERSION))
 CHOWN=docker run --rm -i -v $(CURDIR):/v -w /v alpine chown
 
-DOCKERFILE=Dockerfile
-ifdef NEEDS_ARCH_SPECIFIC
-	DOCKERFILE=Dockerfile.$(ARCH)
-endif
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
 endif
@@ -21,7 +17,7 @@ BUILD?=docker build \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	-t rpmbuild-$@/$(ARCH) \
-	-f $@/$(DOCKERFILE) \
+	-f $@/Dockerfile \
 	.
 
 SPEC_FILES?=docker-ce.spec docker-ce-cli.spec


### PR DESCRIPTION
This was added in b72dc2edb8329151bfe2df6989fb329f41e720fb,
but appears to be unused.
