### PR TITLE
[master] Update minimum containerd.io version to v1.4.1

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,7 +27,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: containerd.io (>= 1.3.0),
+Depends: containerd.io (>= 1.4.1),
          docker-ce-cli,
          iptables,
          libseccomp2 (>= 2.3.0),

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -29,7 +29,7 @@ Requires: ( iptables or nftables )
 Requires: iptables
 %endif
 Requires: libcgroup
-Requires: containerd.io >= 1.3.0
+Requires: containerd.io >= 1.4.1
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
Docker v20.10 ships with containerd.io v1.4.x, so setting the minimum required version to v1.4.1 (current containerd.io release), as we won't test / support older versions of containerd (and runc).

relates to https://github.com/moby/moby/pull/40982, https://github.com/moby/moby/pull/41450
relates to https://github.com/moby/moby/pull/41563