### PR TITLE
rpm: various fixes and clean-ups

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -62,13 +62,13 @@ popd
 
 %install
 # install binary
-install -d $RPM_BUILD_ROOT%{_bindir}
-install -p -m 755 cli/build/docker $RPM_BUILD_ROOT%{_bindir}/docker
+install -d ${RPM_BUILD_ROOT}%{_bindir}
+install -p -m 755 cli/build/docker ${RPM_BUILD_ROOT}%{_bindir}/docker
 
 # install plugins
 pushd ${RPM_BUILD_DIR}/src/plugins
 for installer in *.installer; do
-    DESTDIR=$RPM_BUILD_ROOT \
+    DESTDIR=${RPM_BUILD_ROOT} \
         PREFIX=%{_libexecdir}/docker/cli-plugins \
         bash ${installer} install_plugin
 done

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -62,8 +62,8 @@ popd
 
 %install
 # install binary
-install -d $RPM_BUILD_ROOT/%{_bindir}
-install -p -m 755 cli/build/docker $RPM_BUILD_ROOT/%{_bindir}/docker
+install -d $RPM_BUILD_ROOT%{_bindir}
+install -p -m 755 cli/build/docker $RPM_BUILD_ROOT%{_bindir}/docker
 
 # install plugins
 pushd /root/rpmbuild/BUILD/src/plugins
@@ -84,11 +84,11 @@ install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/sh
 
 # install manpages
 install -d ${RPM_BUILD_ROOT}%{_mandir}/man1
-install -p -m 644 cli/man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1
+install -p -m 644 cli/man/man1/*.1 ${RPM_BUILD_ROOT}%{_mandir}/man1
 install -d ${RPM_BUILD_ROOT}%{_mandir}/man5
-install -p -m 644 cli/man/man5/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
+install -p -m 644 cli/man/man5/*.5 ${RPM_BUILD_ROOT}%{_mandir}/man5
 install -d ${RPM_BUILD_ROOT}%{_mandir}/man8
-install -p -m 644 cli/man/man8/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
+install -p -m 644 cli/man/man8/*.8 ${RPM_BUILD_ROOT}%{_mandir}/man8
 
 mkdir -p build-docs
 for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
@@ -98,15 +98,15 @@ done
 # list files owned by the package here
 %files
 %doc build-docs/LICENSE build-docs/MAINTAINERS build-docs/NOTICE build-docs/README.md
-/%{_bindir}/docker
+%{_bindir}/docker
 /usr/libexec/docker/cli-plugins/*
 /usr/share/bash-completion/completions/docker
 /usr/share/zsh/vendor-completions/_docker
 /usr/share/fish/vendor_completions.d/docker.fish
 %doc
-/%{_mandir}/man1/*
-/%{_mandir}/man5/*
-/%{_mandir}/man8/*
+%{_mandir}/man1/*
+%{_mandir}/man5/*
+%{_mandir}/man8/*
 
 
 %post

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -83,11 +83,11 @@ install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/z
 install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
 
 # install manpages
-install -d %{buildroot}%{_mandir}/man1
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man1
 install -p -m 644 cli/man/man1/*.1 $RPM_BUILD_ROOT/%{_mandir}/man1
-install -d %{buildroot}%{_mandir}/man5
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man5
 install -p -m 644 cli/man/man5/*.5 $RPM_BUILD_ROOT/%{_mandir}/man5
-install -d %{buildroot}%{_mandir}/man8
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man8
 install -p -m 644 cli/man/man8/*.8 $RPM_BUILD_ROOT/%{_mandir}/man8
 
 mkdir -p build-docs

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -44,13 +44,13 @@ depending on a particular stack or provider.
 %build
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
-ln -s /root/rpmbuild/BUILD/src/cli /go/src/github.com/docker/cli
+ln -s ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
 DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit} dynbinary manpages # cli
 popd
 
 # Build all associated plugins
-pushd /root/rpmbuild/BUILD/src/plugins
+pushd ${RPM_BUILD_DIR}/src/plugins
 for installer in *.installer; do
     bash ${installer} build
 done
@@ -66,21 +66,21 @@ install -d $RPM_BUILD_ROOT%{_bindir}
 install -p -m 755 cli/build/docker $RPM_BUILD_ROOT%{_bindir}/docker
 
 # install plugins
-pushd /root/rpmbuild/BUILD/src/plugins
+pushd ${RPM_BUILD_DIR}/src/plugins
 for installer in *.installer; do
     DESTDIR=$RPM_BUILD_ROOT \
-        PREFIX=/usr/libexec/docker/cli-plugins \
+        PREFIX=%{_libexecdir}/docker/cli-plugins \
         bash ${installer} install_plugin
 done
 popd
 
 # add bash, zsh, and fish completions
-install -d $RPM_BUILD_ROOT/usr/share/bash-completion/completions
-install -d $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions
-install -d $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d
-install -p -m 644 cli/contrib/completion/bash/docker $RPM_BUILD_ROOT/usr/share/bash-completion/completions/docker
-install -p -m 644 cli/contrib/completion/zsh/_docker $RPM_BUILD_ROOT/usr/share/zsh/vendor-completions/_docker
-install -p -m 644 cli/contrib/completion/fish/docker.fish $RPM_BUILD_ROOT/usr/share/fish/vendor_completions.d/docker.fish
+install -d ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions
+install -d ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions
+install -d ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d
+install -p -m 644 cli/contrib/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
+install -p -m 644 cli/contrib/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
+install -p -m 644 cli/contrib/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
 
 # install manpages
 install -d ${RPM_BUILD_ROOT}%{_mandir}/man1
@@ -99,10 +99,10 @@ done
 %files
 %doc build-docs/LICENSE build-docs/MAINTAINERS build-docs/NOTICE build-docs/README.md
 %{_bindir}/docker
-/usr/libexec/docker/cli-plugins/*
-/usr/share/bash-completion/completions/docker
-/usr/share/zsh/vendor-completions/_docker
-/usr/share/fish/vendor_completions.d/docker.fish
+%{_libexecdir}/docker/cli-plugins/*
+%{_datadir}/bash-completion/completions/docker
+%{_datadir}/zsh/vendor-completions/_docker
+%{_datadir}/fish/vendor_completions.d/docker.fish
 %doc
 %{_mandir}/man1/*
 %{_mandir}/man5/*

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -93,13 +93,13 @@ engine/bundles/dynbinary-daemon/dockerd -v
 
 %install
 # install daemon binary
-install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) $RPM_BUILD_ROOT%{_bindir}/dockerd
+install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) ${RPM_BUILD_ROOT}%{_bindir}/dockerd
 
 # install proxy
-install -D -p -m 0755 /usr/local/bin/docker-proxy $RPM_BUILD_ROOT%{_bindir}/docker-proxy
+install -D -p -m 0755 /usr/local/bin/docker-proxy ${RPM_BUILD_ROOT}%{_bindir}/docker-proxy
 
 # install tini
-install -D -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT%{_bindir}/docker-init
+install -D -p -m 755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_bindir}/docker-init
 
 # install systemd scripts
 install -D -m 0644 ${RPM_SOURCE_DIR}/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -79,9 +79,9 @@ depending on a particular stack or provider.
 
 export DOCKER_GITCOMMIT=%{_gitcommit}
 mkdir -p /go/src/github.com/docker
-ln -s /root/rpmbuild/BUILD/src/engine /go/src/github.com/docker/docker
+ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
 
-pushd /root/rpmbuild/BUILD/src/engine
+pushd ${RPM_BUILD_DIR}/src/engine
 for component in tini "proxy dynamic";do
     TMP_GOPATH="/go" hack/dockerfile/install/install.sh $component
 done
@@ -102,8 +102,8 @@ install -D -p -m 0755 /usr/local/bin/docker-proxy $RPM_BUILD_ROOT%{_bindir}/dock
 install -D -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT%{_bindir}/docker-init
 
 # install systemd scripts
-install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT%{_unitdir}/docker.service
-install -D -m 0644 %{_topdir}/SOURCES/docker.socket $RPM_BUILD_ROOT%{_unitdir}/docker.socket
+install -D -m 0644 ${RPM_SOURCE_DIR}/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
+install -D -m 0644 ${RPM_SOURCE_DIR}/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
 %files
 %{_bindir}/dockerd

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -93,24 +93,24 @@ engine/bundles/dynbinary-daemon/dockerd -v
 
 %install
 # install daemon binary
-install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) $RPM_BUILD_ROOT/%{_bindir}/dockerd
+install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) $RPM_BUILD_ROOT%{_bindir}/dockerd
 
 # install proxy
-install -D -p -m 0755 /usr/local/bin/docker-proxy $RPM_BUILD_ROOT/%{_bindir}/docker-proxy
+install -D -p -m 0755 /usr/local/bin/docker-proxy $RPM_BUILD_ROOT%{_bindir}/docker-proxy
 
 # install tini
-install -D -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT/%{_bindir}/docker-init
+install -D -p -m 755 /usr/local/bin/docker-init $RPM_BUILD_ROOT%{_bindir}/docker-init
 
 # install systemd scripts
-install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
-install -D -m 0644 %{_topdir}/SOURCES/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
+install -D -m 0644 %{_topdir}/SOURCES/docker.service $RPM_BUILD_ROOT%{_unitdir}/docker.service
+install -D -m 0644 %{_topdir}/SOURCES/docker.socket $RPM_BUILD_ROOT%{_unitdir}/docker.socket
 
 %files
-/%{_bindir}/dockerd
-/%{_bindir}/docker-proxy
-/%{_bindir}/docker-init
-/%{_unitdir}/docker.service
-/%{_unitdir}/docker.socket
+%{_bindir}/dockerd
+%{_bindir}/docker-proxy
+%{_bindir}/docker-init
+%{_unitdir}/docker.service
+%{_unitdir}/docker.socket
 
 %post
 %systemd_post docker.service


### PR DESCRIPTION
### rpm: replace `%{buildroot}` with `$RPM_BUILD_ROOT`

From the [RPM mailinglist][1]:

> `$RPM_BUILD_ROOT` is the official, supported, mechanism for getting the
> value of the configured build root in a build scriptlet.
>
> `%{buildroot}` may be changed in the future w/o warning. Not that I'm planning
> on that, but you've been warned.



### rpm: fix double slashes in paths

The built-in macros for paths all have a leading slash, so removing slashes that were manually added before them.

### rpm: use macros/env-vars instead of hard-coded paths

Use the [built-in macros][2] and env-vars for some paths:

- Use `%{_libexecdir}` macro, instead of `/usr/libexec`
- Use `%{_datadir}` instead of `/usr/share`
- Use `%{_specsdir}` instead of `/root/rpmbuild/SPECS`
- Use `$RPM_BUILD_DIR` instead of `/root/rpmbuild/BUILD`
- Use `$RPM_SOURCE_DIR` instead of `/root/rpmbuild/SOURCES`

### rpm: consistently use curly brackets for env-vars


[1]: https://www.redhat.com/archives/rpm-list/2002-July/msg00121.html
[2]: https://rpm.org/user_doc/macros.html