### PR TITLE
Add checks for binary versions set through build-time variables

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -30,8 +30,15 @@ override_dh_auto_build:
 		done
 
 override_dh_auto_test:
-	./engine/bundles/dynbinary-daemon/dockerd -v
-	./cli/build/docker -v
+	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
+		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($$ver) did not match"
+
+	ver="$$(cli/build/docker --version)"; \
+		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || echo "FAIL: cli version ($$ver) did not match"
+
+	# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
+	ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+		test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($$ver) did not match"
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -64,8 +64,9 @@ done
 popd
 
 
-# %check
-# cli/build/docker -v
+%check
+ver="$(cli/build/docker --version)"; \
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || echo "FAIL: cli version ($ver) did not match"
 
 %install
 # install binary

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -86,7 +86,8 @@ VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 
 %check
-engine/bundles/dynbinary-daemon/dockerd -v
+ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($ver) did not match"
 
 %install
 # install daemon binary

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -31,9 +31,10 @@ popd
 
 
 %check
-# FIXME: --version currently doesn't work as it makes a connection to the daemon
+# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 #${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan scan --accept-license --version
-${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan --help
+ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
+	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($ver) did not match"
 
 %install
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin


### PR DESCRIPTION
relates to https://github.com/docker/docker-ce-packaging/pull/549

Make sure that these versions are set, and match the expected versions

DEB:

       debian/rules override_dh_auto_test
    make[1]: Entering directory '/root/build-deb'
    ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
        test "$ver" = "Docker version 0.0.0-20210531142756-1c174ced, build 7c6a9484" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($ver) did not match"
    PASS: daemon version OK
    ver="$(cli/build/docker --version)"; \
        test "$ver" = "Docker version 0.0.0-20210531142756-1c174ced, build 1c174ced" && echo "PASS: cli version OK" || echo "FAIL: cli version ($ver) did not match"
    PASS: cli version OK
    # FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
    ver="$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
        test "$ver" = "v0.8.0" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($ver) did not match"
    PASS: docker-scan version OK

RPM:

    Executing(%check): /bin/sh -e /var/tmp/rpm-tmp.SIDNvr
    + umask 022
    + cd /root/rpmbuild/BUILD
    + cd src
    ++ engine/bundles/dynbinary-daemon/dockerd --version
    + ver='Docker version 0.0.0-20210531142756-1c174ced, build 7c6a9484'
    + test 'Docker version 0.0.0-20210531142756-1c174ced, build 7c6a9484' = 'Docker version 0.0.0-20210531142756-1c174ced, build 7c6a9484'
    + echo 'PASS: daemon version OK'
    + exit 0
    PASS: daemon version OK
    ...

    Executing(%check): /bin/sh -e /var/tmp/rpm-tmp.jKzBxw
    + umask 022
    + cd /root/rpmbuild/BUILD
    + cd src
    ++ cli/build/docker --version
    PASS: cli version OK
    + ver='Docker version 0.0.0-20210531142756-1c174ced, build 1c174ced'
    + test 'Docker version 0.0.0-20210531142756-1c174ced, build 1c174ced' = 'Docker version 0.0.0-20210531142756-1c174ced, build 1c174ced'
    + echo 'PASS: cli version OK'
    + exit 0
    ...
    Executing(%check): /bin/sh -e /var/tmp/rpm-tmp.5KN9vp
    + umask 022
    + cd /root/rpmbuild/BUILD
    + cd src
    ++ /root/rpmbuild/BUILDROOT/docker-scan-plugin-0.8.0-0.el8.x86_64/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata
    ++ awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }'
    PASS: docker-scan version OK
    + ver=v0.8.0
    + test v0.8.0 = v0.8.0
    + echo 'PASS: docker-scan version OK'
    + exit 0

