### PR TITLE
buildx: remove "-docker" suffix from version

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -18,7 +18,7 @@ build() {
         git fetch --all
         git checkout -q "${BUILDX_COMMIT}"
         local LDFLAGS
-        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
+        LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags) -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
         set -x
         GOFLAGS=-mod=vendor go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
     )


### PR DESCRIPTION
When building the CLI plugin, we were adding a "-docker" suffix. It's a bit
unclear if there was a specific reason for this (possibly to differentiate
between builds from GitHub and builds that are part of the CLI?

Initially, the version had a `-tp-docker` prefix (where `-tp` was used to
indicate it was still experimental); this prefix was removed in commit
0b45cce1abcf8868f4d957317a839f1e80058607 (https://github.com/docker/docker-ce-packaging/pull/490)

    /usr/libexec/docker/cli-plugins/docker-buildx docker-cli-plugin-metadata
    {
         "SchemaVersion": "0.1.0",
         "Vendor": "Docker Inc.",
         "Version": "v0.5.1-docker",
         "ShortDescription": "Build with BuildKit"
    }

This patch removes the `-docker` suffix from the version string.
