### PR TITLE
[master] update buildx to v0.6.3

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.6.2}"
+: "${BUILDX_COMMIT=v0.6.3}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.6.3

- Fix buildkit state volume location for Windows clients
