### PR TITLE
Makefile: chown engine dir during cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help: ## show make targets
 
 .PHONY: clean-engine
 clean-engine:
+	[ ! -d $(ENGINE_DIR) ] || docker run --rm -v $(ENGINE_DIR):/v -w /v alpine chown -R $(shell id -u):$(shell id -g) /v
 	rm -rf $(ENGINE_DIR)
 
 .PHONY: clean


### PR DESCRIPTION
to address https://github.com/docker/docker-ce-packaging/pull/433#issuecomment-613427895


we should have a look why this target is in the main makefile, and why we don't use `make -C static clean` (e.g.)