### PR TITLE
Bump buildx to v0.5.1

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.5.0}"
+: "${BUILDX_COMMIT=v0.5.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

Woopsies https://github.com/docker/buildx/releases/tag/v0.5.1