### PR TITLE
plugins: don't require "experimental" for buildx

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -18,8 +18,7 @@ build() {
         git fetch --all
         git checkout -q "${BUILDX_COMMIT}"
         local LDFLAGS
-        # TODO: unmark `-tp` when no longer a technical preview
-        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-tp-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG} -X main.experimental=1"
+        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
         set -x
         GOFLAGS=-mod=vendor go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
     )


### PR DESCRIPTION
Some features of buildx may still be "experimental" / non-final, but we can call those out individually if needed.

This change removes the requirement to enable "experimental" mode in the cli configuration file, so that it's easier for users to try buildx.
