### PR TITLE
[master] deb: add "Pre-Depends: ${misc:Pre-Depends}" for compat with debhelper > 13

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -27,6 +27,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
+Pre-Depends: ${misc:Pre-Depends}
 Depends: containerd.io (>= 1.6.4),
          docker-ce-cli,
          iptables,


### PR DESCRIPTION
Commit f9ac2f67a22f865769a4e74070580276b229ae70 (https://github.com/docker/docker-ce-packaging/pull/686) updated the "debhelper compat
level" to 13, which seems to have introduced a regression when executing the
preRM and postInst scripts;

    invoke-rc.d: syntax error: unknown option "--skip-systemd-native"
       dpkg: error processing package docker-ce (--install):
       installed docker-ce package post-installation script subprocess returned error exit status 1

Searching for the cause of this regression, I found this mention in the debhelper(7)
man-page: https://man7.org/linux/man-pages/man7/debhelper.7.html

    **Retroactively removed in debhelper/13.5:**
    (...)
    This change makes dh_installinit inject a
    misc:Pre-Depends for init-system-helpers (>= 1.54~).
    Please ensure that the package lists
    ${misc:Pre-Depends} in its Pre-Depends field before
    upgrading to compat 12.

This patch adds the recommended Pre-depends
