### PR TITLE
docker-rootless-extras: add dockerd-rootless-setuptool.sh

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -32,7 +32,7 @@ static-linux: static-cli static-engine ## create tgz with linux x86_64 client an
 
 	# extra binaries for running rootless
 	mkdir -p build/linux/docker-rootless-extras
-	for f in rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh vpnkit; do \
+	for f in rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh dockerd-rootless-setuptool.sh vpnkit; do \
 		if [ -f $(ENGINE_DIR)/bundles/binary-daemon/$$f ]; then \
 			cp -L $(ENGINE_DIR)/bundles/binary-daemon/$$f build/linux/docker-rootless-extras/$$f; \
 		fi \


### PR DESCRIPTION
dockerd-rootless-setuptool.sh was added to Moby in https://github.com/moby/moby/pull/40950
