### PR TITLE
buildx: add add -ldflags=-linkmode=external to fix missing build-id warning

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -18,7 +18,7 @@ build() {
         git fetch --all
         git checkout -q "${BUILDX_COMMIT}"
         local LDFLAGS
-        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
+        LDFLAGS="-linkmode=external -X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
         set -x
         GOFLAGS=-mod=vendor go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
     )


### PR DESCRIPTION
I noticed this warning during a build in CI on https://github.com/docker/docker-ce-packaging/pull/530:

    warning: Missing build-id in /root/rpmbuild/BUILDROOT/docker-ce-cli-0.0.0.20210311145359.d3c36a2-0.el8.x86_64/usr/libexec/docker/cli-plugins/docker-buildx

And looks looks like we had that issue before at some point; rpm-software-management/rpm#367 (comment)

From that thread:

> OK one way is to use gccgo instead of go build, and the other way is to add -ldflags=-linkmode=external flag to go build.
>
> Still, by default (i.e. using go build) it doesn't do that and it's a problem.