### PR TITLE
Add Ubuntu 20.10 "Groovy Gorilla"

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -37,7 +37,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS ?= debian-buster
-UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal
+UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-groovy
 RASPBIAN_VERSIONS ?= raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/deb/ubuntu-groovy/Dockerfile
+++ b/deb/ubuntu-groovy/Dockerfile
@@ -1,0 +1,42 @@
+ARG GO_IMAGE
+ARG DISTRO=ubuntu
+ARG SUITE=groovy
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
Hi folks,

I am posting this to see what I can do to encourage `docker-ce` to be packaged and ready for use when Ubuntu 20.10 "Groovy Gorilla" is released (which will be [22 October](https://discourse.ubuntu.com/t/groovy-gorilla-release-schedule/15531)).

Apologies if posting this PR isn't the right way to do so. There are no issues enabled for this repository, so this was the only real way to reach out.

Please note that this is not building at the moment, owing to an error which has something to do with constructing man pages?

If interested, please see the full output of my `make ubuntu-groovy` run below (the relevant portion is at the very end):

<details>

```console
% make ubuntu-groovy              
Unable to find image 'alpine:latest' locally
latest: Pulling from library/alpine
df20fa9351a1: Already exists
Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
Status: Downloaded newer image for alpine:latest
== Building packages for ubuntu-groovy ==
DOCKER_BUILDKIT=1 docker build  --build-arg GO_IMAGE=golang:1.13.15-buster --build-arg COMMON_FILES=common -t debbuild-ubuntu-groovy/x86_64 -f ubuntu-groovy/Dockerfile .
[+] Building 213.0s (16/16) FINISHED                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                            0.2s
 => => transferring dockerfile: 1.22kB                                                                                                                                          0.1s
 => [internal] load .dockerignore                                                                                                                                               0.2s
 => => transferring context: 2B                                                                                                                                                 0.1s
 => [internal] load metadata for docker.io/library/ubuntu:groovy                                                                                                                1.0s
 => [internal] load metadata for docker.io/library/golang:1.13.15-buster                                                                                                        0.6s
 => [stage-1 1/9] FROM docker.io/library/ubuntu:groovy@sha256:dc782ece8992f189b097fd222e36de3900442ac6d30a149a69a42c69a2da5fbb                                                 69.7s
 => => resolve docker.io/library/ubuntu:groovy@sha256:dc782ece8992f189b097fd222e36de3900442ac6d30a149a69a42c69a2da5fbb                                                          0.0s
 => => sha256:dc782ece8992f189b097fd222e36de3900442ac6d30a149a69a42c69a2da5fbb 1.20kB / 1.20kB                                                                                  0.0s
 => => sha256:0b812eddc275979da443e4ab51958fb5c64c5d8d6db693cead7bc5d1c07f5386 943B / 943B                                                                                      0.0s
 => => sha256:d80d9d9b3dc316d1bf288cf8931eaf2e5762b54250821090cc4a45f0be211726 3.35kB / 3.35kB                                                                                  0.0s
 => => sha256:5cb735c93c49ccc75005489c239a41732c3fba617b5efd9db967f1ab8387063a 31.34MB / 31.34MB                                                                               55.6s
 => => sha256:7431e3c410bb05888131d9f68d2100a319c7e89892e6dab17c0dccc06143fe52 845B / 845B                                                                                     51.0s
 => => sha256:3fb7a4dd012f7f05e95ddda6864c3a38097244f292a40d6b36cd3ed87d0909f1 163B / 163B                                                                                     52.3s
 => => extracting sha256:5cb735c93c49ccc75005489c239a41732c3fba617b5efd9db967f1ab8387063a                                                                                       9.6s
 => => extracting sha256:7431e3c410bb05888131d9f68d2100a319c7e89892e6dab17c0dccc06143fe52                                                                                       0.0s
 => => extracting sha256:3fb7a4dd012f7f05e95ddda6864c3a38097244f292a40d6b36cd3ed87d0909f1                                                                                       0.0s
 => [internal] load build context                                                                                                                                               2.0s
 => => transferring context: 18.28MB                                                                                                                                            1.9s
 => [golang 1/1] FROM docker.io/library/golang:1.13.15-buster@sha256:66a3f6817c129f48c9cc9b96816a1c0b6dcb399393196e3581d9367b55ab29f2                                          88.7s
 => => resolve docker.io/library/golang:1.13.15-buster@sha256:66a3f6817c129f48c9cc9b96816a1c0b6dcb399393196e3581d9367b55ab29f2                                                  0.0s
 => => sha256:66a3f6817c129f48c9cc9b96816a1c0b6dcb399393196e3581d9367b55ab29f2 1.86kB / 1.86kB                                                                                  0.0s
 => => sha256:24bd48a274920bf47ead96c5a2db8e6a3fbe26e8ae27557c2caa9aeae562a998 1.79kB / 1.79kB                                                                                  0.0s
 => => sha256:d6f3656320fe38f736f0ebae2556d09bf3bde9d663ffc69b153494558aec9a79 6.19kB / 6.19kB                                                                                  0.0s
 => => sha256:d6ff36c9ec4822c9ff8953560f7ba41653b348a9c1136755e653575f58fbded7 50.40MB / 50.40MB                                                                               27.8s
 => => sha256:c958d65b3090aefea91284d018b2a86530a3c8174b72616c4e76993c696a5797 7.81MB / 7.81MB                                                                                  4.2s
 => => sha256:edaf0a6b092f5673ec05b40edb606ce58881b2f40494251117d31805225ef064 10.00MB / 10.00MB                                                                                6.2s
 => => sha256:80931cf6881673fd161a3fd73e8971fe4a569fd7fbb44e956d261ca58d97dfab 51.83MB / 51.83MB                                                                               38.1s
 => => sha256:813643441356759e9202aeebde31d45192b5e5e6218cd8d2ad216304bf415551 68.67MB / 68.67MB                                                                               50.9s
 => => sha256:799f41bb59c9731aba2de07a7b3d49d5bc5e3a57ac053779fc0e405d3aed0b9e 120.17MB / 120.17MB                                                                             69.1s
 => => extracting sha256:d6ff36c9ec4822c9ff8953560f7ba41653b348a9c1136755e653575f58fbded7                                                                                      10.6s
 => => sha256:16b5038bccc853e96f534bc85f4f737109ef37ad92d877b54f080a3c86b3cb3a 126B / 126B                                                                                     38.3s
 => => extracting sha256:c958d65b3090aefea91284d018b2a86530a3c8174b72616c4e76993c696a5797                                                                                       1.1s
 => => extracting sha256:edaf0a6b092f5673ec05b40edb606ce58881b2f40494251117d31805225ef064                                                                                       0.9s
 => => extracting sha256:80931cf6881673fd161a3fd73e8971fe4a569fd7fbb44e956d261ca58d97dfab                                                                                       8.2s
 => => extracting sha256:813643441356759e9202aeebde31d45192b5e5e6218cd8d2ad216304bf415551                                                                                       9.6s
 => => extracting sha256:799f41bb59c9731aba2de07a7b3d49d5bc5e3a57ac053779fc0e405d3aed0b9e                                                                                      17.9s
 => => extracting sha256:16b5038bccc853e96f534bc85f4f737109ef37ad92d877b54f080a3c86b3cb3a                                                                                       0.0s
 => [stage-1 2/9] RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then         rm -f /usr/bin/man;         dpkg-divert --quiet --remove --rename /  3.3s
 => [stage-1 3/9] RUN apt-get update && apt-get install -y curl devscripts equivs git                                                                                          99.8s
 => [stage-1 4/9] COPY common /root/build-deb/debian                                                                                                                            0.3s
 => [stage-1 5/9] RUN apt-get update  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control              18.1s 
 => [stage-1 6/9] COPY sources/ /sources                                                                                                                                        0.8s 
 => [stage-1 7/9] COPY --from=golang /usr/local/go /usr/local/go                                                                                                                9.7s 
 => [stage-1 8/9] WORKDIR /root/build-deb                                                                                                                                       0.1s 
 => [stage-1 9/9] COPY build-deb /root/build-deb/build-deb                                                                                                                      0.2s 
 => exporting to image                                                                                                                                                          9.4s 
 => => exporting layers                                                                                                                                                         9.3s 
 => => writing image sha256:f1c4d04cd1399c9c6af08b4df6536289c052262e44d60aeb9098d9e4275cf3f7                                                                                    0.0s
 => => naming to docker.io/debbuild-ubuntu-groovy/x86_64                                                                                                                        0.0s
docker run --rm -e PLATFORM -e EPOCH='5' -e DEB_VERSION=0.0.0-20201002153401-6916b427a0 -e VERSION=0.0.0-20201002153401-6916b427a0 -e CLI_GITCOMMIT=6916b427a0 -e ENGINE_GITCOMMIT=a24a71c50f -v /Users/[user]/docker-ce-packaging/deb/debbuild/ubuntu-groovy:/build  debbuild-ubuntu-groovy/x86_64
+ set -e
+ mkdir -p /root/build-deb/engine
+ tar -C /root/build-deb -xzf /sources/engine.tgz
+ mkdir -p /root/build-deb/cli
+ tar -C /root/build-deb -xzf /sources/cli.tgz
+ mkdir -p /go/src/github.com/docker
+ ln -snf /root/build-deb/engine /go/src/github.com/docker/docker
+ ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+ EPOCH=5
+ EPOCH_SEP=
+ [[ ! -z 5 ]]
+ EPOCH_SEP=:
+ [[ -z 0.0.0-20201002153401-6916b427a0 ]]
+ echo VERSION AAA 0.0.0-20201002153401-6916b427a0
VERSION AAA 0.0.0-20201002153401-6916b427a0
VERSION bbb 0.0.0-20201002153401-6916b427a0
+ VERSION=0.0.0-20201002153401-6916b427a0
+ echo VERSION bbb 0.0.0-20201002153401-6916b427a0
++ awk -F ': ' '$1 == "Source" { print $2; exit }' debian/control
+ debSource=docker-ce
++ awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control
+ debMaintainer='Docker <support@docker.com>'
++ date --rfc-2822
+ debDate='Tue, 06 Oct 2020 22:35:57 +0000'
+ cat
+ export CLI_GITCOMMIT=6916b427a0
+ CLI_GITCOMMIT=6916b427a0
+ export ENGINE_GITCOMMIT=a24a71c50f
+ ENGINE_GITCOMMIT=a24a71c50f
+ echo VERSION BBB 0.0.0-20201002153401-6916b427a0
VERSION BBB 0.0.0-20201002153401-6916b427a0
+ dpkg-buildpackage -uc -us -I.git
dpkg-buildpackage: info: source package docker-ce
dpkg-buildpackage: info: source version 5:0.0.0-20201002153401-6916b427a0-0~ubuntu-groovy
dpkg-buildpackage: info: source distribution groovy
dpkg-buildpackage: info: source changed by Docker <support@docker.com>
 dpkg-source -I.git --before-build .
dpkg-buildpackage: info: host architecture amd64
 debian/rules clean
dh clean --with=bash-completion --with=systemd
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_clean
dh_clean: warning: Compatibility levels before 10 are deprecated (level 9 in use)
 dpkg-source -I.git -b .
dpkg-source: warning: Version number suggests Ubuntu changes, but Maintainer: does not have Ubuntu address
dpkg-source: warning: Version number suggests Ubuntu changes, but there is no XSBC-Original-Maintainer field
dpkg-source: warning: native package version may not have a revision
dpkg-source: warning: source directory 'build-deb' is not <sourcepackage>-<upstreamversion> 'docker-ce-0.0.0-20201002153401-6916b427a0-0~ubuntu'
dpkg-source: info: using source format '1.0'
dpkg-source: info: building docker-ce in docker-ce_0.0.0-20201002153401-6916b427a0-0~ubuntu-groovy.tar.gz
dpkg-source: info: building docker-ce in docker-ce_0.0.0-20201002153401-6916b427a0-0~ubuntu-groovy.dsc
 debian/rules build
dh build --with=bash-completion --with=systemd
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_update_autotools_config
   debian/rules override_dh_auto_build
make[1]: Entering directory '/root/build-deb'
# Build the daemon and dependencies
cd engine && DOCKER_GITCOMMIT=a24a71c50f PRODUCT=docker ./hack/make.sh dynbinary

Removing bundles/

---> Making bundle: dynbinary (in bundles/dynbinary)
Building: bundles/dynbinary-daemon/dockerd-0.0.0-20201002153401-6916b427a0
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/dynbinary-daemon/dockerd-0.0.0-20201002153401-6916b427a0

cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
+ RM_GOPATH=0
+ TMP_GOPATH=/go
+ : /usr/local/bin
+ '[' -z /go ']'
+ export GOPATH=/go
+ GOPATH=/go
+ case "$(go env GOARCH)" in
++ go env GOARCH
+ export GO_BUILDMODE=-buildmode=pie
+ GO_BUILDMODE=-buildmode=pie
++ dirname hack/dockerfile/install/install.sh
+ dir=hack/dockerfile/install
+ bin=tini
+ shift
+ '[' '!' -f hack/dockerfile/install/tini.installer ']'
+ . hack/dockerfile/install/tini.installer
++ : de40ad007797e0dcd8b7126f27bb87401d224240
Install tini version de40ad007797e0dcd8b7126f27bb87401d224240
+ install_tini
+ echo 'Install tini version de40ad007797e0dcd8b7126f27bb87401d224240'
+ git clone https://github.com/krallin/tini.git /go/tini
Cloning into '/go/tini'...
+ cd /go/tini
+ git checkout -q de40ad007797e0dcd8b7126f27bb87401d224240
+ cmake .
-- The C compiler identification is GNU 10.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test HAS_BUILTIN_FORTIFY
-- Performing Test HAS_BUILTIN_FORTIFY - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /go/tini
+ make tini-static
make[2]: Entering directory '/go/tini'
make[3]: Entering directory '/go/tini'
make[4]: Entering directory '/go/tini'
make[5]: Entering directory '/go/tini'
Scanning dependencies of target tini-static
make[5]: Leaving directory '/go/tini'
make[5]: Entering directory '/go/tini'
[ 50%] Building C object CMakeFiles/tini-static.dir/src/tini.c.o
[100%] Linking C executable tini-static
make[5]: Leaving directory '/go/tini'
[100%] Built target tini-static
make[4]: Leaving directory '/go/tini'
make[3]: Leaving directory '/go/tini'
make[2]: Leaving directory '/go/tini'
+ mkdir -p /usr/local/bin
+ cp tini-static /usr/local/bin/docker-init
cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh proxy dynamic
+ RM_GOPATH=0
+ TMP_GOPATH=/go
+ : /usr/local/bin
+ '[' -z /go ']'
+ export GOPATH=/go
+ GOPATH=/go
+ case "$(go env GOARCH)" in
++ go env GOARCH
+ export GO_BUILDMODE=-buildmode=pie
+ GO_BUILDMODE=-buildmode=pie
++ dirname hack/dockerfile/install/install.sh
+ dir=hack/dockerfile/install
+ bin=proxy
+ shift
+ '[' '!' -f hack/dockerfile/install/proxy.installer ']'
+ . hack/dockerfile/install/proxy.installer
++ : d0951081b35fa4216fc4f0064bf065beeb55a74b
+ install_proxy dynamic
+ case "$1" in
+ install_proxy_dynamic
+ export PROXY_LDFLAGS=-linkmode=external install_proxy
+ PROXY_LDFLAGS=-linkmode=external
+ export BUILD_MODE=-buildmode=pie
+ BUILD_MODE=-buildmode=pie
Install docker-proxy version d0951081b35fa4216fc4f0064bf065beeb55a74b
+ _install_proxy
+ echo 'Install docker-proxy version d0951081b35fa4216fc4f0064bf065beeb55a74b'
+ git clone https://github.com/docker/libnetwork.git /go/src/github.com/docker/libnetwork
Cloning into '/go/src/github.com/docker/libnetwork'...
+ cd /go/src/github.com/docker/libnetwork
+ git checkout -q d0951081b35fa4216fc4f0064bf065beeb55a74b
+ go build -buildmode=pie -ldflags=-linkmode=external -o /usr/local/bin/docker-proxy github.com/docker/libnetwork/cmd/proxy
+ return
cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
+ RM_GOPATH=0
+ TMP_GOPATH=/go
+ : /usr/local/bin
+ '[' -z /go ']'
+ export GOPATH=/go
+ GOPATH=/go
+ case "$(go env GOARCH)" in
++ go env GOARCH
+ export GO_BUILDMODE=-buildmode=pie
+ GO_BUILDMODE=-buildmode=pie
++ dirname hack/dockerfile/install/install.sh
+ dir=hack/dockerfile/install
+ bin=rootlesskit
+ shift
+ '[' '!' -f hack/dockerfile/install/rootlesskit.installer ']'
+ . hack/dockerfile/install/rootlesskit.installer
++ : f766387c3b360bc6dc6c2f353e9e630cf2c6ee86
+ install_rootlesskit dynamic
+ case "$1" in
+ install_rootlesskit_dynamic
+ export ROOTLESSKIT_LDFLAGS=-linkmode=external install_rootlesskit
+ ROOTLESSKIT_LDFLAGS=-linkmode=external
+ export BUILD_MODE=-buildmode=pie
+ BUILD_MODE=-buildmode=pie
+ _install_rootlesskit
+ echo 'Install rootlesskit version f766387c3b360bc6dc6c2f353e9e630cf2c6ee86'
Install rootlesskit version f766387c3b360bc6dc6c2f353e9e630cf2c6ee86
+ git clone https://github.com/rootless-containers/rootlesskit.git /go/src/github.com/rootless-containers/rootlesskit
Cloning into '/go/src/github.com/rootless-containers/rootlesskit'...
+ cd /go/src/github.com/rootless-containers/rootlesskit
+ git checkout -q f766387c3b360bc6dc6c2f353e9e630cf2c6ee86
+ for f in rootlesskit rootlesskit-docker-proxy
+ go build -buildmode=pie -ldflags=-linkmode=external -o /usr/local/bin/rootlesskit github.com/rootless-containers/rootlesskit/cmd/rootlesskit
+ for f in rootlesskit rootlesskit-docker-proxy
+ go build -buildmode=pie -ldflags=-linkmode=external -o /usr/local/bin/rootlesskit-docker-proxy github.com/rootless-containers/rootlesskit/cmd/rootlesskit-docker-proxy
+ return
# Build the CLI
cd /go/src/github.com/docker/cli && \
	LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=0.0.0-20201002153401-6916b427a0 GITCOMMIT=6916b427a0 dynbinary manpages
make[2]: Entering directory '/root/build-deb/cli'
./scripts/build/dynbinary
Building dynamically linked build/docker-linux-amd64
scripts/docs/generate-man.sh
Project root: /go/src/github.com/docker/cli
Generating man pages into /go/src/github.com/docker/cli/man/man1
make[2]: Leaving directory '/root/build-deb/cli'
# Build the CLI plugins
# Make sure to set LDFLAGS="" since, dpkg-buildflags sets it to some weird values
set -e;cd /sources && \
	tar xzf plugin-installers.tgz; \
	for installer in plugins/*.installer; do \
		LDFLAGS='' bash ${installer} build; \
	done
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/build.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/builder/build.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/builder/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/builder.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/checkpoint/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/checkpoint/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/checkpoint/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/checkpoint.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/config/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/config/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/config/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/config/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/config.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/container/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/container/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/container.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/export.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/import.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/update.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context/use.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/context.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/image/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/image/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/image.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest/annotate.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest/push.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/manifest.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/network/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/network.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/demote.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/promote.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/ps.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node/update.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/node.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/disable.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/enable.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/install.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/push.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/set.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin/upgrade.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/plugin.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/run.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/secret/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/secret/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/secret/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/secret/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/secret.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/create.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/logs.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/ps.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/rollback.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/scale.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service/update.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/service.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack/deploy.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack/ls.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack/ps.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack/rm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack/services.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/stack.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/ca.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/init.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/join.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/join-token.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/leave.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/unlock.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/unlock-key.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm/update.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/swarm.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/system/df.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/system/dial-stdio.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/system/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/system.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/inspect.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/key/generate.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/key/load.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/key.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/revoke.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/sign.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/signer/add.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/signer/remove.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust/signer.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/trust.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/volume/prune.md does not exist, skipping
2020/10/06 22:42:37 WARN: /go/src/github.com/docker/cli/man/src/volume/rm.md does not exist, skipping
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
WARNING: go-md2man does not handle node type HTMLSpan
Cloning into '/go/src/github.com/docker/app'...
Fetching origin
make[2]: Entering directory '/go/src/github.com/docker/app'
go build -tags= -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9d2c67f8 -X github.com/docker/app/internal.Version=v0.9.1-beta3" -o bin/docker-app ./cmd/docker-app
make[2]: Leaving directory '/go/src/github.com/docker/app'
Cloning into '/go/src/github.com/docker/buildx'...
Fetching origin
+ GOFLAGS=-mod=vendor
+ go build -o bin/docker-buildx -ldflags '-X github.com/docker/buildx/version.Version=v0.4.2-docker -X github.com/docker/buildx/version.Revision=fb7b670b764764dc4716df3eba07ffdae4cc47b2 -X github.com/docker/buildx/version.Package=github.com/docker/buildx' ./cmd/buildx
make[1]: Leaving directory '/root/build-deb'
   debian/rules override_dh_auto_test
make[1]: Entering directory '/root/build-deb'
./engine/bundles/dynbinary-daemon/dockerd -v
Docker version 0.0.0-20201002153401-6916b427a0, build a24a71c50f
./cli/build/docker -v
Docker version 0.0.0-20201002153401-6916b427a0, build 6916b427a0
make[1]: Leaving directory '/root/build-deb'
 debian/rules binary
dh binary --with=bash-completion --with=systemd
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_testroot
   dh_prep
   debian/rules override_dh_auto_install
make[1]: Entering directory '/root/build-deb'
# docker-ce-cli install
install -D -m 0644 /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
install -D -m 0644 /go/src/github.com/docker/cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
install -D -m 0755 /go/src/github.com/docker/cli/build/docker debian/docker-ce-cli/usr/bin/docker
set -e;cd /sources && \
	tar xzf plugin-installers.tgz; \
	for installer in plugins/*.installer; do \
		DESTDIR=/root/build-deb/debian/docker-ce-cli \
		PREFIX=/usr/libexec/docker/cli-plugins \
			bash ${installer} install_plugin; \
	done
# docker-ce install
install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service
install -D -m 0644 /sources/docker.socket debian/docker-ce/lib/systemd/system/docker.socket
install -D -m 0755 /root/build-deb/engine/bundles/dynbinary-daemon/dockerd-0.0.0-20201002153401-6916b427a0 debian/docker-ce/usr/bin/dockerd
install -D -m 0755 /usr/local/bin/docker-proxy debian/docker-ce/usr/bin/docker-proxy
install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
# docker-ce-rootless-extras install
install -D -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
install -D -m 0755 /usr/local/bin/rootlesskit-docker-proxy debian/docker-ce-rootless-extras/usr/bin/rootlesskit-docker-proxy
install -D -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
install -D -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
# TODO: how can we install vpnkit?
make[1]: Leaving directory '/root/build-deb'
   debian/rules override_dh_install
make[1]: Entering directory '/root/build-deb'
dh_install
dh_install: warning: Compatibility levels before 10 are deprecated (level 9 in use)
# TODO Can we do this from within our container?
dh_apparmor --profile-name=docker-ce -pdocker-ce
make[1]: Leaving directory '/root/build-deb'
   dh_installdocs
dh_installdocs: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_installchangelogs
   dh_installman
dh_installman: warning: Compatibility levels before 10 are deprecated (level 9 in use)
dh_installman: warning: Section for ./cli/man/man1/docker-attach.1 is computed as "2020", which is not a valid section
dh_installman: error: Could not determine section for ./cli/man/man1/docker-attach.1
dh_installman: error: Aborting due to earlier error
make: *** [debian/rules:68: binary] Error 25
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
make: *** [ubuntu-groovy] Error 2
```

</details>

(Also, please note: Groovy is not currently added to the Jenkinsfile in this PR, so I believe the Groovy build wouldn't be part of CI. This PR, as written, might pass CI regardless of whether Groovy can build `docker-ce`.)

Best regards,

\- DeeDeeG