### PR TITLE
deb: change rootless-extras to "enhance", not "depend" on docker-ce

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -82,7 +82,8 @@ Description: Docker CLI: the open-source application container engine
 
 Package: docker-ce-rootless-extras
 Architecture: linux-any
-Depends: docker-ce, ${shlibs:Depends}
+Depends: ${shlibs:Depends}
+Enhances: docker-ce
 Conflicts: rootlesskit
 Replaces: rootlesskit
 Breaks: rootlesskit


### PR DESCRIPTION
Seen this error from a bug-report (https://github.com/containerd/containerd/issues/5175);

    dpkg: error processing package docker-ce (--configure):
     installed docker-ce package post-installation script subprocess returned error exit status 1
    dpkg: dependency problems prevent configuration of docker-ce-rootless-extras:
     docker-ce-rootless-extras depends on docker-ce; however:
      Package docker-ce is not configured yet.

    dpkg: error processing package docker-ce-rootless-extras (--configure):
     dependency problems - leaving unconfigured
    Errors were encountered while processing:
     docker-ce
     docker-ce-rootless-extras
    E: Sub-process /usr/bin/dpkg returned an error code (1)

Looking through the possible options in the debian documantion:
https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends

We could pick `Pre-Depends` to wait with installing until `docker-ce` is fully
installed and configured, but but that's quite a strong relation, and from the
documentation:

    unlike with Depends, Pre-Depends does not permit circular dependencies to be
    broken. If a circular dependency is encountered while attempting to honor
    Pre-Depends, the installation will be aborted.

To prevent installations from being aborted, I picked `Enhances`;

    Enhances
    This field is similar to Suggests but works in the opposite direction. It
    is used to declare that a package can enhance the functionality of another package.

