### PR TITLE
deb/rpm: make bundles rule compatible with release-packaging arch format

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,6 +1,17 @@
 ARCH=$(shell uname -m)
-# if this fails on centos-based OS: yum install -y epel-release && yum install -y dpkg
-DPKG_ARCH=$(shell dpkg --print-architecture)
+
+# These are the architecture formats as used in release-packaging Jenkinsfile
+# This is an ugly chimera, nobody uses this combination of dpkg and uname formats
+# Why don't we pick one format and stick with it? Because at the time of writing
+# it was deemed too risky/involving too many changes across repos to change architecture
+# formats in release-packaging Jenkinsfile. But someone please do it.
+# Why do we need to list this here? Because I haven't been able to figure out how
+# to do Makefile rules with multiple patterns. (See how it's used in {deb,rpm}/Makefile)
+# Adding new architectures or changing the format in release-packaging will prevent make
+# from finding the corresponding rule unless this list is updated.
+# Or Jenkinsfiles/Makefiles removed (🎵 Gotta have faith-a-faith-a-faith... 🎵)
+ARCHES:=amd64 aarch64 armhf armel s390x ppc64le
+
 BUILDTIME=$(shell date -u -d "@$${SOURCE_DATE_EPOCH:-$$(date +%s)}" --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')
 CHOWN:=docker run --rm -v $(CURDIR):/v -w /v alpine chown
 DEFAULT_PRODUCT_LICENSE:=Community Engine

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -103,5 +103,8 @@ sources/plugin-installers.tgz: $(wildcard ../plugins/*)
 		alpine \
 		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins
 
-debbuild/bundles-ce-%-$(DPKG_ARCH).tar.gz: %
+# See ARCHES in common.mk. Could not figure out how to match both distro and arch.
+BUNDLES:=$(addsuffix .tar.gz,$(addprefix debbuild/bundles-ce-%-,$(ARCHES)))
+
+$(BUNDLES): %
 	tar czf $@ --transform="s|^debbuild/\(.*\)|bundles/$(VERSION)/build-deb/\1|" debbuild/$*

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -48,6 +48,7 @@ RHEL_RELEASES ?=
 endif
 
 DISTROS := $(FEDORA_RELEASES) $(CENTOS_RELEASES) $(RHEL_RELEASES)
+BUNDLES := $(patsubst %,rpmbuild/bundles-ce-%-$(DPKG_ARCH).tar.gz,$(DISTROS))
 
 .PHONY: help
 help: ## show make targets
@@ -114,5 +115,8 @@ rpmbuild/SOURCES/plugin-installers.tgz: $(wildcard ../plugins/*)
 		alpine \
 		tar -C / -c -z -f /v/plugin-installers.tgz --exclude .git plugins
 
-rpmbuild/bundles-ce-%-$(DPKG_ARCH).tar.gz: %
+# See ARCHES in common.mk. Could not figure out how to match both distro and arch.
+BUNDLES:=$(addsuffix .tar.gz,$(addprefix rpmbuild/bundles-ce-%-,$(ARCHES)))
+
+$(BUNDLES): %
 	tar czf $@ --transform="s|^rpmbuild/\(.*\)|bundles/$(VERSION)/build-rpm/\1|" rpmbuild/$*


### PR DESCRIPTION
See comment in common.mk

Signed-off-by: Tibor Vass <tibor@docker.com>

Related to https://github.com/docker/release-packaging/pull/569