### PR TITLE
Add "procps" to daemon "Recommends" (for "docker top")

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -38,6 +38,7 @@ Recommends: apparmor,
             git,
             libltdl7,
             pigz,
+            procps,
             xz-utils
 Suggests: aufs-tools [amd64], cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~),


### PR DESCRIPTION
~~Hi!  This is adjusting the dependencies for `docker-ce` and `docker-ce-cli` -- moving `git` to `Recommends` on the latter (because these days, `dockerd` should only be shelling out to `git` as a not-recommended-for-use backwards compatibility measure) and~~ adding `procps` (which is needed for `docker top` and given it's only `Priority: important` not essential, might not be installed).

Both of these *do* belong in `Recommends:` (not `Depends:`) because they're both related to technically optional behavior of the CLI (although behavior that's common enough to warrant `Recommends:` instead of `Suggests:` so most users get them automatically).

I'm guessing there are more items in this list of `Recommends:` for `docker-ce` that should *also* move, but I'm not personally up-to-date enough to recognize them offhand (`libltdl7`?).  Happy to adjust/include them if someone else knows more reliably! :heart:

(Directly inspired by https://github.com/bottlerocket-os/bottlerocket/pull/1210; @samuelkarp :heart:)