### PR TITLE
Fix Fedora 34 Dockerfile to exclude scan-plugin on non-x86

### DIFF
--- a/rpm/fedora-34/Dockerfile
+++ b/rpm/fedora-34/Dockerfile
@@ -19,7 +19,15 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+
+# TODO change once we support scan-plugin on other architectures
+RUN \
+  if [ "$(uname -m)" = "x86_64" ]; then \
+    dnf builddep -y /root/rpmbuild/SPECS/*.spec; \
+  else \
+    dnf builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
+  fi
+
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>