### PR TITLE
[20.10 backport] update buildx to v0.6.3

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.6.2}"
+: "${BUILDX_COMMIT=v0.6.3}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {

--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.6.1}"
+: "${BUILDX_COMMIT=v0.6.2}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
cherry-pick of https://github.com/docker/docker-ce-packaging/pull/569 and https://github.com/docker/docker-ce-packaging/pull/579

release notes: https://github.com/docker/buildx/releases/tag/v0.6.2

- Fix connection error showing up in some SSH configurations

release notes: https://github.com/docker/buildx/releases/tag/v0.6.3

- Fix buildkit state volume location for Windows clients
