### PR TITLE
[20.10 backport] add checks for binary versions set through build-time variables

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -37,14 +37,17 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
-		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($$ver) did not match"
+		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($$ver) did not match" && exit 1)
 
 	ver="$$(cli/build/docker --version)"; \
-		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || echo "FAIL: cli version ($$ver) did not match"
+		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || (echo "FAIL: cli version ($$ver) did not match" && exit 1)
 
 	# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
-	ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
-		test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($$ver) did not match"
+	# TODO change once we support scan-plugin on other architectures
+	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
+		ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+			test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($$ver) did not match" && exit 1); \
+	fi
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -36,8 +36,15 @@ override_dh_auto_build:
 		done
 
 override_dh_auto_test:
-	./engine/bundles/dynbinary-daemon/dockerd -v
-	./cli/build/docker -v
+	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
+		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($$ver) did not match"
+
+	ver="$$(cli/build/docker --version)"; \
+		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || echo "FAIL: cli version ($$ver) did not match"
+
+	# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
+	ver="$$(/usr/libexec/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+		test "$$ver" = "$(SCAN_VERSION)" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($$ver) did not match"
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -64,8 +64,9 @@ done
 popd
 
 
-# %check
-# cli/build/docker -v
+%check
+ver="$(cli/build/docker --version)"; \
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || echo "FAIL: cli version ($ver) did not match"
 
 %install
 # install binary

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -66,7 +66,7 @@ popd
 
 %check
 ver="$(cli/build/docker --version)"; \
-    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || echo "FAIL: cli version ($ver) did not match"
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_cli}" && echo "PASS: cli version OK" || (echo "FAIL: cli version ($ver) did not match" && exit 1)
 
 %install
 # install binary

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -90,7 +90,7 @@ popd
 
 %check
 ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
-    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($ver) did not match"
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($ver) did not match" && exit 1)
 
 %install
 # install daemon binary

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -89,7 +89,8 @@ VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 
 %check
-engine/bundles/dynbinary-daemon/dockerd -v
+ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
+    test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || echo "FAIL: daemon version ($ver) did not match"
 
 %install
 # install daemon binary

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -31,9 +31,10 @@ popd
 
 
 %check
-# FIXME: --version currently doesn't work as it makes a connection to the daemon
+# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 #${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan scan --accept-license --version
-${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan --help
+ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
+	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($ver) did not match"
 
 %install
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -34,7 +34,7 @@ popd
 # FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 #${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan scan --accept-license --version
 ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
-	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || echo "FAIL: docker-scan version ($ver) did not match"
+	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($ver) did not match" && exit 1)
 
 %install
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin


### PR DESCRIPTION
relates to https://github.com/docker/docker-ce-packaging/pull/549, https://github.com/docker/docker-ce-packaging/pull/553#issuecomment-873409190

Backport of:

- https://github.com/docker/docker-ce-packaging/pull/551
- https://github.com/docker/docker-ce-packaging/pull/556
