### PR TITLE
Fix binary version checks masking failure exit code

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -30,14 +30,17 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
-		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($$ver) did not match"
+		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($$ver) did not match" && exit 1)
 
 	ver="$$(cli/build/docker --version)"; \
-		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || echo "FAIL: cli version ($$ver) did not match"
+		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || (echo "FAIL: cli version ($$ver) did not match" && exit 1)
 
 	# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
-	ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
-		test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($$ver) did not match"
+	# TODO change once we support scan-plugin on other architectures
+	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
+		ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+			test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($$ver) did not match" && exit 1); \
+	fi
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -66,7 +66,7 @@ popd
 
 %check
 ver="$(cli/build/docker --version)"; \
-    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || echo "FAIL: cli version ($ver) did not match"
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || (echo "FAIL: cli version ($ver) did not match" && exit 1)
 
 %install
 # install binary

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -86,7 +86,7 @@ popd
 
 %check
 ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
-    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($ver) did not match"
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($ver) did not match" && exit 1)
 
 %install
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) ${RPM_BUILD_ROOT}%{_bindir}/dockerd

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -34,7 +34,7 @@ popd
 # FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 #${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan scan --accept-license --version
 ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
-	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($ver) did not match"
+	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($ver) did not match" && exit 1)
 
 %install
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin


### PR DESCRIPTION
Commit 928a8f2b578a782f902b64d223f06ff423afd736 (https://github.com/docker/docker-ce-packaging/pull/551) added a check for binary set through build-time variables, but I messed up, and forgot to add a non-zero exit code. As a result the exit code was the exit code of the "echo", which would always be successful.

This also revealed a missing check for "target architecture": the scan cli plugin is only built on x86, so the version check should not be performed on other architectures.

relates to https://github.com/docker/docker-ce-packaging/pull/553#issuecomment-873409190