### PR TITLE
[20.10 backport] rpm: scan-cli-plugin: fix build-time "version" and "commit" variables

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -7,6 +7,7 @@ GEN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/
 GEN_SCAN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) "$(DOCKER_SCAN_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
+SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
@@ -33,7 +34,9 @@ RPMBUILD_FLAGS?=-ba\
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
-	--define '_scan_version $(word 1,$(GEN_SCAN_RPM_VER))' \
+	--define '_scan_rpm_version $(word 1,$(GEN_SCAN_RPM_VER))' \
+	--define '_scan_version $(word 4,$(GEN_SCAN_RPM_VER))' \
+	--define '_scan_gitcommit $(SCAN_GITCOMMIT)' \
 	$(RPMBUILD_EXTRA_FLAGS) \
 	$(SPECS)
 

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name: docker-scan-plugin
-Version: %{_scan_version}
+Version: %{_scan_rpm_version}
 Release: %{_release}%{?dist}
 Epoch: 0
 Source0: scan-cli-plugin.tgz
@@ -26,7 +26,7 @@ Docker Scan plugin for the Docker CLI.
 
 %build
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin
-bash -c 'GOPROXY="https://proxy.golang.org" PLATFORM_BINARY=docker-scan make native-build'
+bash -c 'GOPROXY="https://proxy.golang.org" TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
 popd
 
 


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/549

When building rpm (and deb) packages, binaries are built from a source tarball.
Source tarballs will only include the raw source code, but do not include the
git repository; https://github.com/docker/docker-ce-packaging/blob/c4c2d89b4e22ff484b08f138ca05b6098077590c/rpm/Makefile#L110-L116

    tar -C / -c -z -f /v/scan-cli-plugin.tgz --exclude .git scan-cli-plugin

Because of this, the makefile used to build the scan-cli-plugin binaries will
not be able to determine the "commit" (and version) to set as build-time variable
to include in the `--version` output; https://github.com/docker/scan-cli-plugin/blob/3eaac3e88412543fb18767feb697e11dca21d20f/builder.Makefile#L5-L19
resulting in both `version` and `git commit` to be empty in the version output:

    docker scan --version
    Version:
    Git commit:
    Provider:   Snyk (1.563.0 (standalone))

This patch updates the RPM spec to add variables for passing this information,
and collects the commit and version from the host to pass it to the build-
container in which the RPMs are built, similar to how  they're passed for the
equivalent "deb" build-containers (which use env-vars for this);
https://github.com/docker/docker-ce-packaging/blob/c4c2d89b4e22ff484b08f138ca05b6098077590c/deb/Makefile#L36-L37

Before:

    docker scan --version
    Version:
    Git commit:
    Provider:   Snyk (1.563.0 (standalone))

    docker info
    Client:
     Context:    default
     Debug Mode: false
     Plugins:
      app: Docker App (Docker Inc., v0.9.1-beta3)
      buildx: Build with BuildKit (Docker Inc., v0.5.1-docker)
      scan: Docker Scan (Docker Inc.)
    ...

After:

    docker scan --version
    Version:    v0.8.0
    Git commit: 35651ca
    Provider:   Snyk (1.563.0 (standalone))

    docker info

    Client:
     Context:    default
     Debug Mode: false
     Plugins:
      app: Docker App (Docker Inc., v0.9.1-beta3)
      buildx: Build with BuildKit (Docker Inc., v0.5.1-docker)
      scan: Docker Scan (Docker Inc., v0.8.0)
    ...

(cherry picked from commit 20c5feedcbbef5dc045fa2e987d9c3be5e86e2ac)
