### PR TITLE
[master] rpm: use same options for creating symlinks as in the deb builds

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -69,7 +69,7 @@ depending on a particular stack or provider.
 %build
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
-ln -s ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
+ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} GO_LINKMODE=dynamic ./scripts/build/binary && DISABLE_WARN_OUTSIDE_CONTAINER=1 make manpages # cli
 popd

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -38,7 +38,7 @@ Either VPNKit or slirp4netns (>= 0.4.0) needs to be installed separately.
 
 export DOCKER_GITCOMMIT=%{_gitcommit_engine}
 mkdir -p /go/src/github.com/docker
-ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
+ln -snf ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
 TMP_GOPATH="/go" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh rootlesskit dynamic
 
 %check

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -82,7 +82,7 @@ depending on a particular stack or provider.
 
 export DOCKER_GITCOMMIT=%{_gitcommit_engine}
 mkdir -p /go/src/github.com/docker
-ln -s ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
+ln -snf ${RPM_BUILD_DIR}/src/engine /go/src/github.com/docker/docker
 
 pushd ${RPM_BUILD_DIR}/src/engine
 TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini


### PR DESCRIPTION
Found this branch in my local fork, and looks like I didn't open a PR for it yet 😅 


Use the same options for creating the symlinks as for the deb packages, and
add the `-n` and `-f` options;

    -n, --no-dereference        treat LINK_NAME as a normal file if
                                it is a symbolic link to a directory
    -f, --force                 remove existing destination files

