### PR TITLE
[20.10 backport] update buildx to v0.8.0

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.7.1}"
+: "${BUILDX_COMMIT=v0.8.0}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/648

https://github.com/docker/buildx/releases/tag/v0.8.0
