### PR TITLE
deb: add support for building raspbian 11 "Bullseye"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,19 @@ test_steps = [
 			}
 		}
 	},
+	'raspbian': { ->
+		stage('Raspbian') {
+			wrappedNode(label: 'ubuntu && armhf', cleanWorkspace: true) {
+				try {
+					checkout scm
+					sh "make REF=$branch checkout"
+					sh "make -C deb raspbian-buster raspbian-bullseye"
+				} finally {
+					sh "make clean"
+				}
+			}
+		}
+	},
 	'rpm': { ->
 		stage('Centos 7 and 8 RPM Packages') {
 			wrappedNode(label: 'ubuntu && x86_64', cleanWorkspace: true) {

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -38,7 +38,7 @@ RUN?=docker run --rm \
 
 DEBIAN_VERSIONS ?= debian-buster
 UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-groovy
-RASPBIAN_VERSIONS ?= raspbian-buster
+RASPBIAN_VERSIONS ?= raspbian-buster raspbian-bullseye
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 
 .PHONY: help

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -1,0 +1,36 @@
+ARG GO_IMAGE
+ARG DISTRO=raspbian
+ARG SUITE=bullseye
+ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS apparmor seccomp selinux
+ENV RUNC_BUILDTAGS apparmor seccomp selinux
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
depends on:

- [x] https://github.com/docker/docker-ce-packaging/pull/520 deb: make dh-systemd dependency optional as it's deprecated
- [x] https://github.com/docker/containerd-packaging/pull/214 Jenkinsfile: test building Raspbian 11 "bullseye"
    - [x] https://github.com/docker/containerd-packaging/pull/212 deb: make dh-systemd dependency optional as it's deprecated 
    - [x] https://github.com/docker/containerd-packaging/pull/219 deb: keep '/var/lib/apt/lists/' to allow building for Debian unstable

This failed for me locally, but that was not on native arm, so adding a stage to the Jenkinsfile to test it in CI

```
---> Making bundle: dynbinary (in bundles/dynbinary)
/root/build-deb/engine/hack/make/.binary: line 6: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.go-autogen: line 21: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 43: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 43: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 43: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 43: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 74: /usr/local/go/bin/go: No such file or directory
/root/build-deb/engine/hack/make/.binary: line 74: /usr/local/go/bin/go: No such file or directory
Building: bundles/dynbinary-daemon/dockerd-0.0.0-20201222173220-2291f61
GOOS="" GOARCH="" GOARM=""
/root/build-deb/engine/hack/make/.binary: line 84: /usr/local/go/bin/go: No such file or directory
make[1]: *** [debian/rules:7: override_dh_auto_build] Error 127
make[1]: Leaving directory '/root/build-deb'
make: *** [debian/rules:68: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
make: *** [raspbian-bullseye] Error 2
```