### PR TITLE
[20.10] fix systemd startup order

### DIFF
--- a/systemd/docker.service
+++ b/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target firewalld.service containerd.service
+After=network-online.target docker.socket firewalld.service containerd.service
 Wants=network-online.target
 Requires=docker.socket containerd.service
 


### PR DESCRIPTION
This applies the same fix as was added in https://github.com/docker/docker/commit/fe68df36fc9c85ae30af9bf53a13e8af0534e613, to address https://github.com/docker/for-linux/issues/989#issuecomment-911857268

The systemd unit only contained a `Requires=` for the `docker.socket`, but failed
to add it to `After=`. The `Requires=` option only defines that a dependency
must be present, but does not influence startup order. From the systemd docs:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=

> Wants=
>
> (..)
> Note that requirement dependencies do not influence the order in which services
> are started or stopped. This has to be configured independently with the `After=`
> or `Before=` options. (...)

As a result, the `docker` service could start before the socket was created, and
would fail to start.
