### PR TITLE
[19.03 backport] Backport CentOS 8 changes 

### DIFF
--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -20,7 +20,9 @@ ENV SUITE=${SUITE}
 
 # In aarch64 (arm64) images, the altarch repo is specified as repository, but
 # failing, so replace the URL.
-RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
+RUN if [ -f /etc/yum.repos.d/CentOS-Linux-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Linux-Sources.repo; fi
+
+RUN if [ -f /etc/yum.repos.d/CentOS-Linux-PowerTools.repo ]; then sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo; fi
 
 # RHEL8 / CentOS 8 changed behavior and no longer "rpm --import" or
 # "rpmkeys --import"as part of rpm package's %post scriplet. See
@@ -28,7 +30,6 @@ RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/cento
 # https://access.redhat.com/solutions/3720351
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN yum install -y rpm-build rpmlint yum-utils
-RUN yum-config-manager --set-enabled PowerTools
 COPY SPECS /root/rpmbuild/SPECS
 RUN yum-builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -21,6 +21,12 @@ ENV SUITE=${SUITE}
 # In aarch64 (arm64) images, the altarch repo is specified as repository, but
 # failing, so replace the URL.
 RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
+
+# RHEL8 / CentOS 8 changed behavior and no longer "rpm --import" or
+# "rpmkeys --import"as part of rpm package's %post scriplet. See
+# https://forums.centos.org/viewtopic.php?f=54&t=72574, and
+# https://access.redhat.com/solutions/3720351
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN yum install -y rpm-build rpmlint yum-utils
 RUN yum-config-manager --set-enabled PowerTools
 COPY SPECS /root/rpmbuild/SPECS


### PR DESCRIPTION
Backports of #470 and #513

Attempt to fix https://ci-next.docker.com/teams-core/blue/organizations/jenkins/release-packaging/detail/ce-19.03/86/pipeline