### PR TITLE
[19.03 backport] systemd unit fixes/updates

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -2,7 +2,7 @@
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 BindsTo=containerd.service
-After=network-online.target firewalld.service containerd.service
+After=network-online.target firewalld.service containerd.service multi-user.target
 Wants=network-online.target
 Requires=docker.socket
 

--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-BindsTo=containerd.service
 After=network-online.target firewalld.service containerd.service multi-user.target
 Wants=network-online.target
-Requires=docker.socket
+Requires=docker.socket containerd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Backports of:

- (picked to get a clean cherry-pick) https://github.com/docker/docker-ce-packaging/pull/488 systemd: add multi-user.target to After list
    - relates to https://github.com/moby/moby/pull/41297
- https://github.com/docker/docker-ce-packaging/pull/508 Do not "Bind" docker "To" containerd (carry #365)
    - fixes to https://github.com/docker/for-linux/issues/678
    - fixes/addresses/relates to https://github.com/docker/for-linux/issues/1155
    - also see https://bugs.launchpad.net/ubuntu/+source/containerd/+bug/1870514

  