### PR TITLE
Remove more remnants from image-based engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 build
 debbuild
 rpmbuild
-tmp
-artifacts
 sources
 *.tar

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -54,10 +54,6 @@ clean: ## remove build artifacts
 	[ ! -d sources ] || $(CHOWN) -R $(shell id -u):$(shell id -g) sources
 	$(RM) -r sources
 
-engine-$(ARCH).tar:
-	$(MAKE) -C ../image image-linux
-	docker save -o $@ $$(cat ../image/image-linux)
-
 .PHONY: deb
 deb: ubuntu debian ## build all deb packages except for raspbian
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -54,12 +54,6 @@ help: ## show make targets
 clean: ## remove build artifacts
 	[ ! -d rpmbuild ] || $(CHOWN) -R $(shell id -u):$(shell id -g) rpmbuild
 	$(RM) -r rpmbuild/
-	[ ! -d artifacts ] || $(CHOWN) -R $(shell id -u):$(shell id -g) artifacts
-	$(RM) -r artifacts/
-	[ ! -d tmp ] || $(CHOWN) -R $(shell id -u):$(shell id -g) tmp
-	$(RM) -r tmp/
-	-docker rm docker2oci
-	$(MAKE) -C ../image clean
 
 .PHONY: rpm
 rpm: fedora centos ## build all rpm packages


### PR DESCRIPTION
follow- up to:

- https://github.com/docker/docker-ce-packaging/pull/411 Remove image-based build (for docker engine activate)
- https://github.com/docker/docker-ce-packaging/pull/420 Remove some remnants related to image-based builds

relates to https://github.com/docker/cli/pull/2207 
relates to https://github.com/docker/cli/issues/2213