### PR TITLE
[19.03 backport] deb: use DEBIAN_FRONTEND=noninteractive for all dockerfiles

### DIFF
--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/debian-stretch/Dockerfile
+++ b/deb/debian-stretch/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/raspbian-stretch/Dockerfile
+++ b/deb/raspbian-stretch/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/ubuntu-disco/Dockerfile
+++ b/deb/ubuntu-disco/Dockerfile
@@ -13,6 +13,7 @@ RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
         dpkg-divert --quiet --remove --rename /usr/bin/man; \
     fi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/ubuntu-eoan/Dockerfile
+++ b/deb/ubuntu-eoan/Dockerfile
@@ -13,6 +13,7 @@ RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
         dpkg-divert --quiet --remove --rename /usr/bin/man; \
     fi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -7,6 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=direct


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/468 to keep the diff with master smaller

This was needed for Ubuntu 20.04, but doesn't hurt to use
for other versions as well.
