### PR TITLE
Add Ubuntu 20.04 Focal Fossa

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is solely maintained by Docker, Inc.
 
 The scripts will build for this list of packages types:
 
+* DEB packages for Ubuntu 20.04 Focal
 * DEB packages for Ubuntu 19.10 Eoan
 * DEB packages for Ubuntu 19.04 Disco
 * DEB packages for Ubuntu 18.10 Cosmic

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -40,7 +40,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS := debian-stretch debian-buster
-UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan
+UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-cosmic ubuntu-disco ubuntu-eoan ubuntu-focal
 RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -13,6 +13,7 @@ RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
         dpkg-divert --quiet --remove --rename /usr/bin/man; \
     fi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -1,0 +1,40 @@
+ARG GO_IMAGE
+ARG DISTRO=ubuntu
+ARG SUITE=focal
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
Hi folks,

I am filing this pull request in an attempt to partly address https://github.com/docker/for-linux/issues/940 (for Ubuntu 20.04 Focal Fossa).

Not sure if this is the exact right way to do this, but thought I'd give it a shot.

Thanks.

P.S. I expect this would need to be added to a release branch, such as `19.03`, but I figure adding it to `master` is the proper first step.