### PR TITLE
[20.10 backport] upgrade docker scan to v0.17.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -36,7 +36,7 @@ DOCKER_SCAN_REPO   ?= https://github.com/docker/scan-cli-plugin.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_SCAN_REF    ?= v0.16.0
+DOCKER_SCAN_REF    ?= v0.17.0
 
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE

--- a/plugins/scan.installer.disabled
+++ b/plugins/scan.installer.disabled
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/scan-cli-plugin
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-COMMIT=v0.16.0
+COMMIT=v0.17.0
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/624

- Bump snyk 1.827.0
