### PR TITLE
[20.10 backport] static: add option to specify containerd and runc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,5 @@ deb: checkout ## build deb packages
 static: DOCKER_BUILD_PKGS:=static-linux cross-mac cross-win cross-arm
 static: checkout ## build static-compiled packages
 	for p in $(DOCKER_BUILD_PKGS); do \
-		$(MAKE) -C $@ VERSION=$(VERSION) GO_VERSION=$(GO_VERSION) TARGETPLATFORM=$(TARGETPLATFORM) $${p}; \
+		$(MAKE) -C $@ VERSION=$(VERSION) GO_VERSION=$(GO_VERSION) TARGETPLATFORM=$(TARGETPLATFORM) CONTAINERD_VERSION=$(CONTAINERD_VERSION) RUNC_VERSION=$(RUNC_VERSION) $${p}; \
 	done

--- a/static/Makefile
+++ b/static/Makefile
@@ -7,6 +7,25 @@ HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
 
+DOCKER_BUILD_OPTS=
+
+ifneq ($(strip $(CONTAINERD_VERSION)),)
+# Set custom build-args to override the containerd version to build for static
+# packages. The Dockerfile for 20.10 and earlier used CONTAINERD_COMMIT, later
+# versions use CONTAINERD_VERSION. We can remove CONTAINERD_VERSION once 20.10.x
+# reaches EOL.
+DOCKER_BUILD_OPTS +=--build-arg=CONTAINERD_VERSION=$(CONTAINERD_VERSION)
+DOCKER_BUILD_OPTS +=--build-arg=CONTAINERD_COMMIT=$(CONTAINERD_VERSION)
+endif
+
+ifneq ($(strip $(RUNC_VERSION)),)
+# Set custom build-args to override the runc version to build for static packages.
+# The Dockerfile for 20.10 and earlier used RUNC_COMMIT, later versions use
+# RUNC_VERSION. We can remove RUNC_COMMIT once 20.10.x reaches EOL.
+DOCKER_BUILD_OPTS +=--build-arg=RUNC_VERSION=$(RUNC_VERSION)
+DOCKER_BUILD_OPTS +=--build-arg=RUNC_COMMIT=$(RUNC_VERSION)
+endif
+
 .PHONY: help
 help: ## show make targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -78,7 +97,7 @@ static-cli:
 
 .PHONY: static-engine
 static-engine:
-	$(MAKE) -C $(ENGINE_DIR) VERSION=$(GEN_STATIC_VER) binary
+	$(MAKE) -C $(ENGINE_DIR) VERSION=$(GEN_STATIC_VER) DOCKER_BUILD_OPTS="$(DOCKER_BUILD_OPTS)" binary
 
 .PHONY: cross-all-cli
 cross-all-cli:
@@ -86,7 +105,7 @@ cross-all-cli:
 
 .PHONY: cross-win-engine
 cross-win-engine:
-	$(MAKE) -C $(ENGINE_DIR) VERSION=$(GEN_STATIC_VER) DOCKER_CROSSPLATFORMS=windows/amd64 cross
+	$(MAKE) -C $(ENGINE_DIR) VERSION=$(GEN_STATIC_VER) DOCKER_CROSSPLATFORMS=windows/amd64 DOCKER_BUILD_OPTS="$(DOCKER_BUILD_OPTS)" cross
 
 BUILD_PLUGIN_RUN_VARS = --rm \
 	-e GOOS \


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/583

This allows passing `CONTAINERD_VERSION` and `RUNC_VERSION` make vars to override the default version in the upstream repository's Dockerfile.

With this, it's easier to make the static packages match the latest released `containerd.io` deb/rpm (which are used by the .deb and .rpm docker-ce packages), without having to modify the upstream moby repository.

Currently, this uses the DOCKER_BUILD_OPTS make variable, which is available in the moby Makefile, but work is in progress to add `CONTAINERD_VERSION` and `RUNC_VERSION` make variables in the upstream repository. Once those changes are merged, we can update the makefile in this repository accordingly.

With this patch:

If `RUNC_VERSION` and `CONTAINERD_VERSION` are not passed, the defaults are used:

    $ make \
        DOCKER_BUILD_PKGS=static-linux \
        REF=v20.10.8 \
        VERSION=v20.10.8 \
        static

    $ docker run --rm -v $(pwd)/static/build/linux/docker/:/docker alpine sh -c '/docker/containerd --version && /docker/runc --version'
    containerd github.com/containerd/containerd v1.4.9 e25210fe30a0a703442421b0f60afac609f950a3
    runc version 1.0.1
    commit: v1.0.1-0-g4144b638
    spec: 1.0.2-dev
    go: go1.16.8
    libseccomp: 2.4.4

Passing the `RUNC_VERSION` and `CONTAINERD_VERSION` vars overrides the version
of containerd and runc:

    $ make \
        DOCKER_BUILD_PKGS=static-linux \
        REF=v20.10.8 \
        VERSION=v20.10.8 \
        RUNC_VERSION=v1.0.2 \
        CONTAINERD_VERSION=v1.4.10 \
        static

    $ docker run --rm -v $(pwd)/static/build/linux/docker/:/docker alpine sh -c '/docker/containerd --version && /docker/runc --version'
    containerd github.com/containerd/containerd v1.4.10 8848fdb7c4ae3815afcc990a8a99d663dda1b590
    runc version 1.0.2
    commit: v1.0.2-0-g52b36a2d
    spec: 1.0.2-dev
    go: go1.16.8
    libseccomp: 2.4.4
