### PR TITLE
Revert "systemd: add multi-user.target to After list"

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target firewalld.service containerd.service multi-user.target
+After=network-online.target firewalld.service containerd.service
 Wants=network-online.target
 Requires=docker.socket containerd.service
 


### PR DESCRIPTION
This reverts commit 36bb01538e1db523abf92232737cdc06903266b1, which caused the docker service to not be starting, or delayed starting the service in certain conditions.

relates to / introduced in https://github.com/moby/moby/pull/41297 / https://github.com/docker/docker-ce-packaging/pull/488 systemd: add multi-user.target to After list

fixes / addresses https://github.com/moby/moby/issues/41767 `systemctl docker start` get stuck in cloud-init
fixes / addresses https://github.com/docker/for-linux/issues/1161 Docker service not starting in centos 7.9
fixes / addresses https://github.com/docker/for-linux/issues/1162 Docker 20.10 daemon takes 5 minutes to start after reboot
fixes / addresses https://github.com/docker/machine/issues/4858 Latest docker release (20.10.0) doesn't work with docker-machine