### PR TITLE
[master] deb: add apparmor as "recommends" on Debian as well

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -34,7 +34,7 @@ Recommends: ca-certificates,
             xz-utils,
             libltdl7,
             docker-ce-rootless-extras,
-            ${apparmor:Recommends}
+            apparmor
 Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~), docker.io, lxc-docker, lxc-docker-virtual-package, docker-engine, docker-engine-cs
 Replaces: docker-engine

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -2,11 +2,6 @@
 
 VERSION ?= $(shell cat engine/VERSION)
 
-override_dh_gencontrol:
-	# if we're on Ubuntu, we need to Recommends: apparmor
-	echo 'apparmor:Recommends=$(shell dpkg-vendor --is Ubuntu && echo apparmor)' >> debian/docker-ce.substvars
-	dh_gencontrol
-
 override_dh_auto_build:
 	# Build the daemon and dependencies
 	cd engine && DOCKER_GITCOMMIT=$(ENGINE_GITCOMMIT) PRODUCT=docker ./hack/make.sh dynbinary


### PR DESCRIPTION
Debian did not have AppArmor available until Debian 7 "Wheezy", and not have it enabled by _default_ until Debian 10 "Buster". The packaging scripts did not add AppArmor as recommended dependency for that reason (https://github.com/moby/moby/commit/eee1efcfd6c46dbdc5da02ca12722e399a56bb12 / https://github.com/moby/moby/pull/12111).

Now that Debian 10 "Buster" is the current stable, and older releases reached EOL, we can remove the special handling for Debian/Ubuntu, and unconditionally add apparmor as a recommended dependency.


Fixes https://github.com/docker/for-linux/issues/974