### PR TITLE
[19.03 backport] static: add containerd-shim-runc-v2

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -25,7 +25,7 @@ static: static-linux cross-mac cross-win cross-arm ## create all static packages
 static-linux: static-cli static-engine ## create tgz with linux x86_64 client and server
 	mkdir -p build/linux/docker
 	cp $(CLI_DIR)/build/docker build/linux/docker/
-	for f in dockerd containerd ctr containerd-shim docker-init docker-proxy runc; do \
+	for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
 		cp -L $(ENGINE_DIR)/bundles/binary-daemon/$$f build/linux/docker/$$f; \
 	done
 	tar -C build/linux -c -z -f build/linux/docker-$(STATIC_VERSION).tgz docker


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/docker/docker-ce-packaging/pull/465#issuecomment-706133455.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
(cherry picked from commit 912015018bf457c02afd87723fb8a7e42fee9a2f)