### PR TITLE
[20.10 backport] update buildx to v0.6.1

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.5.1}"
+: "${BUILDX_COMMIT=v0.6.0}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {

--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -20,7 +20,7 @@ build() {
         local LDFLAGS
         LDFLAGS="-X ${PKG}/version.Version=$(git describe --match 'v[0-9]*' --always --tags)-docker -X ${PKG}/version.Revision=$(git rev-parse HEAD) -X ${PKG}/version.Package=${PKG}"
         set -x
-        GOFLAGS=-mod=vendor go build -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
+        GO111MODULE=on go build -mod=vendor -o bin/docker-buildx -ldflags "${LDFLAGS}" ./cmd/buildx
     )
 }
 

--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.6.0}"
+: "${BUILDX_COMMIT=v0.6.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/561 and https://github.com/docker/docker-ce-packaging/pull/565

release notes: https://github.com/docker/buildx/releases/tag/v0.6.0