### PR TITLE
[20.10 backport] deb: force dpkg-build to use xz compression instead of zstd

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -3,6 +3,11 @@
 VERSION ?= $(shell cat engine/VERSION)
 TARGET_ARCH = $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 
+# force packages to be built with xz compression, as Ubuntu 21.10 and up use
+# zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_build:
 	# Build the daemon and dependencies
 	cd engine && DOCKER_GITCOMMIT=$(ENGINE_GITCOMMIT) PRODUCT=docker ./hack/make.sh dynbinary


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/588

relates to https://github.com/docker/containerd-packaging/pull/257
relates to https://github.com/docker/docker-ce-packaging/pull/585


Ubuntu 21.10 switched the default compression for .deb packages to use zstd.
While this change may bring some performance improvement, it is non-standard,
and not all deb-related tooling currently support zstd compression. One of those
tools, dpkg-sig, has not (yet) been modified to support zstd compression; we use
this tool to sign our packages (and verify that packages are signed), which
currently fails if packages use zstd compression;

    dpkg-sig --verify ./containerd.io_1.4.11-1_amd64.deb
    Processing ./containerd.io_1.4.11-1_amd64.deb...
    BADSIG _gpgbuilder

It should be noted that signing individual packages is *optional* [1], and that
dpkg-sig has not received updates since 2006 [2] (possibly better replaced with
debsigs / debsig-verify), but changing would be a potential breaking change, as
these tools are not interchangeable [3]

[1]: https://www.debian.org/doc/manuals/securing-debian-manual/deb-pack-sign.en.html
[2]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995113
[3]: https://raphaelhertzog.com/2010/09/17/how-to-create-debian-packages-with-alternative-compression-methods/

This patch hard-codes the compression to use in the debian rules, instead of using
the default that's used by the distro.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 0f4c193dfaf6bcb1d4d6c07470cd4f67a9a146d0)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>