### PR TITLE
[master] rpmlint: fix "W: no-documentation"

### DIFF
--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -99,14 +99,15 @@ install -p -m 644 cli/man/man5/*.5 ${RPM_BUILD_ROOT}%{_mandir}/man5
 install -d ${RPM_BUILD_ROOT}%{_mandir}/man8
 install -p -m 644 cli/man/man8/*.8 ${RPM_BUILD_ROOT}%{_mandir}/man8
 
-mkdir -p build-docs
-for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
-    cp "cli/$cli_file" "build-docs/$cli_file"
+for f in AUTHORS LICENSE MAINTAINERS NOTICE README.md; do
+    install -D -p -m 0644 "engine/$f" "build-docs/$f"
 done
 
 # list files owned by the package here
 %files
-%doc build-docs/LICENSE build-docs/MAINTAINERS build-docs/NOTICE build-docs/README.md
+%doc build-docs/*
+%license build-docs/LICENSE
+%license build-docs/NOTICE
 %{_bindir}/docker
 %{_datadir}/bash-completion/completions/docker
 %{_datadir}/zsh/vendor-completions/_docker

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -50,7 +50,14 @@ install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh ${RPM_BUILD_R
 install -D -p -m 0755 /usr/local/bin/rootlesskit ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit
 install -D -p -m 0755 /usr/local/bin/rootlesskit-docker-proxy ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit-docker-proxy
 
+for f in AUTHORS LICENSE MAINTAINERS NOTICE README.md SECURITY.md; do
+    install -D -p -m 0644 "engine/$f" "docker-ce-rootless-extras-docs/$f"
+done
+
 %files
+%doc docker-ce-rootless-extras-docs/*
+%license docker-ce-rootless-extras-docs/LICENSE
+%license docker-ce-rootless-extras-docs/NOTICE
 %{_bindir}/dockerd-rootless.sh
 %{_bindir}/dockerd-rootless-setuptool.sh
 %{_bindir}/rootlesskit

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -102,7 +102,14 @@ install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_bindir}/doc
 install -D -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
 install -D -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
+for f in AUTHORS LICENSE MAINTAINERS NOTICE README.md SECURITY.md; do
+    install -D -p -m 0644 "engine/$f" "docker-ce-docs/$f"
+done
+
 %files
+%doc docker-ce-docs/*
+%license docker-ce-docs/LICENSE
+%license docker-ce-docs/NOTICE
 %{_bindir}/dockerd
 %{_bindir}/docker-proxy
 %{_bindir}/docker-init

--- a/rpm/SPECS/docker-scan-plugin.spec
+++ b/rpm/SPECS/docker-scan-plugin.spec
@@ -32,22 +32,32 @@ Docker Scan plugin for the Docker CLI.
 
 %build
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin
-bash -c 'TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
+    bash -c 'TAG_NAME="%{_scan_version}" COMMIT="%{_scan_gitcommit}" PLATFORM_BINARY=docker-scan make native-build'
 popd
 
+for f in LICENSE MAINTAINERS NOTICE README.md; do
+    install -D -p -m 0644 "${RPM_BUILD_DIR}/src/scan-cli-plugin/$f" "scan-cli-plugin-docs/$f"
+done
 
 %check
 # FIXME: --version currently doesn't work as it makes a connection to the daemon, so using the plugin metadata instead
 #${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan scan --accept-license --version
 ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
-	test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($ver) did not match" && exit 1)
+    test "$ver" = "%{_scan_version}" && echo "PASS: docker-scan version OK" || (echo "FAIL: docker-scan version ($ver) did not match" && exit 1)
 
 %install
 pushd ${RPM_BUILD_DIR}/src/scan-cli-plugin
-install -D -p -m 0755 bin/docker-scan ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan
+    install -D -p -m 0755 bin/docker-scan ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-scan
 popd
 
+for f in AUTHORS LICENSE MAINTAINERS NOTICE README.md SECURITY.md; do
+    install -D -p -m 0644 "${RPM_BUILD_DIR}/src/scan-cli-plugin/$f" "scan-cli-plugin-docs/$f"
+done
+
 %files
+%doc scan-cli-plugin-docs/*
+%license scan-cli-plugin-docs/LICENSE
+%license scan-cli-plugin-docs/NOTICE
 %{_libexecdir}/docker/cli-plugins/docker-scan
 
 %post


### PR DESCRIPTION
These packages were causing a warning that they didn't contain documentation.
For some of these, we need to add man-pages, but at least we can add some of
the files we have. Also adding `AUTHORS` and `SECURITY.md` to existing packages:

    docker-ce.x86_64: W: no-documentation
    docker-ce-rootless-extras.x86_64: W: no-documentation
    docker-compose-plugin.x86_64: W: no-documentation
    docker-scan-plugin.x86_64: W: no-documentation
    The package contains no documentation (README, doc, etc). You have to include
    documentation files.

I'm using unique directory names for each package to collect the docs in, as
we build the packages in the same environment (so possibly they would trip over
each-other), but possibly this is not needed (so "just to be sure").

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>