### PR TITLE
[20.10] Add libarchive build-dep to fix missing archive_write_add_filter_zstd

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -37,6 +37,7 @@ BuildRequires: device-mapper-devel
 BuildRequires: gcc
 BuildRequires: git
 BuildRequires: glibc-static
+BuildRequires: libarchive
 BuildRequires: libseccomp-devel
 BuildRequires: libselinux-devel
 BuildRequires: libtool


### PR DESCRIPTION
taken from https://github.com/docker/docker-ce-packaging/pull/554


Trying to fix

    + echo 'Install tini version de40ad007797e0dcd8b7126f27bb87401d224240'
    + git clone https://github.com/krallin/tini.git /go/tini
    Install tini version de40ad007797e0dcd8b7126f27bb87401d224240
    Cloning into '/go/tini'...
    + cd /go/tini
    + git checkout -q de40ad007797e0dcd8b7126f27bb87401d224240
    + cmake .
    cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd
    error: Bad exit status from /var/tmp/rpm-tmp.Dl5CDf (%build)

According to https://bugs.centos.org/view.php?id=18212, upgrading to libarchive-3.3.3-1.el8.x86_64
should resolve the problem.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 78242140d7f85863e8a8e3a133f3ebf73b9596ca)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>