### PR TITLE
Fix windows exe extension not added by docker/cli cross build scripts.

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -53,7 +53,7 @@ cross-mac: cross-all-cli cross-mac-plugins ## create tgz with darwin x86_64 clie
 .PHONY: cross-win
 cross-win: cross-all-cli cross-win-engine cross-win-plugins ## create zip file with windows x86_64 client and server
 	mkdir -p build/win/docker
-	cp $(CLI_DIR)/build/docker-windows-amd64 build/win/docker/docker.exe
+	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/windows/amd64/dockerd-$(STATIC_VERSION).exe build/win/docker/dockerd.exe
 	docker run --rm -v $(CURDIR)/build/win:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(STATIC_VERSION).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build


### PR DESCRIPTION
Related to https://github.com/docker/cli/pull/2362