### PR TITLE
update buildx to v0.8.1

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.8.0}"
+: "${BUILDX_COMMIT=v0.8.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
https://github.com/docker/buildx/releases/tag/v0.8.1

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>