### PR TITLE
[master] RHEL8 iptables build fix (#410)

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -21,7 +21,11 @@ Requires: docker-ce-cli
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd
+%if 0%{?rhel} >= 8
+Requires: ( iptables or nftables )
+%else
 Requires: iptables
+%endif
 Requires: libcgroup
 Requires: containerd.io >= 1.2.2-3
 Requires: tar


### PR DESCRIPTION
cherry-pick of https://github.com/docker/docker-ce-packaging/pull/410 for master

add optional requirement for nftables on RHEL8+ derivatives

(cherry picked from commit cfc7f43d3ed851510b3cd994145a322499aa3767)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>