### PR TITLE
[master] plugins/buildx: force go modules to use vendor mode

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -21,7 +21,7 @@ build() {
         # TODO: unmark `-tp` when no longer a technical preview
         LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-tp-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG} -X main.experimental=1"
         set -x
-        go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
+        GOFLAGS=-mod=vendor go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
     )
 }
 


### PR DESCRIPTION
this should help with building older versions of the plugin with Go 1.13