### PR TITLE
[master] fetch source from upstream docker/docker repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 debbuild
 rpmbuild
 sources
+src
 *.tar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ test_steps = [
 					sh("git -C cli checkout $branch")
 					sh('git clone https://github.com/docker/docker.git engine')
 					sh("git -C engine checkout $branch")
-					sh('make -C deb VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial ubuntu-focal')
+					sh('make -C deb ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial ubuntu-focal')
 				} finally {
 					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
 				}
@@ -28,7 +28,7 @@ test_steps = [
 					sh("git -C cli checkout $branch")
 					sh('git clone https://github.com/docker/docker.git engine')
 					sh("git -C engine checkout $branch")
-					sh('make -C rpm VERSION=0.0.1-dev ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7 centos-8')
+					sh('make -C rpm ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7 centos-8')
 				} finally {
 					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
 				}
@@ -44,7 +44,7 @@ test_steps = [
 					sh("git -C cli checkout $branch")
 					sh('git clone https://github.com/docker/docker.git engine')
 					sh("git -C engine checkout $branch")
-					sh('make VERSION=0.0.1-dev DOCKER_BUILD_PKGS=static-linux ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli static')
+					sh('make DOCKER_BUILD_PKGS=static-linux ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli static')
 				} finally {
 					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
 				}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,13 +8,10 @@ test_steps = [
 			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
 				try {
 					checkout scm
-					sh('git clone https://github.com/docker/cli.git')
-					sh("git -C cli checkout $branch")
-					sh('git clone https://github.com/docker/docker.git engine')
-					sh("git -C engine checkout $branch")
-					sh('make -C deb ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli ubuntu-xenial ubuntu-focal')
+					sh "make REF=$branch checkout"
+					sh "make -C deb ubuntu-xenial ubuntu-focal"
 				} finally {
-					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
+					sh "make clean"
 				}
 			}
 		}
@@ -24,13 +21,10 @@ test_steps = [
 			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
 				try {
 					checkout scm
-					sh('git clone https://github.com/docker/cli.git')
-					sh("git -C cli checkout $branch")
-					sh('git clone https://github.com/docker/docker.git engine')
-					sh("git -C engine checkout $branch")
-					sh('make -C rpm ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli centos-7 centos-8')
+					sh "make REF=$branch checkout"
+					sh "make -C rpm centos-7 centos-8"
 				} finally {
-					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
+					sh "make clean"
 				}
 			}
 		}
@@ -40,13 +34,10 @@ test_steps = [
 			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {
 				try {
 					checkout scm
-					sh('git clone https://github.com/docker/cli.git')
-					sh("git -C cli checkout $branch")
-					sh('git clone https://github.com/docker/docker.git engine')
-					sh("git -C engine checkout $branch")
-					sh('make DOCKER_BUILD_PKGS=static-linux ENGINE_DIR=$(pwd)/engine CLI_DIR=$(pwd)/cli static')
+					sh "make REF=$branch checkout"
+					sh "make REF=$branch DOCKER_BUILD_PKGS=static-linux static"
 				} finally {
-					sh('make ENGINE_DIR=$(pwd)/engine clean-engine')
+					sh "make clean"
 				}
 			}
 		}

--- a/common.mk
+++ b/common.mk
@@ -8,6 +8,21 @@ PLATFORM=Docker Engine - Community
 SHELL:=/bin/bash
 VERSION?=0.0.1-dev
 
+# DOCKER_CLI_REPO and DOCKER_ENGINE_REPO define the source repositories to clone
+# the source from. These can be overridden to build from a fork.
+DOCKER_CLI_REPO    ?= https://github.com/docker/cli.git
+DOCKER_ENGINE_REPO ?= https://github.com/docker/docker.git
+
+# REF can be used to specify the same branch or tag to use for *both* the CLI
+# and Engine source code. This can be useful if both the CLI and Engine have a
+# release branch with the same name (e.g. "19.03"), or of both repositories have
+# tagged a release with the same version.
+#
+# For other situations, specify DOCKER_CLI_REF and/or DOCKER_ENGINE_REF separately.
+REF                ?= HEAD
+DOCKER_CLI_REF     ?= $(REF)
+DOCKER_ENGINE_REF  ?= $(REF)
+
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE
 export PLATFORM

--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@ DOCKER_GITCOMMIT:=abcdefg
 GO_VERSION:=1.13.10
 PLATFORM=Docker Engine - Community
 SHELL:=/bin/bash
-VERSION?=0.0.0-dev
+VERSION?=0.0.1-dev
 
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE

--- a/common.mk
+++ b/common.mk
@@ -1,5 +1,6 @@
 ARCH=$(shell uname -m)
 BUILDTIME=$(shell date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
+CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 DEFAULT_PRODUCT_LICENSE:=Community Engine
 DOCKER_GITCOMMIT:=abcdefg
 GO_VERSION:=1.13.10

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,14 +1,12 @@
 include ../common.mk
 
-CLI_DIR=$(realpath $(CURDIR)/../../cli)
-ENGINE_DIR=$(realpath $(CURDIR)/../../engine)
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
-GITCOMMIT?=$(shell cd $(CLI_DIR) && git rev-parse --short HEAD)
-CLI_GITCOMMIT?=$(GITCOMMIT)
-ENGINE_GITCOMMIT?=$(GITCOMMIT)
+GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
+CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
+ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-GEN_DEB_VER=$(shell ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
+GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 EPOCH?=5
 
 ifdef BUILD_IMAGE
@@ -76,7 +74,7 @@ $(DISTROS): sources/cli.tgz sources/engine.tgz sources/docker.service sources/do
 sources/engine.tgz:
 	mkdir -p $(@D)
 	docker run --rm -w /v \
-		-v $(ENGINE_DIR):/engine \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/docker):/engine \
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/engine.tgz --exclude .git engine
@@ -84,7 +82,7 @@ sources/engine.tgz:
 sources/cli.tgz:
 	mkdir -p $(@D)
 	docker run --rm -w /v \
-		-v $(CLI_DIR):/cli \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/cli):/cli \
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -8,7 +8,6 @@ CLI_GITCOMMIT?=$(GITCOMMIT)
 ENGINE_GITCOMMIT?=$(GITCOMMIT)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 GEN_DEB_VER=$(shell ./gen-deb-ver $(CLI_DIR) "$(VERSION)")
 EPOCH?=5
 

--- a/deb/README.md
+++ b/deb/README.md
@@ -3,30 +3,37 @@
 `.deb` packages can be built from this directory with the following syntax
 
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli deb
+make deb
 ```
 
 Artifacts will be located in `debbuild` under the following directory structure:
 `debbuild/$distro-$distro_version/`
 
-### NOTES:
+### Building from local source
+
+Specify the location of the source repositories for the engine and cli when
+building packages
+
 * `ENGINE_DIR` -> Specifies the directory where the engine code is located, eg: `$GOPATH/src/github.com/docker/docker`
 * `CLI_DIR` -> Specifies the directory where the cli code is located, eg: `$GOPATH/src/github.com/docker/cli`
+
+```shell
+make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli deb
+```
 
 ## Specifying a specific distro
 
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli ubuntu
+make ubuntu
 ```
 
 ## Specifying a specific distro version
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli ubuntu-xenial
+make ubuntu-xenial
 ```
 
-## Building the latest docker-ce
+## Building the for all distros
 
 ```shell
-git clone https://github.com/docker/docker-ce.git
-make ENGINE_DIR=docker-ce/components/engine CLI_DIR=docker-ce/components/cli deb
+make deb
 ```

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,13 +1,11 @@
 include ../common.mk
 
-CLI_DIR=$(realpath $(CURDIR)/../../cli)
-ENGINE_DIR=$(realpath $(CURDIR)/../../engine)
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) "$(VERSION)")
-CLI_GITCOMMIT?=$(shell cd $(CLI_DIR) && git rev-parse --short HEAD)
-ENGINE_GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)
+GEN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
+ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
@@ -81,7 +79,7 @@ $(DISTROS): rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCE
 rpmbuild/SOURCES/engine.tgz:
 	mkdir -p $(@D)
 	docker run --rm -w /v \
-		-v $(ENGINE_DIR):/engine \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/docker):/engine \
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/engine.tgz --exclude .git engine
@@ -89,7 +87,7 @@ rpmbuild/SOURCES/engine.tgz:
 rpmbuild/SOURCES/cli.tgz:
 	mkdir -p $(@D)
 	docker run --rm -w /v \
-		-v $(CLI_DIR):/cli \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/cli):/cli \
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -5,7 +5,6 @@ ENGINE_DIR=$(realpath $(CURDIR)/../../engine)
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(CLI_DIR) "$(VERSION)")
 CLI_GITCOMMIT?=$(shell cd $(CLI_DIR) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(ENGINE_DIR) && git rev-parse --short HEAD)

--- a/rpm/README.md
+++ b/rpm/README.md
@@ -3,30 +3,37 @@
 `.rpm` packages can be built from this directory with the following syntax
 
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli rpm
+make rpm
 ```
 
 Artifacts will be located in `rpmbuild` under the following directory structure:
 `rpmbuild/$distro-$distro_version/`
 
-### NOTES:
+### Building from local source
+
+Specify the location of the source repositories for the engine and cli when
+building packages
+
 * `ENGINE_DIR` -> Specifies the directory where the engine code is located, eg: `$GOPATH/src/github.com/docker/docker`
 * `CLI_DIR` -> Specifies the directory where the cli code is located, eg: `$GOPATH/src/github.com/docker/cli`
+
+```shell
+make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli rpm
+```
 
 ## Specifying a specific distro
 
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli fedora
+make centos
 ```
 
 ## Specifying a specific distro version
 ```shell
-make ENGINE_DIR=/path/to/engine CLI_DIR=/path/to/cli fedora-25
+make centos-8
 ```
 
-## Building the latest docker-ce
+## Building the for all distros
 
 ```shell
-git clone https://github.com/docker/docker-ce.git
-make ENGINE_DIR=docker-ce/components/engine CLI_DIR=docker-ce/components/cli rpm
+make rpm
 ```

--- a/static/Makefile
+++ b/static/Makefile
@@ -7,7 +7,6 @@ HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 GO_VERSION=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
 DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
-CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 
 .PHONY: help
 help: ## show make targets

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,7 +1,7 @@
 include ../common.mk
 
-CLI_DIR=$(realpath $(CURDIR)/../../cli)
-ENGINE_DIR=$(realpath $(CURDIR)/../../engine)
+CLI_DIR=$(realpath $(CURDIR)/../src/github.com/docker/cli)
+ENGINE_DIR=$(realpath $(CURDIR)/../src/github.com/docker/docker)
 GEN_STATIC_VER=$(shell ./gen-static-ver $(CLI_DIR) $(VERSION))
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux


### PR DESCRIPTION
Various changes in this PR:

- remove the VERSION from the Jenkinsfile, as it was just to set a default (which is already defined in the Makefile)
- use upstream https://github.com/docker/docker (https://github.com/moby/moby) repository to fetch the source, and add Makefile variables to allow overriding the repository and reference (branch/tag/commit) to build from
- Add `DOCKER_CLI_REPO`, `DOCKER_ENGINE_REPO`, `REF`, `DOCKER_CLI_REF` and `DOCKER_ENGINE_REF` make variables to allow overriding the repository and  reference to build from.
- if an `ENGINE_DIR` or `CLI_DIR` is specified, copy the source instead of cloning (to keep the source in a fixed location)
