### PR TITLE
[master]: deb/rpm define dependencies between docker-ce-cli and docker-compose-plugin

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -63,7 +63,8 @@ Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
 # TODO change once we support scan-plugin on other architectures
-Recommends: docker-scan-plugin [amd64]
+Recommends: docker-compose-plugin,
+            docker-scan-plugin [amd64]
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker-engine-cs,

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -16,6 +16,17 @@ Packager: Docker <support@docker.com>
 # required packages on install
 Requires: /bin/sh
 Requires: /usr/sbin/groupadd
+
+# CentOS 7 and RHEL 7 do not yet support weak dependencies
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} == 7
+Requires: docker-compose-plugin
+%else
+Recommends: docker-compose-plugin
+%endif
+
 # TODO change once we support scan-plugin on other architectures
 %ifarch x86_64
 # CentOS 7 and RHEL 7 do not yet support weak dependencies

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -12,6 +12,14 @@ URL: https://github.com/docker/compose/
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
+# CentOS 7 and RHEL 7 do not yet support weak dependencies.
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} != 7
+Enhances: docker-ce-cli
+%endif
+
 BuildRequires: bash
 
 %description


### PR DESCRIPTION
Follow-up to https://github.com/docker/docker-ce-packaging/pull/553

With this change, the compose-cli-plugin will automatically be installed as dependency of the cli.

### deb: add docker-compose-plugin as "recommends"

This adds a "weak" dependency on the docker-compose-plugin, per the
recommendations in https://debian-handbook.info/browse/stable/sect.package-meta-information.html#id-1.8.6.7.10.10

The "recommends" dependency will be installed by default, but does allow users to opt-out
using `--no-install-recommends` to perform a lightweight installation for setups that only
need basic functionality of docker;

> (...) the “recommended” dependencies, the most important, considerably improve
> the functionality offered by the package but are not indispensable to its operation.
> (...) You should always install the “recommended” packages, unless you know exactly
> why you do not need them. This is now also the default for APT unless configured
> otherwise.

### rpm: add docker-compose-plugin as "recommends" / "requires"

This defines the dependency between the docker cli and compose (as a plugin). RHEL8
and CentOS 8 (and up) support weak dependencies;

- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software#support-for-weak-dependencies_new-features-in-rhel-8
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/packaging_and_distributing_software/new-features-in-rhel-8_packaging-and-distributing-software#boolean-dependencies-syntax

But CentOS 7 and RHEL 7 do not yet support this, so for those, we use "Requires",
using the `%rhel` macro for detection, which also works on CentOS:

    rpm --eval '%{rhel}'
    7

Making the dependency _recommended_ will install it by default, but users _are_ able
to opt-out explicitly, using `--setopt=install_weak_deps=False`, for example, to
perform a light-weight installation that does not require all features of Docker.

