### PR TITLE
[20.10 backport] rpmlint: fix "E: description-line-too-long"

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -37,8 +37,8 @@ Docker is is a product for you to build, ship and run any application as a
 lightweight container.
 
 Docker containers are both hardware-agnostic and platform-agnostic. This means
-they can run anywhere, from your laptop to the largest cloud compute instance and
-everything in between - and they don't require you to use a particular
+they can run anywhere, from your laptop to the largest cloud compute instance
+and everything in between - and they don't require you to use a particular
 language, framework or packaging system. That makes them great building blocks
 for deploying and scaling web apps, databases, and backend services without
 depending on a particular stack or provider.

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -66,8 +66,8 @@ Docker is a product for you to build, ship and run any application as a
 lightweight container.
 
 Docker containers are both hardware-agnostic and platform-agnostic. This means
-they can run anywhere, from your laptop to the largest cloud compute instance and
-everything in between - and they don't require you to use a particular
+they can run anywhere, from your laptop to the largest cloud compute instance
+and everything in between - and they don't require you to use a particular
 language, framework or packaging system. That makes them great building blocks
 for deploying and scaling web apps, databases, and backend services without
 depending on a particular stack or provider.


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/640

addresses one of the warnings/errors in https://github.com/docker/docker-ce-packaging/issues/639

Fixes an error reported by rpmlint:

    docker-ce.x86_64: E: description-line-too-long they can run anywhere, from your laptop to the largest cloud compute instance and
    docker-ce-cli.x86_64: E: description-line-too-long they can run anywhere, from your laptop to the largest cloud compute instance and
    Your description lines must not exceed 80 characters. If a line is exceeding
    this number, cut it to fit in two lines.
