### PR TITLE
Don't disable socket activation when stopping docker service

### DIFF
--- a/systemd/docker.socket
+++ b/systemd/docker.socket
@@ -1,6 +1,5 @@
 [Unit]
 Description=Docker Socket for the API
-PartOf=docker.service
 
 [Socket]
 ListenStream=/var/run/docker.sock


### PR DESCRIPTION
PartOf deactivates the socket whenever the service get deactivated.
The socket unit however should be active nevertheless, so that the
docker service can be started again through socket activation.

Based on the original patch in upstream moby/moby by Max Harmathy (https://github.com/moby/moby/pull/37470).

Fixes https://github.com/moby/moby/issues/37468
