### PR TITLE
[20.10 backport] Require `dbus-user-session` for rootless

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -85,7 +85,8 @@ Description: Docker CLI: the open-source application container engine
 
 Package: docker-ce-rootless-extras
 Architecture: linux-any
-Depends: ${shlibs:Depends}
+Depends: dbus-user-session,
+         ${shlibs:Depends}
 Enhances: docker-ce
 Conflicts: rootlesskit
 Replaces: rootlesskit

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -13,6 +13,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: docker-ce
+# TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
 # slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
 Requires: slirp4netns >= 0.4
 # fuse-overlayfs >= 0.7 is available in the all supported versions of CentOS and Fedora.


### PR DESCRIPTION
Backport https://github.com/docker/docker-ce-packaging/pull/571

---
On Debian, `dbus-user-session` is not installed by default.
The lack of `dbus-user-session` results in a cryptic error on rootless+cgroup2+systemd:
`read unix @->/run/systemd/private: read: connection reset by peer: unknown.`

ref: moby/moby#42793
