### PR TITLE
[20.10 backport] Makefile: enable GOPROXY to work around vanity URL being offline

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -28,6 +28,7 @@ BUILD?=DOCKER_BUILDKIT=1 \
 RUN_FLAGS=
 RUN?=docker run --rm \
 	-e PLATFORM \
+	-e GOPROXY=https://proxy.golang.org \
 	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(word 1, $(GEN_DEB_VER)) \
 	-e VERSION=$(word 2, $(GEN_DEB_VER)) \

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -47,6 +47,7 @@ RPMBUILD_FLAGS?=-ba\
 RUN_FLAGS=
 RUN?=docker run --rm \
 	-e PLATFORM \
+	-e GOPROXY=https://proxy.golang.org \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES:ro \
 	-v $(CURDIR)/rpmbuild/$@/RPMS:/root/rpmbuild/RPMS \
 	-v $(CURDIR)/rpmbuild/$@/SRPMS:/root/rpmbuild/SRPMS \


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/684

The https://honnef.co/go/tools domain looks to be offline, causing projects that
do not use vendoring to fail:

    go: downloading google.golang.org/protobuf v1.27.1
    go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
    go: google.golang.org/grpc@v1.44.0 requires
    google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013 requires
    honnef.co/go/tools@v0.0.0-20190523083050-ea95bdfd59fc: unrecognized import path "honnef.co/go/tools": reading https://honnef.co/go/tools?go-get=1: 502 Bad Gateway
    make: *** [Makefile:71: manpages] Error 1

For now, let's use the GOPROXY (we should look at making this a build-arg probably)

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 1dfe9a2bd4c3ecc22f1bf1007ca94d570bd5aafc)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>