### PR TITLE
[19.03 backport] To allow build for selective distros from top directory.

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -35,9 +35,9 @@ RUN=docker run --rm -i \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
 
-DEBIAN_VERSIONS := debian-stretch debian-buster
-UBUNTU_VERSIONS := ubuntu-xenial ubuntu-bionic ubuntu-focal
-RASPBIAN_VERSIONS := raspbian-stretch raspbian-buster
+DEBIAN_VERSIONS ?= debian-stretch debian-buster
+UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal
+RASPBIAN_VERSIONS ?= raspbian-stretch raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 
 .PHONY: help

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -40,9 +40,9 @@ RUN?=$(RPMBUILD) rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 SOURCE_FILES=engine.tgz cli.tgz docker.service docker.socket plugin-installers.tgz
 SOURCES=$(addprefix rpmbuild/SOURCES/, $(SOURCE_FILES))
 
-FEDORA_RELEASES := fedora-32 fedora-31
-CENTOS_RELEASES := centos-7 centos-8
-RHEL_RELEASES := rhel-7
+FEDORA_RELEASES ?= fedora-32 fedora-31
+CENTOS_RELEASES ?= centos-7 centos-8
+RHEL_RELEASES ?= rhel-7
 DISTROS := $(FEDORA_RELEASES) $(CENTOS_RELEASES) $(RHEL_RELEASES)
 
 .PHONY: help


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/500
cherry-pick wasn't clean because default distros differ in this branch, but easy to resolve


e.g.-
for rpm- RHEL_RELEASES= CENTOS_RELEASES= FEDORA_RELEASES=centos-8 make rpm
for deb- RASPBIAN_VERSIONS= UBUNTU_VERSIONS= DEBIAN_VERSIONS=ubuntu-xenial make deb
