### PR TITLE
[master] plugins: update buildx to v0.4.2

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.4.1}"
+: "${BUILDX_COMMIT=v0.4.2}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
full diff: https://github.com/docker/buildx/compare/v0.4.1...v0.4.2

- bake: fix parsing json config with hcl v2
- bake: update go-cty to pull in more stdlib funcs
- bake: ensure --builder is wired from root options
- build: support cacheonly exporter
- build: improve error checking on load
- build: remove warning for multi-platform iidfile

