### PR TITLE
mac: build arm64 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,5 @@ deb: checkout ## build deb packages
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm
 static: checkout ## build static-compiled packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) GO_VERSION=$(GO_VERSION) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) GO_VERSION=$(GO_VERSION) TARGETPLATFORM=$(TARGETPLATFORM) $${p}; \
 	done

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -10,8 +10,7 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh proxy dynamic
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 	# Build the CLI
-	cd /go/src/github.com/docker/cli && \
-		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) dynbinary manpages
+	cd /go/src/github.com/docker/cli && VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' GO_LINKMODE=dynamic ./scripts/build/binary && DISABLE_WARN_OUTSIDE_CONTAINER=1 LDFLAGS='' make manpages
 
 	# Build the scan-plugin
 	# TODO change once we support scan-plugin on other architectures

--- a/plugins/app.installer
+++ b/plugins/app.installer
@@ -18,7 +18,7 @@ build() {
         git fetch --all
         git checkout -q "${COMMIT}"
         # There's no real versions yet, but this'll just leave it blank
-        make dynamic
+        GO111MODULE=off make dynamic
     )
 }
 

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -51,7 +51,7 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -s ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
-DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages # cli
+VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} GO_LINKMODE=dynamic ./scripts/build/binary && DISABLE_WARN_OUTSIDE_CONTAINER=1 make manpages # cli
 popd
 
 # Build all associated plugins

--- a/static/Makefile
+++ b/static/Makefile
@@ -74,7 +74,7 @@ cross-arm: cross-all-cli ## create tgz with linux armhf client only
 
 .PHONY: static-cli
 static-cli:
-	$(MAKE) -C $(CLI_DIR) -f docker.Makefile VERSION=$(GEN_STATIC_VER) build
+	cd $(CLI_DIR) && VERSION=$(GEN_STATIC_VER) docker buildx bake --set binary.platform=$(TARGETPLATFORM) --set binary.args.CGO_ENABLED=$(CGO_ENABLED) binary
 
 .PHONY: static-engine
 static-engine:

--- a/static/Makefile
+++ b/static/Makefile
@@ -60,10 +60,10 @@ cross-mac: buildx cross-mac-plugins
 .PHONY: cross-win
 cross-win: cross-win-engine cross-win-plugins
 	cd $(CLI_DIR) && VERSION=$(GEN_STATIC_VER) docker buildx bake --set binary.platform=windows/amd64 binary
-	mkdir -p build/win/docker
-	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/docker/docker.exe
-	cp $(ENGINE_DIR)/bundles/cross/windows/amd64/dockerd-$(GEN_STATIC_VER).exe build/win/docker/dockerd.exe
-	docker run --rm -v $(CURDIR)/build/win:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
+	mkdir -p build/win/amd64/docker
+	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/amd64/docker/docker.exe
+	cp $(ENGINE_DIR)/bundles/cross/windows/amd64/dockerd-$(GEN_STATIC_VER).exe build/win/amd64/docker/dockerd.exe
+	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 
 .PHONY: cross-arm

--- a/static/Makefile
+++ b/static/Makefile
@@ -90,24 +90,29 @@ cross-win-engine:
 	$(MAKE) -C $(ENGINE_DIR) VERSION=$(GEN_STATIC_VER) DOCKER_CROSSPLATFORMS=windows/amd64 cross
 
 BUILD_PLUGIN_RUN_VARS = --rm \
-	-e GOOS=$(SPOOF_GOOS) \
-	-v "$(CURDIR)/build/$(CLI_BUILD_DIR)/docker/cli-plugins":/out \
+	-e GOOS \
+	-e GOARCH \
+	-v "$(CURDIR)/build/$(CLI_BUILD_DIR)/$*/docker/cli-plugins":/out \
 	-v "$(CURDIR)/../plugins":/plugins:ro \
 	-v "$(CURDIR)/scripts/build-cli-plugins":/build:ro
 
 .PHONY: cross-mac-plugins
-cross-mac-plugins: SPOOF_GOOS := darwin
-cross-mac-plugins: CLI_BUILD_DIR := mac
-cross-mac-plugins:
-	mkdir -p build/$(CLI_BUILD_DIR)/docker
-	docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
-	$(CHOWN) -R $(shell id -u):$(shell id -g) build
+cross-mac-plugins: cross-mac-plugins-amd64 cross-mac-plugins-arm64
+
+.PHONY: cross-mac-plugins-%
+cross-mac-plugins-%: CLI_BUILD_DIR := mac
+cross-mac-plugins-%:
+	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker
+	GOOS=darwin GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
 
 .PHONY: cross-win-plugins
-cross-win-plugins: SPOOF_GOOS := windows
-cross-win-plugins: CLI_BUILD_DIR := win
-cross-win-plugins:
-	mkdir -p build/$(CLI_BUILD_DIR)/docker/cli-plugins
-	docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
-	$(CHOWN) -R $(shell id -u):$(shell id -g) build
+cross-win-plugins: cross-win-plugins-amd64
+
+.PHONY: cross-win-plugins-%
+cross-win-plugins-%: CLI_BUILD_DIR := win
+cross-win-plugins-%:
+	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker/cli-plugins
+	GOOS=windows GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
 	find build/$(CLI_BUILD_DIR)/$*/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;

--- a/static/Makefile
+++ b/static/Makefile
@@ -5,8 +5,7 @@ ENGINE_DIR=$(realpath $(CURDIR)/../src/github.com/docker/docker)
 GEN_STATIC_VER=$(shell ./gen-static-ver $(CLI_DIR) $(VERSION))
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
-GO_VERSION=$(shell grep "ARG GO_VERSION" $(CLI_DIR)/dockerfiles/Dockerfile.dev | awk -F'=' '{print $$2}')
-DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
+DOCKER_CLI_PLUGIN_GOLANG_IMG=golang:1.16.3
 
 .PHONY: help
 help: ## show make targets
@@ -103,7 +102,7 @@ cross-mac-plugins: cross-mac-plugins-amd64 cross-mac-plugins-arm64
 cross-mac-plugins-%: CLI_BUILD_DIR := mac
 cross-mac-plugins-%:
 	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker
-	GOOS=darwin GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	GOOS=darwin GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_PLUGIN_GOLANG_IMG) /build
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
 
 .PHONY: cross-win-plugins
@@ -113,6 +112,6 @@ cross-win-plugins: cross-win-plugins-amd64
 cross-win-plugins-%: CLI_BUILD_DIR := win
 cross-win-plugins-%:
 	mkdir -p build/$(CLI_BUILD_DIR)/$*/docker/cli-plugins
-	GOOS=windows GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
+	GOOS=windows GOARCH=$* docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_PLUGIN_GOLANG_IMG) /build
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build/$(CLI_BUILD_DIR)/$*
 	find build/$(CLI_BUILD_DIR)/$*/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;

--- a/static/Makefile
+++ b/static/Makefile
@@ -44,14 +44,23 @@ hash_files:
 	@echo "Hashing directory $(DIR_TO_HASH)"
 	$(HASH_CMD) "$(DIR_TO_HASH)"
 
+.PHONY: buildx
+buildx:
+	docker buildx inspect | grep -q 'Driver: docker-container' || docker buildx create --use
+
 .PHONY: cross-mac
-cross-mac: cross-all-cli cross-mac-plugins ## create tgz with darwin x86_64 client only
-	mkdir -p build/mac/docker
-	cp $(CLI_DIR)/build/docker-darwin-amd64 build/mac/docker/docker
-	tar -C build/mac -c -z -f build/mac/docker-$(GEN_STATIC_VER).tgz docker
+cross-mac: buildx cross-mac-plugins
+	cd $(CLI_DIR) && VERSION=$(GEN_STATIC_VER) docker buildx bake --set binary.platform=darwin/amd64,darwin/arm64 binary
+	dest=$$PWD/build/mac; cd $(CLI_DIR)/build && for platform in *; do \
+		arch=$$(echo $$platform | cut -d_ -f2); \
+		mkdir -p $$dest/$$arch/docker; \
+		cp $$platform/docker-darwin-* $$dest/$$arch/docker/docker && \
+		tar -C $$dest/$$arch -c -z -f $$dest/$$arch/docker-$(GEN_STATIC_VER).tgz docker; \
+	done
 
 .PHONY: cross-win
-cross-win: cross-all-cli cross-win-engine cross-win-plugins ## create zip file with windows x86_64 client and server
+cross-win: cross-win-engine cross-win-plugins
+	cd $(CLI_DIR) && VERSION=$(GEN_STATIC_VER) docker buildx bake --set binary.platform=windows/amd64 binary
 	mkdir -p build/win/docker
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/windows/amd64/dockerd-$(GEN_STATIC_VER).exe build/win/docker/dockerd.exe
@@ -101,4 +110,4 @@ cross-win-plugins:
 	mkdir -p build/$(CLI_BUILD_DIR)/docker/cli-plugins
 	docker run $(BUILD_PLUGIN_RUN_VARS) $(DOCKER_CLI_GOLANG_IMG) /build
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
-	find build/$(CLI_BUILD_DIR)/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;
+	find build/$(CLI_BUILD_DIR)/$*/docker -type f -not -name "*.exe" -exec mv {} {}.exe \;


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This PR uses golang 1.16 In order to build plugins for darwin/arm64.
However, docker app plugin does not build with go 1.16 (could not figure out how to disable go modules), and it was meant to be removed anyway.
ARM binaries had issues building with cgo, so as a workaround, this PR sets CGO_ENABLED=0 for arm (32 bit, aka armel/armhf) binaries only.

Related:
- https://github.com/docker/cli/pull/2993
- https://github.com/docker/release-packaging/pull/574
- https://github.com/docker/release-packaging/pull/568
- https://github.com/docker/release-repo/pull/575