### PR TITLE
[20.10 backport] rpm: add fedora-36 to makefile

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -53,7 +53,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-35 fedora-34
+FEDORA_RELEASES ?= fedora-36 fedora-35 fedora-34
 CENTOS_RELEASES ?= centos-7 centos-8
 ifeq ($(ARCH),s390x)
 RHEL_RELEASES ?= rhel-7


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/666
(cherry picked from commit dbaee894182b5206644cd41bf72f631d6b3117c6)


Opening as draft to check if the 20.10 upstream cli branch also needs fixes for this (see https://github.com/docker/cli/pull/3513)