### PR TITLE
deb/rpm: add forgotten Ubuntu hirsute and fedora-34 distros

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -40,7 +40,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS ?= debian-buster debian-bullseye
-UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-groovy
+UBUNTU_VERSIONS ?= ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-groovy ubuntu-hirsute
 RASPBIAN_VERSIONS ?= raspbian-buster raspbian-bullseye
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -47,7 +47,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-33 fedora-32
+FEDORA_RELEASES ?= fedora-34 fedora-33 fedora-32
 CENTOS_RELEASES ?= centos-7 centos-8
 ifeq ($(ARCH),s390x)
 RHEL_RELEASES ?= rhel-7


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

Follow up to https://github.com/docker/docker-ce-packaging/pull/533