### PR TITLE
[19.03 backport] rpm lacks dependency to groupadd

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -15,6 +15,7 @@ Packager: Docker <support@docker.com>
 
 # required packages on install
 Requires: /bin/sh
+Requires: /usr/sbin/groupadd
 
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -17,6 +17,7 @@ URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
+Requires: /usr/sbin/groupadd
 Requires: docker-ce-cli
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/331 for the 19.03 branch