### PR TITLE
[master] Update minimum containerd.io version to v1.3.0

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,7 +27,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: containerd.io (>= 1.2.2-3),
+Depends: containerd.io (>= 1.3.0),
          docker-ce-cli,
          iptables,
          libseccomp2 (>= 2.3.0),

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -29,7 +29,7 @@ Requires: ( iptables or nftables )
 Requires: iptables
 %endif
 Requires: libcgroup
-Requires: containerd.io >= 1.2.2-3
+Requires: containerd.io >= 1.3.0
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
Relates to https://github.com/moby/moby/pull/41210

The engine now defaults to the "io.containerd.runc.v2" shim, which is only available in containerd v1.3.0 and up.

Opening as draft, because no containerd.io v1.3.x packages are available yet, so verification will likely fail