### PR TITLE
[20.10] update buildx to v0.8.2

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.8.1}"
+: "${BUILDX_COMMIT=v0.8.2}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
equivalent of ~https://github.com/docker/docker-ce-packaging/pull/673~ https://github.com/docker/docker-ce-packaging/pull/672 for the 20.10 branch

release notes: https://github.com/docker/buildx/releases/tag/v0.8.2

Notable changes:

- Update Compose spec used by buildx bake to v1.2.1 to fix parsing ports definition
- Fix possible crash on handling progress streams from BuildKit v0.10
- Fix parsing groups in buildx bake when already loaded by a parent group
