### PR TITLE
deb: remove unused DOCKER_GOPATH variable

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 
 VERSION ?= $(shell cat engine/VERSION)
-DOCKER_GOPATH := /go/src/github.com/docker
 
 override_dh_gencontrol:
 	# if we're on Ubuntu, we need to Recommends: apparmor


### PR DESCRIPTION
This variable was added in 09b3ac888d8d6ab625e56a458f6bd6f72b1ba0c2 (https://github.com/docker/docker-ce-packaging/pull/314) but appears to be unused.
