### PR TITLE
Downgrade "aufs-tools" and "cgroupfs-mount" to "Suggests"

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -28,14 +28,13 @@ Vcs-Git: git://github.com/docker/docker.git
 Package: docker-ce
 Architecture: linux-any
 Depends: docker-ce-cli, containerd.io (>= 1.2.2-3), iptables, libseccomp2 (>= 2.3.0), ${shlibs:Depends}
-Recommends: aufs-tools [amd64],
-            ca-certificates,
-            cgroupfs-mount | cgroup-lite,
+Recommends: ca-certificates,
             git,
             pigz,
             xz-utils,
             libltdl7,
             ${apparmor:Recommends}
+Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
 Replaces: docker-engine
 Description: Docker: the open-source application container engine


### PR DESCRIPTION
Quoting from https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends (as a refresher/context):

> `Recommends`
> > This declares a strong, but not absolute, dependency.
> >
> > The `Recommends` field should list packages that would be found together with this one in all but unusual installations.
>
> `Suggests`
> > This is used to declare that one package may be more useful with one or more others. Using this field tells the packaging system and the user that the listed packages are related to this one and can perhaps enhance its usefulness, but that installing this one without them is perfectly reasonable.

My justification for this change, given that context, is that `aufs` hasn't been the default graph driver for quite some time now, and I'd wager the majority of new installations these days already have cgroups via `systemd` or some other similar package, so it's going to be less common for users to need something like `cgroupfs-mount` (and pulling it in on `systemd`-using systems is a noop that just generates noise).

(Another way to consider this is that in a properly configured APT installation, `Recommends` get installed by default but `Suggests` do not. :smile:)

There has been some discussion around the former in https://bugs.debian.org/948087 recently that prompted me to finally pull the trigger on opening this, but it's something I've been thinking about for quite some time now.