### PR TITLE
Add docker-ce-rootless-extras deb & rpm

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -33,6 +33,7 @@ Recommends: ca-certificates,
             pigz,
             xz-utils,
             libltdl7,
+            docker-ce-rootless-extras,
             ${apparmor:Recommends}
 Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
@@ -64,3 +65,20 @@ Description: Docker CLI: the open-source application container engine
  language, framework or packaging system. That makes them great building blocks
  for deploying and scaling web apps, databases, and backend services without
  depending on a particular stack or provider.
+
+Package: docker-ce-rootless-extras
+Architecture: linux-any
+Depends: docker-ce, ${shlibs:Depends}
+Conflicts: rootlesskit
+Replaces: rootlesskit
+Breaks: rootlesskit
+# slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
+Recommends: slirp4netns (>= 0.4.0)
+# Unlike RPM, DEB packages do not contain "Recommends: fuse-overlayfs (>= 0.7.0)" here,
+# because Debian (since 10) and Ubuntu support the kernel-mode rootless overlayfs.
+Description: Rootless support for Docker.
+  Use dockerd-rootless.sh to run the daemon.
+  Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
+  This package contains RootlessKit, but does not contain VPNKit.
+  Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
+Homepage: https://docs.docker.com/engine/security/rootless/

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -12,6 +12,7 @@ override_dh_auto_build:
 	cd engine && DOCKER_GITCOMMIT=$(ENGINE_GITCOMMIT) PRODUCT=docker ./hack/make.sh dynbinary
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh proxy dynamic
+	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 	# Build the CLI
 	cd /go/src/github.com/docker/cli && \
 		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) dynbinary manpages
@@ -48,6 +49,13 @@ override_dh_auto_install:
 	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd
 	install -D -m 0755 /usr/local/bin/docker-proxy debian/docker-ce/usr/bin/docker-proxy
 	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
+
+	# docker-ce-rootless-extras install
+	install -D -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
+	install -D -m 0755 /usr/local/bin/rootlesskit-docker-proxy debian/docker-ce-rootless-extras/usr/bin/rootlesskit-docker-proxy
+	install -D -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
+	install -D -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
+	# TODO: how can we install vpnkit?
 
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -18,7 +18,7 @@ BUILD?=DOCKER_BUILDKIT=1 \
 	-f $@/Dockerfile \
 	.
 
-SPEC_FILES?=docker-ce.spec docker-ce-cli.spec
+SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec
 SPECS?=$(addprefix SPECS/, $(SPEC_FILES))
 RPMBUILD_FLAGS?=-ba\
 	--define '_gitcommit_cli $(CLI_GITCOMMIT)' \

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -1,0 +1,64 @@
+%global debug_package %{nil}
+
+Name: docker-ce-rootless-extras
+Version: %{_version}
+Release: %{_release}%{?dist}
+Epoch: 0
+Source0: engine.tgz
+Summary: Rootless support for Docker
+Group: Tools/Docker
+License: ASL 2.0
+URL: https://docs.docker.com/engine/security/rootless/
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+Requires: docker-ce
+# slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
+Requires: slirp4netns >= 0.4
+# fuse-overlayfs >= 0.7 is available in the all supported versions of CentOS and Fedora.
+Requires: fuse-overlayfs >= 0.7
+
+BuildRequires: bash
+
+# conflicting packages
+Conflicts: rootlesskit
+
+%description
+Rootless support for Docker.
+Use dockerd-rootless.sh to run the daemon.
+Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
+This package contains RootlessKit, but does not contain VPNKit.
+Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
+
+%prep
+%setup -q -c -n src -a 0
+
+%build
+
+export DOCKER_GITCOMMIT=%{_gitcommit_engine}
+mkdir -p /go/src/github.com/docker
+ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
+TMP_GOPATH="/go" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
+
+%check
+/usr/local/bin/rootlesskit -v
+
+%install
+install -D -p -m 0755 engine/contrib/dockerd-rootless.sh ${RPM_BUILD_ROOT}%{_bindir}/dockerd-rootless.sh
+install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh ${RPM_BUILD_ROOT}%{_bindir}/dockerd-rootless-setuptool.sh
+install -D -p -m 0755 /usr/local/bin/rootlesskit ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit
+install -D -p -m 0755 /usr/local/bin/rootlesskit-docker-proxy ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit-docker-proxy
+
+%files
+%{_bindir}/dockerd-rootless.sh
+%{_bindir}/dockerd-rootless-setuptool.sh
+%{_bindir}/rootlesskit
+%{_bindir}/rootlesskit-docker-proxy
+
+%post
+
+%preun
+
+%postun
+
+%changelog

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -18,6 +18,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce-cli
+Requires: docker-ce-rootless-extras
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd


### PR DESCRIPTION
# Deb
```console
  $ dpkg -c ./docker-ce-rootless-extras_0.0.0-20200611183532-31822ff745-0~ubuntu-eoan_amd64.deb
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./usr/
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./usr/bin/
  -rwxr-xr-x root/root     11724 2020-06-12 15:55 ./usr/bin/dockerd-rootless-setuptool.sh
  -rwxr-xr-x root/root      3138 2020-06-12 15:55 ./usr/bin/dockerd-rootless.sh
  -rwxr-xr-x root/root  15741392 2020-06-12 15:55 ./usr/bin/rootlesskit
  -rwxr-xr-x root/root   9344264 2020-06-12 15:55 ./usr/bin/rootlesskit-docker-proxy
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./usr/share/
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./usr/share/doc/
  drwxr-xr-x root/root         0 2020-06-12 15:55 ./usr/share/doc/docker-ce-rootless-extras/
  -rw-r--r-- root/root       160 2020-06-12 15:55 ./usr/share/doc/docker-ce-rootless-extras/changelog.Debian.gz
```

NOTE: VPNKit is not included (yet), as it takes a lot of time for compilation. We could use prebuilt VPNKit binary as we use in the static tgz, but it is only available for amd64 and in Docker image currently.

This is not problematic for Ubuntu >= 19.10 and Debian >= 11, because slirp4netns is apt-installable instead of VPNKit.


# RPM

```console
$ rpm -qpl ./docker-ce-rootless-extras-0.0.0.20200611183532.31822ff745-0.el7.x86_64.rpm 
/usr/bin/dockerd-rootless-setuptool.sh
/usr/bin/dockerd-rootless.sh
/usr/bin/rootlesskit
/usr/bin/rootlesskit-docker-proxy
```

VPNKit is not included, but this is not a problem because slirp4netns is available for all the supported versions of CentOS and Fedora.