### PR TITLE
[20.10 backport] CentOS 7: use go-proxy to work around old git version

### DIFF
--- a/plugins/scan.installer.disabled
+++ b/plugins/scan.installer.disabled
@@ -19,10 +19,7 @@ build() {
             git fetch --all
             git checkout -q "${COMMIT}"
         fi
-        # Using goproxy instead of "direct" to work around an issue in go mod
-        # not working with older git versions (default version on CentOS 7 is
-        # git 1.8), see https://github.com/golang/go/issues/38373
-        GOPROXY="https://proxy.golang.org" PLATFORM_BINARY=docker-scan TAG_NAME="${COMMIT}" make native-build
+        PLATFORM_BINARY=docker-scan TAG_NAME="${COMMIT}" make native-build
     )
 }
 

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -39,10 +39,7 @@ Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
 export DOCKER_GITCOMMIT=%{_gitcommit_engine}
 mkdir -p /go/src/github.com/docker
 ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
-# Using goproxy instead of "direct" to work around an issue in go mod not
-# working with older git versions (default version on CentOS 7 is git 1.8),
-# see https://github.com/golang/go/issues/38373
-TMP_GOPATH="/go" GOPROXY="https://proxy.golang.org" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
+TMP_GOPATH="/go" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
 
 %check
 /usr/local/bin/rootlesskit -v

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -26,10 +26,7 @@ Docker Scan plugin for the Docker CLI.
 
 %build
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin
-# Using goproxy instead of "direct" to work around an issue in go mod not
-# working with older git versions (default version on CentOS 7 is git 1.8),
-# see https://github.com/golang/go/issues/38373
-bash -c 'GOPROXY="https://proxy.golang.org" TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
+bash -c 'TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
 popd
 
 

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -6,7 +6,12 @@ ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+
+# Using goproxy instead of "direct" to work around an issue in go mod
+# not working with older git versions (default version on CentOS 7 is
+# git 1.8), see https://github.com/golang/go/issues/38373, and
+# https://github.com/docker/docker-ce-packaging/pull/631#issuecomment-1059363763
+ENV GOPROXY=https://proxy.golang.org
 ENV GO111MODULE=off
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/635 for the 20.10 branch. Not strictly needed currently, but just in case go modules acts up again 🤣 

CentOS 7 comes with a very old (1.8) version of git, which is not compatible
with go modules. We previously applied this fix to individual build scripts
for rootless-extras and the scan-cli-plugin, but now that other bits are
failing as well, lets move this to the Dockerfile for this distro, so that
for other distros we can use "direct" and fetch from GitHub.

Without this, the build of docker/cli (master branch) failed with:

    + ./scripts/vendor init
    + go mod edit -modfile=vendor.mod -require=github.com/cpuguy83/go-md2man/v2@v2.0.1
    + cp man/tools.go .
    + ./scripts/vendor update
    + go mod tidy -modfile=vendor.mod
    go: github.com/theupdateframework/notary@v0.7.1-0.20210315103452-bf96a202a09a requires
        github.com/docker/go@v1.5.1-1.0.20160303222718-d30aec9fd63c: invalid pseudo-version: git fetch --unshallow -f origin in /go/pkg/mod/cache/vcs/48fbd2dfabec81f4c93170677bfc89087d4bec07a2d08f6ca5ce3d17962677ee: exit status 128:
        fatal: git fetch-pack: expected shallow list
    make: *** [manpages] Error 1
    error: Bad exit status from /var/tmp/rpm-tmp.aKncVr (%build)
