### PR TITLE
Add workaround for CentOS 7 not working without GOPROXY

### DIFF
--- a/plugins/scan.installer.disabled
+++ b/plugins/scan.installer.disabled
@@ -19,10 +19,9 @@ build() {
             git fetch --all
             git checkout -q "${COMMIT}"
         fi
-        # TODO remove GOPROXY override once we updated to Go 1.14+
         # Using goproxy instead of "direct" to work around an issue in go mod
-        # on Go 1.13 not working with older git versions (default version on
-        # CentOS 7 is git 1.8), see https://github.com/golang/go/issues/38373
+        # not working with older git versions (default version on CentOS 7 is
+        # git 1.8), see https://github.com/golang/go/issues/38373
         GOPROXY="https://proxy.golang.org" PLATFORM_BINARY=docker-scan TAG_NAME="${COMMIT}" make native-build
     )
 }

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -39,7 +39,10 @@ Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
 export DOCKER_GITCOMMIT=%{_gitcommit_engine}
 mkdir -p /go/src/github.com/docker
 ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
-TMP_GOPATH="/go" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
+# Using goproxy instead of "direct" to work around an issue in go mod not
+# working with older git versions (default version on CentOS 7 is git 1.8),
+# see https://github.com/golang/go/issues/38373
+TMP_GOPATH="/go" GOPROXY="https://proxy.golang.org" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
 
 %check
 /usr/local/bin/rootlesskit -v

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -26,6 +26,9 @@ Docker Scan plugin for the Docker CLI.
 
 %build
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin
+# Using goproxy instead of "direct" to work around an issue in go mod not
+# working with older git versions (default version on CentOS 7 is git 1.8),
+# see https://github.com/golang/go/issues/38373
 bash -c 'GOPROXY="https://proxy.golang.org" TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
 popd
 


### PR DESCRIPTION
This fix was previously included in the rootlesskit install script
in moby, but should've been addressed by Go 1.14 and up. Unfortunately,
this does not appear the case, and go modules without proxy is still
broken on older versions of git, such as the version of git used by
CentOS 7.


relates to:

- https://github.com/docker/docker-ce-packaging/pull/553#issuecomment-913410815
- https://github.com/moby/moby/commit/3cec4b8cd42179e67dcfdda2adce03516c6a5cd1 (https://github.com/moby/moby/pull/42674)
- https://github.com/golang/go/issues/38373