### PR TITLE
[19.03 backport] bump buildx to v0.4.2

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.3.1}"
+: "${BUILDX_COMMIT=master}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {

--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.4.1}"
+: "${BUILDX_COMMIT=v0.4.2}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {

--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=master}"
+: "${BUILDX_COMMIT=v0.4.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
cherry-picks of:

- https://github.com/docker/docker-ce-packaging/pull/439 [master] Bump buildx to master to check if it builds on the CI
- https://github.com/docker/docker-ce-packaging/pull/460 [master] buildx: use v0.4.1
- https://github.com/docker/docker-ce-packaging/pull/495 [master] plugins: update buildx to v0.4.2