### PR TITLE
[master] deb: make docker-ce "Provide" docker.io

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -46,6 +46,7 @@ Conflicts: docker (<< 1.5~),
            docker.io,
            lxc-docker,
            lxc-docker-virtual-package
+Provides: docker.io
 Replaces: docker-engine
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a


### PR DESCRIPTION
fixes https://github.com/docker/for-linux/issues/1077

To satisfy the dependency for packages that "Depends: docker.io"

We need to verify if this causes problems for the docker-ce-cli package,
because that package has a Conflict with docker.io, which could mean that
adding the "Provides" would actually cause the docker-ce package to conflict
with the docker-ce-cli package;

Referring to the Debian packaging documentation:
https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides

> ## 7.5. Virtual packages - Provides
>
> ...
> If there are both concrete and virtual packages of the same name, then the
> dependency may be satisfied (**or the conflict caused**) by either the
> concrete package with the name in question or any other concrete package
> which provides the virtual package with the name in question.

