### PR TITLE
deb: add support for building debian 11 "Bullseye"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ test_steps = [
 				try {
 					checkout scm
 					sh "make REF=$branch checkout"
-					sh "make -C deb ubuntu-xenial ubuntu-focal"
+					sh "make -C deb ubuntu-xenial ubuntu-focal debian-bullseye"
 				} finally {
 					sh "make clean"
 				}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The scripts will build for this list of packages types:
 * DEB packages for Ubuntu 20.04 Focal
 * DEB packages for Ubuntu 18.04 Bionic
 * DEB packages for Ubuntu 16.04 Xenial
+* DEB packages for Debian 11 BullsEye
 * DEB packages for Debian 10 Buster
 * RPM packages for Fedora 33
 * RPM packages for Fedora 32

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -36,7 +36,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
 
-DEBIAN_VERSIONS ?= debian-buster
+DEBIAN_VERSIONS ?= debian-buster debian-bullseye
 UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-groovy
 RASPBIAN_VERSIONS ?= raspbian-buster
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -1,0 +1,36 @@
+ARG GO_IMAGE
+ARG DISTRO=debian
+ARG SUITE=bullseye
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
depends on:

- [x] https://github.com/docker/docker-ce-packaging/pull/520 deb: make dh-systemd dependency optional as it's deprecated
- [x] https://github.com/docker/containerd-packaging/pull/213 Jenkinsfile: test building Debian 11 "bullseye"
    - [x] https://github.com/docker/containerd-packaging/pull/212 deb: make dh-systemd dependency optional as it's deprecated 
    - [x] https://github.com/docker/containerd-packaging/pull/219 deb: keep '/var/lib/apt/lists/' to allow building for Debian unstable