### PR TITLE
[master] deb: update apt cache before running mk-build-deps

### DIFF
--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -19,7 +19,8 @@ ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES
 COPY ${COMMON_FILES} /root/build-deb/debian
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
 ARG DISTRO

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -19,7 +19,8 @@ ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES
 COPY ${COMMON_FILES} /root/build-deb/debian
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
 ARG DISTRO

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -19,7 +19,8 @@ ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES
 COPY ${COMMON_FILES} /root/build-deb/debian
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
 ARG DISTRO

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -25,7 +25,8 @@ ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES
 COPY ${COMMON_FILES} /root/build-deb/debian
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
 ARG DISTRO

--- a/deb/ubuntu-xenial/Dockerfile
+++ b/deb/ubuntu-xenial/Dockerfile
@@ -19,7 +19,8 @@ ENV RUNC_BUILDTAGS apparmor seccomp selinux
 
 ARG COMMON_FILES
 COPY ${COMMON_FILES} /root/build-deb/debian
-RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
 COPY sources/ /sources
 ARG DISTRO


### PR DESCRIPTION
mk-build-deps does not seem to be updating the cache by itself, and
because of that may be installing packages using an outdated package index
if the previous layer is in the build-cache:

    #6 [stage-1 2/8] RUN apt-get update && apt-get install -y curl devscripts e...
    #6 CACHED

    #8 [stage-1 3/8] COPY common /root/build-deb/debian
    #8 CACHED

    #9 [stage-1 4/8] RUN mk-build-deps -t "apt-get -o Debug::pkgProblemResolver...

