### PR TITLE
Makefile: switch to POSIX mode to handle errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.POSIX:
+
 include common.mk
 
 STATIC_VERSION=$(shell static/gen-static-ver $(realpath $(CURDIR)/src/github.com/docker/docker) $(VERSION))

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,3 +1,5 @@
+.POSIX:
+
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,3 +1,5 @@
+.POSIX:
+
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,3 +1,5 @@
+.POSIX:
+
 include ../common.mk
 
 CLI_DIR=$(realpath $(CURDIR)/../src/github.com/docker/cli)


### PR DESCRIPTION
from https://pubs.opengroup.org/onlinepubs/009695399/utilities/make.html#tag_04_84_13_03

> .POSIX
>
> The application shall ensure that this special target is specified without prerequisites
> or commands. If it appears as the first non-comment line in the makefile, make shall
> process the makefile as specified by this section; otherwise, the behavior of make is
> unspecified.

Running the makefile with `.POSIX` runs shells with the `-e` options, which helps with
handling errors; without this, make completes "succesfully", even shell commands in a
target fail, for example:

    make[2]: Leaving directory '/home/ubuntu/workspace/docker-ce-packaging_PR-504/engine'
    mkdir -p build/linux/docker
    cp /home/ubuntu/workspace/docker-ce-packaging_PR-504/cli/build/docker build/linux/docker/
    for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
    	cp -L /home/ubuntu/workspace/docker-ce-packaging_PR-504/engine/bundles/binary-daemon/$f build/linux/docker/$f; \
    done
    cp: cannot stat '/home/ubuntu/workspace/docker-ce-packaging_PR-504/engine/bundles/binary-daemon/containerd-shim-runc-v2': No such file or directory

With this patch applied, the target succesfully detects the failure (changed one filename to be invalid for testing):

    make[1]: Entering directory '/docker/static'
    mkdir -p build/linux/docker
    cp /docker/src/github.com/docker/cli/build/docker build/linux/docker/
    for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v99 docker-init docker-proxy runc; do \
        cp -L /docker/src/github.com/docker/docker/bundles/binary-daemon/$f build/linux/docker/$f; \
    done
    cp: can't stat '/docker/src/github.com/docker/docker/bundles/binary-daemon/containerd-shim-runc-v99': No such file or directory
    make[1]: *** [Makefile:30: static-linux] Error 1
    make[1]: Leaving directory '/docker/static'
    make: *** [Makefile:70: static] Error 2

Note that this patch does not change behavior on macOS, which runs an older version of GNU make, that
does not support these options.
