### PR TITLE
Move containerd.service from Requires= to Wants=

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -2,8 +2,8 @@
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
 After=network-online.target firewalld.service containerd.service
-Wants=network-online.target
-Requires=docker.socket containerd.service
+Wants=network-online.target containerd.service
+Requires=docker.socket
 
 [Service]
 Type=notify


### PR DESCRIPTION
Per the systemd.unit documentation:

> If this unit gets activated, the units listed will be activated as well. If one of the other units fails to activate, and an ordering dependency After= on the failing unit is set, this unit will not be started. Besides, with or without specifying After=, this unit will be stopped if one of the other units is explicitly stopped.
>
> Often, it is a better choice to use Wants= instead of Requires= in order to achieve a system that is more robust when dealing with failing services.

This should also be generally "safe" given we added `--containerd=/run/containerd/containerd.sock` to the flags we pass to `dockerd`.

See https://github.com/docker/docker-ce-packaging/pull/511#issuecomment-739088735.