### PR TITLE
[master] rpm/centos-8: some small fix-ups

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
 
 def pkgs = [
     [target: "centos-7",                 image: "centos:7",                               arches: ["amd64", "aarch64"]],          // (EOL: June 30, 2024)
-    [target: "centos-8",                 image: "centos:8",                               arches: ["amd64", "aarch64"]],
+    [target: "centos-8",                 image: "quay.io/centos/centos:stream8",          arches: ["amd64", "aarch64"]],
     [target: "debian-buster",            image: "debian:buster",                          arches: ["amd64", "aarch64", "armhf"]], // Debian 10 (EOL: 2024)
     [target: "debian-bullseye",          image: "debian:bullseye",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
     [target: "fedora-34",                image: "fedora:34",                              arches: ["amd64", "aarch64"]],          // EOL: May 17, 2022

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -1,7 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=centos
-ARG SUITE=stream8
-ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:${SUITE}
+ARG SUITE=8
+ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}
 
 FROM ${GO_IMAGE} AS golang
 


### PR DESCRIPTION
Some small fix-ups after https://github.com/docker/docker-ce-packaging/pull/621

### rpm/centos-8: adjust SUITE variable to keep it the same as before

This was a bit of an  oversight in https://github.com/docker/docker-ce-packaging/commit/49ff9113494665d7aff0496a6aacf54a96bc344a; when checking if the `$SUITE` variable was used elsewhere, I searched for `$SUITE`, and not for `${SUITE}`. While it looks like the variable is not used for any of the rpm-related build-scripts, it _is_ used in deb-related scripts.

Let's change it back to the previous value; just in case it will be used somewhere and causing side-effects.


### Jenkinsfile: use quay.io/centos/centos:stream8 as well

The `image` field in the Jenkinsfile is not really used in this repository (other than to name the stage), but in our internal pipeline, the equivalent is used for some validation steps (to be upstreamed to this repository).

Let's update the Jenkinsfile to match our internal one, and to make sure we don't forget updating it when we upstream some of those validation steps.

Relates to https://github.com/docker/docker-ce-packaging/commit/49ff9113494665d7aff0496a6aacf54a96bc344a
