### PR TITLE
systemd: set OOMScoreAdjust for dockerd

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -42,6 +42,7 @@ Delegate=yes
 
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
+OOMScoreAdjust=-500
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
dockerd currently sets the oom-score-adjust itself. This functionality was added when we did not yet run dockerd as a systemd service. Now that we do, it's better to instead have systemd handle this.
