### PR TITLE
[master] rpm: fix circular dependency between scan-cli-plugin and docker-ce-cli

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -18,7 +18,15 @@ Requires: /bin/sh
 Requires: /usr/sbin/groupadd
 # TODO change once we support scan-plugin on other architectures
 %ifarch x86_64
+# CentOS 7 and RHEL 7 do not yet support weak dependencies
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} == 7
 Requires: docker-scan-plugin(x86-64)
+%else
+Recommends: docker-scan-plugin(x86-64)
+%endif
 %endif
 
 BuildRequires: make

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -12,7 +12,13 @@ URL: https://github.com/docker/scan-cli-plugin/
 Vendor: Docker
 Packager: Docker <support@docker.com>
 
-Requires: docker-ce-cli
+# CentOS 7 and RHEL 7 do not yet support weak dependencies.
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} != 7
+Enhances: docker-ce-cli
+%endif
 
 # TODO change once we support scan-plugin on other architectures
 BuildArch: x86_64


### PR DESCRIPTION
This fixes a problem when installing the packages from local files instead of
from the package repository. The current packages had a strong dependency set
in both directions (`docker-ce-cli` requires `docker-scan-plugin`, and vice-
versa). This caused a circular dependency, which could not be resolved when
trying to install the packages offline (from downloaded rpm files);

    yum install ./docker-scan-plugin-0.17.0-3.fc35.x86_64.rpm
    Last metadata expiration check: 1:09:40 ago on Tue Mar  8 08:30:47 2022.
    Error:
    Problem: conflicting requests
    - nothing provides docker-ce-cli needed by docker-scan-plugin-0.17.0-3.fc35.x86_64
      (try to add '--skip-broken' to skip uninstallable packages)

    yum install ./docker-ce-cli-20.10.13-3.fc35.x86_64.rpm
    Last metadata expiration check: 1:10:23 ago on Tue Mar  8 08:30:47 2022.
    Error:
    Problem: conflicting requests
    - nothing provides docker-scan-plugin(x86-64) needed by docker-ce-cli-1:20.10.13-3.fc35.x86_64
      (try to add '--skip-broken' to skip uninstallable packages)

This patch

- changes the `docker-scan-plugin` to `Enhances
- changes the `docker-ce-cli` package to mark the scan plugin as `Recommends`,
  with the exception of CentOS/RHEL 7, which do not yet support weak dependencies.
  For those, we continue to use `Requires`.

The `Recommends` dependency should be installed by default, but users can opt-out
by passing `--setopt=install_weak_deps=False` to `dnf`.
