### PR TITLE
Always require iptables for libnetwork

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -23,11 +23,7 @@ Requires: docker-ce-rootless-extras
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd
-%if 0%{?rhel} >= 8
-Requires: ( iptables or nftables )
-%else
 Requires: iptables
-%endif
 Requires: libcgroup
 Requires: containerd.io >= 1.4.1
 Requires: tar


### PR DESCRIPTION
Fix https://github.com/moby/moby/issues/41799.

`docker/libnetwork` depends on `iptables` user-space executable, which is not provided by `nftables` package for EL.
Hence, with the current RPM spec, some CentOS 8 installations fail to start Docker daemon, unless server admins explicitly install iptables.
In order to address the issue, this PR attempts to change the spec for `docker-ce` to always require `iptables`.