### PR TITLE
[20.10 backport] add docker-compose-plugin package (deb, rpm)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean-src:
 	$(RM) -r src
 
 .PHONY: src
-src: src/github.com/docker/cli src/github.com/docker/docker src/github.com/docker/scan-cli-plugin ## clone source
+src: src/github.com/docker/cli src/github.com/docker/docker src/github.com/docker/compose src/github.com/docker/scan-cli-plugin ## clone source
 
 ifdef CLI_DIR
 src/github.com/docker/cli:
@@ -37,6 +37,10 @@ src/github.com/docker/docker:
 	git -C $@ remote add origin "$(DOCKER_ENGINE_REPO)"
 endif
 
+src/github.com/docker/compose:
+	git init $@
+	git -C $@ remote add origin "$(DOCKER_COMPOSE_REPO)"
+
 src/github.com/docker/scan-cli-plugin:
 	git init $@
 	git -C $@ remote add origin "$(DOCKER_SCAN_REPO)"
@@ -50,12 +54,16 @@ checkout-cli: src/github.com/docker/cli
 checkout-docker: src/github.com/docker/docker
 	./scripts/checkout.sh src/github.com/docker/docker "$(DOCKER_ENGINE_REF)"
 
+.PHONY: checkout-compose
+checkout-compose: src/github.com/docker/compose
+	./scripts/checkout.sh src/github.com/docker/compose "$(DOCKER_COMPOSE_REF)"
+
 .PHONY: checkout-scan-cli-plugin
 checkout-scan-cli-plugin: src/github.com/docker/scan-cli-plugin
 	./scripts/checkout.sh src/github.com/docker/scan-cli-plugin "$(DOCKER_SCAN_REF)"
 
 .PHONY: checkout
-checkout: checkout-cli checkout-docker checkout-scan-cli-plugin ## checkout source at the given reference(s)
+checkout: checkout-cli checkout-docker checkout-compose checkout-scan-cli-plugin ## checkout source at the given reference(s)
 
 .PHONY: clean
 clean: clean-src ## remove build artifacts

--- a/common.mk
+++ b/common.mk
@@ -23,9 +23,10 @@ VERSION?=0.0.1-dev
 
 # DOCKER_CLI_REPO and DOCKER_ENGINE_REPO define the source repositories to clone
 # the source from. These can be overridden to build from a fork.
-DOCKER_CLI_REPO    ?= https://github.com/docker/cli.git
-DOCKER_ENGINE_REPO ?= https://github.com/docker/docker.git
-DOCKER_SCAN_REPO   ?= https://github.com/docker/scan-cli-plugin.git
+DOCKER_CLI_REPO     ?= https://github.com/docker/cli.git
+DOCKER_ENGINE_REPO  ?= https://github.com/docker/docker.git
+DOCKER_SCAN_REPO    ?= https://github.com/docker/scan-cli-plugin.git
+DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 
 # REF can be used to specify the same branch or tag to use for *both* the CLI
 # and Engine source code. This can be useful if both the CLI and Engine have a
@@ -37,6 +38,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.17.0
+DOCKER_COMPOSE_REF ?= v2.3.1
 
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -33,6 +33,7 @@ RUN?=docker run --rm \
 	-e VERSION=$(word 2, $(GEN_DEB_VER)) \
 	-e CLI_GITCOMMIT=$(CLI_GITCOMMIT) \
 	-e ENGINE_GITCOMMIT=$(ENGINE_GITCOMMIT) \
+	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
 	-e SCAN_VERSION=$(DOCKER_SCAN_REF) \
 	-e SCAN_GITCOMMIT=$(SCAN_GITCOMMIT) \
 	-v $(CURDIR)/debbuild/$@:/build \
@@ -77,7 +78,7 @@ $(DISTROS): sources
 	$(CHOWN) -R $(shell id -u):$(shell id -g) "debbuild/$@"
 
 .PHONY: sources
-sources: sources/cli.tgz sources/engine.tgz sources/scan-cli-plugin.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz
+sources: sources/cli.tgz sources/engine.tgz sources/compose.tgz sources/scan-cli-plugin.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz
 
 sources/engine.tgz:
 	mkdir -p $(@D)
@@ -94,6 +95,14 @@ sources/cli.tgz:
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
+
+sources/compose.tgz:
+	mkdir -p $(@D)
+	docker run --rm -w /v \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/compose):/compose \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/compose.tgz --exclude .git compose
 
 sources/scan-cli-plugin.tgz:
 	mkdir -p $(@D)

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -7,6 +7,8 @@ mkdir -p /root/build-deb/engine
 tar -C /root/build-deb -xzf /sources/engine.tgz
 mkdir -p /root/build-deb/cli
 tar -C /root/build-deb -xzf /sources/cli.tgz
+mkdir -p /root/build-deb/compose
+tar -C /root/build-deb -xzf /sources/compose.tgz
 mkdir -p /root/build-deb/scan-cli-plugin
 tar -C /root/build-deb -xzf /sources/scan-cli-plugin.tgz
 
@@ -14,6 +16,7 @@ tar -C /root/build-deb -xzf /sources/scan-cli-plugin.tgz
 mkdir -p /go/src/github.com/docker
 ln -snf /root/build-deb/engine /go/src/github.com/docker/docker
 ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
+ln -snf /root/build-deb/compose /go/src/github.com/docker/compose
 ln -snf /root/build-deb/scan-cli-plugin /go/src/github.com/docker/scan-cli-plugin
 
 EPOCH="${EPOCH:-}"

--- a/deb/common/control
+++ b/deb/common/control
@@ -102,6 +102,18 @@ Description: Rootless support for Docker.
   Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
 Homepage: https://docs.docker.com/engine/security/rootless/
 
+Package: docker-compose-plugin
+Priority: optional
+Architecture: linux-any
+Enhances: docker-ce-cli
+Description: Docker Compose (V2) plugin for the Docker CLI.
+ .
+ This plugin provides the 'docker compose' subcommand.
+ .
+ The binary can also be run standalone as a direct replacement for
+ Docker Compose V1 ('docker-compose').
+Homepage: https://github.com/docker/compose
+
 Package: docker-scan-plugin
 Priority: optional
 # TODO change once we support scan-plugin on other architectures (see dpkg-architecture -L)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -18,6 +18,15 @@ override_dh_auto_build:
 	cd /go/src/github.com/docker/cli && \
 		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) dynbinary manpages
 
+	# Build the compose plugin
+	# FIXME: using GOPROXY, to work around:
+	# go: github.com/Azure/azure-sdk-for-go@v48.2.0+incompatible: reading github.com/Azure/azure-sdk-for-go/go.mod at revision v48.2.0: unknown revision v48.2.0
+	cd /go/src/github.com/docker/compose \
+	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download \
+	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
+	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on GIT_TAG=$(COMPOSE_VERSION) \
+		make COMPOSE_BINARY=/usr/libexec/docker/cli-plugins/docker-compose -f builder.Makefile compose-plugin
+
 	# Build the scan-plugin
 	# TODO change once we support scan-plugin on other architectures
 	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
@@ -41,6 +50,9 @@ override_dh_auto_test:
 
 	ver="$$(cli/build/docker --version)"; \
 		test "$$ver" = "Docker version $(VERSION), build $(CLI_GITCOMMIT)" && echo "PASS: cli version OK" || (echo "FAIL: cli version ($$ver) did not match" && exit 1)
+
+	ver="$$(/usr/libexec/docker/cli-plugins/docker-compose docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+		test "$$ver" = "$(COMPOSE_VERSION)" && echo "PASS: docker-compose version OK" || (echo "FAIL: docker-compose version ($$ver) did not match" && exit 1)
 
 	# FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 	# TODO change once we support scan-plugin on other architectures
@@ -71,6 +83,9 @@ override_dh_auto_install:
 	install -D -m 0755 /usr/local/bin/docker-proxy debian/docker-ce/usr/bin/docker-proxy
 	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
 
+	# docker-compose-plugin install
+	install -D -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
+
 	# docker-scan-plugin install
 	# TODO change once we support scan-plugin on other architectures
 	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
@@ -97,6 +112,10 @@ override_dh_install:
 	dh_apparmor --profile-name=docker-ce -pdocker-ce
 
 override_dh_gencontrol:
+	# Use separate version for the compose-plugin package, then generate the other control files as usual
+	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_VERSION#v}~$${DISTRO}-$${SUITE}
+
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)
 	# TODO change once we support scan-plugin on other architectures (see dpkg-architecture -L)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -4,6 +4,7 @@ PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+GEN_COMPOSE_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
 GEN_SCAN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) "$(DOCKER_SCAN_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
@@ -22,9 +23,9 @@ BUILD?=DOCKER_BUILDKIT=1 \
 
 
 ifeq ($(ARCH),x86_64)
-SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec docker-scan-plugin.spec
+SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec docker-compose-plugin.spec docker-scan-plugin.spec
 else
-SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec
+SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec docker-compose-plugin.spec
 endif
 
 SPECS?=$(addprefix SPECS/, $(SPEC_FILES))
@@ -34,6 +35,8 @@ RPMBUILD_FLAGS?=-ba\
 	--define '_release $(word 2,$(GEN_RPM_VER))' \
 	--define '_version $(word 1,$(GEN_RPM_VER))' \
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
+	--define '_compose_rpm_version $(word 1,$(GEN_COMPOSE_RPM_VER))' \
+	--define '_compose_version $(word 4,$(GEN_COMPOSE_RPM_VER))' \
 	--define '_scan_rpm_version $(word 1,$(GEN_SCAN_RPM_VER))' \
 	--define '_scan_version $(word 4,$(GEN_SCAN_RPM_VER))' \
 	--define '_scan_gitcommit $(SCAN_GITCOMMIT)' \
@@ -87,12 +90,15 @@ centos: $(CENTOS_RELEASES) ## build all centos rpm packages
 rhel: $(RHEL_RELEASES) ## build all rhel rpm packages
 
 .PHONY: $(DISTROS)
-$(DISTROS): rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/scan-cli-plugin.tgz rpmbuild/SOURCES/docker.service rpmbuild/SOURCES/docker.socket rpmbuild/SOURCES/plugin-installers.tgz
+$(DISTROS): sources
 	@echo "== Building packages for $@ =="
 	mkdir -p "rpmbuild/$@"
 	$(BUILD)
 	$(RUN)
 	$(CHOWN) -R $(shell id -u):$(shell id -g) "rpmbuild/$@"
+
+.PHONY: sources
+sources: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/compose.tgz rpmbuild/SOURCES/scan-cli-plugin.tgz rpmbuild/SOURCES/docker.service rpmbuild/SOURCES/docker.socket rpmbuild/SOURCES/plugin-installers.tgz
 
 rpmbuild/SOURCES/engine.tgz:
 	mkdir -p $(@D)
@@ -109,6 +115,14 @@ rpmbuild/SOURCES/cli.tgz:
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
+
+rpmbuild/SOURCES/compose.tgz:
+	mkdir -p $(@D)
+	docker run --rm -w /v \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/compose):/compose \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/compose.tgz --exclude .git compose
 
 rpmbuild/SOURCES/scan-cli-plugin.tgz:
 	mkdir -p $(@D)

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -1,0 +1,64 @@
+%global debug_package %{nil}
+
+Name: docker-compose-plugin
+Version: %{_compose_rpm_version}
+Release: %{_release}%{?dist}
+Epoch: 0
+Source0: compose.tgz
+Summary: Docker Compose (V2) plugin for the Docker CLI
+Group: Tools/Docker
+License: ASL 2.0
+URL: https://github.com/docker/compose/
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+Requires: docker-ce-cli
+
+BuildRequires: bash
+
+%description
+Docker Compose (V2) plugin for the Docker CLI.
+
+This plugin provides the 'docker compose' subcommand.
+
+The binary can also be run standalone as a direct replacement for
+Docker Compose V1 ('docker-compose').
+
+%prep
+%setup -q -c -n src -a 0
+
+%build
+pushd ${RPM_BUILD_DIR}/src/compose
+    # FIXME: using GOPROXY, to work around:
+    # go: github.com/Azure/azure-sdk-for-go@v48.2.0+incompatible: reading github.com/Azure/azure-sdk-for-go/go.mod at revision v48.2.0: unknown revision v48.2.0
+    GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download
+    GOPROXY="https://proxy.golang.org" GO111MODULE=on GIT_TAG="%{_compose_version}" \
+        make COMPOSE_BINARY="bin/docker-compose" -f builder.Makefile compose-plugin
+popd
+
+%check
+ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-compose docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
+    test "$ver" = "%{_compose_version}" && echo "PASS: docker-compose version OK" || (echo "FAIL: docker-compose version ($ver) did not match" && exit 1)
+
+%install
+pushd ${RPM_BUILD_DIR}/src/compose
+    install -D -p -m 0755 bin/docker-compose ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-compose
+popd
+
+for f in LICENSE MAINTAINERS NOTICE README.md; do
+    install -D -p -m 0644 "${RPM_BUILD_DIR}/src/compose/$f" "docker-compose-plugin-docs/$f"
+done
+
+%files
+%doc docker-compose-plugin-docs/*
+%license docker-compose-plugin-docs/LICENSE
+%license docker-compose-plugin-docs/NOTICE
+%{_libexecdir}/docker/cli-plugins/docker-compose
+
+%post
+
+%preun
+
+%postun
+
+%changelog

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -12,8 +12,6 @@ URL: https://github.com/docker/compose/
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
-Requires: docker-ce-cli
-
 BuildRequires: bash
 
 %description


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/553

depends on https://github.com/docker/docker-ce-packaging/pull/637

```bash
git cherry-pick -s -S -x \
    d66f7a68c9cf5ecb42d7aa66c22287ea5f0241c3 \
    276d806d084c0b11acf66ede0aef484049632449 \
    cab7b567fdd3e7108af65ed2734820d3095d2e4d
```

Minor conflict in the first two commits, due to https://github.com/docker/docker-ce-packaging/pull/547 not being in the 20.10 branch