### PR TITLE
systemd: add multi-user.target to After list

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -2,7 +2,7 @@
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 BindsTo=containerd.service
-After=network-online.target firewalld.service containerd.service
+After=network-online.target firewalld.service containerd.service multi-user.target
 Wants=network-online.target
 Requires=docker.socket
 


### PR DESCRIPTION
See: https://github.com/moby/moby/pull/41297
By adding multi-user.target to the After list on the unit file, we get rid of a dependency chain that forces multi-user.target (and therefore a graphical desktop) to wait for network-online.target. This sped up my boot sequence by 9 seconds, while maintaining the same functionality.