### PR TITLE
To allow build for selective distros from top directory

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -36,9 +36,9 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
 
-DEBIAN_VERSIONS := debian-buster
-UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-focal
-RASPBIAN_VERSIONS := raspbian-buster
+DEBIAN_VERSIONS ?= debian-buster
+UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal
+RASPBIAN_VERSIONS ?= raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 
 .PHONY: help

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -39,9 +39,9 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES := fedora-32 fedora-31
-CENTOS_RELEASES := centos-7 centos-8
-RHEL_RELEASES := rhel-7
+FEDORA_RELEASES ?= fedora-32 fedora-31
+CENTOS_RELEASES ?= centos-7 centos-8
+RHEL_RELEASES ?= rhel-7
 DISTROS := $(FEDORA_RELEASES) $(CENTOS_RELEASES) $(RHEL_RELEASES)
 
 .PHONY: help


### PR DESCRIPTION
Similar PR is opened in docker-ce  - https://github.com/docker/docker-ce/pull/659

Objective is to allow docker-ce-packaging to build/troubleshoot for specific distros from top directory.

e.g.-
   for rpm- RHEL_RELEASES= CENTOS_RELEASES= FEDORA_RELEASES=centos-8 make rpm
   for deb- RASPBIAN_VERSIONS= UBUNTU_VERSIONS= DEBIAN_VERSIONS=ubuntu-xenial make deb

Signed-off-by: Alok Kumar <alok232549@gmail.com>