### PR TITLE
CLI backend packaging

### DIFF
--- a/backends/compose-cli.installer
+++ b/backends/compose-cli.installer
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source "$(dirname "$0")/../plugins/.common"
+
+GOPATH=$(go env GOPATH)
+REPO=https://github.com/docker/compose-cli.git
+COMMIT=v1.0.6
+DEST=${GOPATH}/src/github.com/docker/compose-cli
+
+build() {
+    if [ ! -d "${DEST}" ]; then
+        git clone "${REPO}" "${DEST}"
+    fi
+    (
+        cd "${DEST}"
+        git fetch --all
+        git checkout -q "${COMMIT}"
+
+        GO111MODULE=on go mod download
+        GO111MODULE=on make -f builder.Makefile cli
+    )
+}
+
+install_backend() {
+    (
+        cd "${DEST}"
+        cp bin/docker bin/docker-compose-cli-backend
+        install_binary bin/docker-compose-cli-backend
+    )
+}
+
+build_or_install "$@"

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,6 +1,7 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
+BACKENDS_DIR=$(realpath $(CURDIR)/../backends)
 GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
@@ -66,7 +67,7 @@ debian: $(DEBIAN_VERSIONS) ## build all debian deb packages
 raspbian: $(RASPBIAN_VERSIONS) ## build all raspbian deb packages
 
 .PHONY: $(DISTROS)
-$(DISTROS): sources/cli.tgz sources/engine.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz
+$(DISTROS): sources/cli.tgz sources/engine.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz sources/backend-installers.tgz
 	@echo "== Building packages for $@ =="
 	$(BUILD)
 	$(RUN)
@@ -102,3 +103,10 @@ sources/plugin-installers.tgz: $(wildcard ../plugins/*)
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins
+
+sources/backend-installers.tgz: $(wildcard ../backends/*)
+	docker run --rm -w /v \
+		-v $(BACKENDS_DIR):/backends \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/backend-installers.tgz --exclude .git backends

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -18,6 +18,13 @@ override_dh_auto_build:
 		for installer in plugins/*.installer; do \
 			LDFLAGS='' bash $${installer} build; \
 		done
+	# Build the CLI backends
+	# Make sure to set LDFLAGS="" since, dpkg-buildflags sets it to some weird values
+	set -e;cd /sources && \
+		tar xzf backend-installers.tgz; \
+		for installer in backends/*.installer; do \
+			LDFLAGS='' bash $${installer} build; \
+		done
 
 override_dh_auto_test:
 	./engine/bundles/dynbinary-daemon/dockerd -v
@@ -37,6 +44,13 @@ override_dh_auto_install:
 			DESTDIR=/root/build-deb/debian/docker-ce-cli \
 			PREFIX=/usr/libexec/docker/cli-plugins \
 				bash $${installer} install_plugin; \
+		done
+	set -e;cd /sources && \
+		tar xzf backend-installers.tgz; \
+		for installer in backends/*.installer; do \
+			DESTDIR=/root/build-deb/debian/docker-ce-cli \
+			PREFIX=/usr/libexec/docker/cli-backends \
+				bash $${installer} install_backend; \
 		done
 	# docker-ce install
 	install -D -m 0644 /sources/docker.service debian/docker-ce/lib/systemd/system/docker.service

--- a/plugins/.common
+++ b/plugins/.common
@@ -29,6 +29,9 @@ build_or_install() {
         install_plugin)
             install_plugin
             ;;
+        install_backend)
+            install_backend
+            ;;
         *)
             echo "Are you sure that's a command? o.O"
             exit 1

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,6 +1,7 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
+BACKENDS_DIR=$(realpath $(CURDIR)/../backends)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
@@ -70,7 +71,7 @@ centos: $(CENTOS_RELEASES) ## build all centos rpm packages
 rhel: $(RHEL_RELEASES) ## build all rhel rpm packages
 
 .PHONY: $(DISTROS)
-$(DISTROS): rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/docker.service rpmbuild/SOURCES/docker.socket rpmbuild/SOURCES/plugin-installers.tgz
+$(DISTROS): rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/docker.service rpmbuild/SOURCES/docker.socket rpmbuild/SOURCES/plugin-installers.tgz rpmbuild/SOURCES/backend-installers.tgz
 	@echo "== Building packages for $@ =="
 	$(CHOWN) -R root:root rpmbuild
 	$(BUILD)
@@ -107,3 +108,10 @@ rpmbuild/SOURCES/plugin-installers.tgz: $(wildcard ../plugins/*)
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins
+
+rpmbuild/SOURCES/backend-installers.tgz: $(wildcard ../backends/*)
+	docker run --rm -w /v \
+		-v $(BACKENDS_DIR):/backends \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/backend-installers.tgz --exclude .git backends

--- a/static/Makefile
+++ b/static/Makefile
@@ -45,13 +45,13 @@ hash_files:
 	$(HASH_CMD) "$(DIR_TO_HASH)"
 
 .PHONY: cross-mac
-cross-mac: cross-all-cli cross-mac-plugins ## create tgz with darwin x86_64 client only
+cross-mac: cross-all-cli cross-mac-plugins cross-mac-backends ## create tgz with darwin x86_64 client only
 	mkdir -p build/mac/docker
 	cp $(CLI_DIR)/build/docker-darwin-amd64 build/mac/docker/docker
 	tar -C build/mac -c -z -f build/mac/docker-$(GEN_STATIC_VER).tgz docker
 
 .PHONY: cross-win
-cross-win: cross-all-cli cross-win-engine cross-win-plugins ## create zip file with windows x86_64 client and server
+cross-win: cross-all-cli cross-win-engine cross-win-plugins cross-win-backends ## create zip file with windows x86_64 client and server
 	mkdir -p build/win/docker
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/windows/amd64/dockerd-$(GEN_STATIC_VER).exe build/win/docker/dockerd.exe
@@ -100,5 +100,28 @@ cross-win-plugins: CLI_BUILD_DIR := win
 cross-win-plugins:
 	mkdir -p build/$(CLI_BUILD_DIR)/docker/cli-plugins
 	docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	$(CHOWN) -R $(shell id -u):$(shell id -g) build
+	find build/$(CLI_BUILD_DIR)/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;
+
+BUILD_BACKEND_RUN_VARS = --rm \
+	-e GOOS=$(SPOOF_GOOS) \
+	-v "$(CURDIR)/build/$(CLI_BUILD_DIR)/docker/cli-backends":/out \
+	-v "$(CURDIR)/../backends":/backends:ro \
+	-v "$(CURDIR)/scripts/build-cli-backends":/build:ro
+
+.PHONY: cross-mac-backends
+cross-mac-backends: SPOOF_GOOS := darwin
+cross-mac-backends: CLI_BUILD_DIR := mac
+cross-mac-backends:
+	mkdir -p build/$(CLI_BUILD_DIR)/docker
+	docker run $(BUILD_BACKEND_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	$(CHOWN) -R $(shell id -u):$(shell id -g) build
+
+.PHONY: cross-win-backends
+cross-win-backends: SPOOF_GOOS := windows
+cross-win-backends: CLI_BUILD_DIR := win
+cross-win-backends:
+	mkdir -p build/$(CLI_BUILD_DIR)/docker/cli-backends
+	docker run $(BUILD_BACKEND_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 	find build/$(CLI_BUILD_DIR)/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;

--- a/static/scripts/build-cli-backends
+++ b/static/scripts/build-cli-backends
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+shopt -s globstar
+
+# /backends should be volume mounted from root backends dir
+# /out should also be volume mounted from static/out/
+for installer in /backends/*.installer; do
+	bash "${installer}" build
+	DESTDIR='/out' PREFIX="/" bash "${installer}" install_backend
+done


### PR DESCRIPTION
Adding packaging for CLI backends next to CLI plugins.

Related to https://github.com/docker/cli/pull/2894 and https://github.com/docker/compose-cli/pull/1078
Fixes https://github.com/docker/dev-tooling-team/issues/250

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>