### PR TITLE
[master] set minimum containerd.io version to v1.6.4

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,7 +27,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: containerd.io (>= 1.4.1),
+Depends: containerd.io (>= 1.6.4),
          docker-ce-cli,
          iptables,
          libseccomp2 (>= 2.3.0),

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -28,7 +28,7 @@ Requires: iptables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.4.1
+Requires: containerd.io >= 1.6.4
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
This is for the upcoming 22 release, which will ship when we have containerd.io 1.6 packages, so (as we did with previous releases), set the minimum version to the current version.

Similar to 3f2b79d15d9775302704ce3952c4ed1079fe4127 (https://github.com/docker/docker-ce-packaging/pull/506)
