### PR TITLE
CentOS: fix failing repository on aarch64 (arm64)

### DIFF
--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -17,6 +17,10 @@ ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+
+# In aarch64 (arm64) images, the altarch repo is specified as repository, but
+# failing, so replace the URL.
+RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS
 RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -17,6 +17,10 @@ ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+
+# In aarch64 (arm64) images, the altarch repo is specified as repository, but
+# failing, so replace the URL.
+RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint yum-utils
 RUN yum-config-manager --set-enabled PowerTools
 COPY SPECS /root/rpmbuild/SPECS


### PR DESCRIPTION
This repository is only specified in the aarch64 (arm64) images,
and therefore was not caught in CI.

Bringing back the fix that was previously there, to prevent failures:

    #9 [stage-1 4/6] RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
    #9 0.982 Loaded plugins: fastestmirror, ovl
    #9 1.177 Enabling base-source repository
    #9 1.177 Enabling extras-source repository
    #9 1.178 Enabling updates-source repository
    #9 1.179 Loading mirror speeds from cached hostfile
    #9 1.181  * base: d36uatko69830t.cloudfront.net
    #9 1.182  * extras: d36uatko69830t.cloudfront.net
    #9 1.182  * updates: d36uatko69830t.cloudfront.net
    #9 2.272 http://vault.centos.org/altarch/7/extras/Source/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
    #9 2.272 Trying other mirror.
    #9 2.273 To address this issue please refer to the below wiki article
