### PR TITLE
fix generating pre-release deb/rpm versions when using '.'

### DIFF
--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -24,19 +24,19 @@ gen_deb_version() {
 	increment="$3"
 	testVersion="${fullVersion#*-$pattern}"
 	baseVersion="${fullVersion%-"$pattern"*}"
-	echo "$baseVersion-$increment.$testVersion.$pattern$testVersion"
+	echo "$baseVersion-$increment.${testVersion##.}.$pattern$testVersion"
 }
 
 case "$debVersion" in
 	*-dev)
 		;;
-	*-tp[0-9]*)
+	*-tp[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" tp 0)"
 		;;
-	*-beta[0-9]*)
+	*-beta[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" beta 1)"
 		;;
-	*-rc[0-9]*)
+	*-rc[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" rc 2)"
 		;;
 	*)

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -23,18 +23,18 @@ rpmRelease=3
 # Docker 18.01.0-ce-cs1-rc1: version=18.01.0.ce.cs1, release=0.1.rc1
 # Docker 18.01.0-ce-dev nightly: version=18.01.0.ce, release=0.0.YYYYMMDD.HHMMSS.gitHASH
 
-if [[ "$rpmVersion" =~ .*-tp[0-9]+$ ]]; then
-	tpVersion=${rpmVersion#*-tp}
+if [[ "$rpmVersion" =~ .*-tp[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-tp}
 	rpmVersion=${rpmVersion%-tp*}
-	rpmRelease="0.${tpVersion}.tp${tpVersion}"
-elif [[ "$rpmVersion" =~ .*-beta[0-9]+$ ]]; then
-	betaVersion=${rpmVersion#*-beta}
+	rpmRelease="0.${testVersion##.}.tp${testVersion}"
+elif [[ "$rpmVersion" =~ .*-beta[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-beta}
 	rpmVersion=${rpmVersion%-beta*}
-	rpmRelease="1.${betaVersion}.beta${betaVersion}"
-elif [[ "$rpmVersion" =~ .*-rc[0-9]+$ ]]; then
-	rcVersion=${rpmVersion#*-rc}
+	rpmRelease="1.${testVersion##.}.beta${testVersion}"
+elif [[ "$rpmVersion" =~ .*-rc[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-rc}
 	rpmVersion=${rpmVersion%-rc*}
-	rpmRelease="2.${rcVersion}.rc${rcVersion}"
+	rpmRelease="2.${testVersion##.}.rc${testVersion}"
 fi
 
 DOCKER_GITCOMMIT=$($GIT_COMMAND rev-parse --short HEAD)


### PR DESCRIPTION
The script assumed that pre-release suffixes used the format `-tp<number>`,
`-beta<number>` or `-rc<number>`, however, it's more common (and standard
practice in SemVer) to delimit the `alpha/beta/rc` with a `.`, which allows
SemVer comparing to first sort by pre-release version (`alpha`, `beta`, `rc`),
then by the numeric suffix.

Altogether, we should consider removing this code; using `tp` as a pre-release
*before* `alpha` / `beta` is non-standard (pre-releases are named `alpha`, `beta`,
`rc`, so that they can be sorted alphabetically. Using `tp` violates that assumption,
and adds the complexity of having to add a numeric prefix to make it sort again.
Also see https://www.debian.org/doc/debian-policy/ch-controlfields.html#epochs-should-be-used-sparingly

Before:

    ./rpm/gen-rpm-ver . 22.06.0-beta0
    22.06.0 1.0.beta0 6e7db7f 22.06.0-beta0

    ./rpm/gen-rpm-ver . 22.06.0-beta.0
    22.06.0.beta.0 3 6e7db7f 22.06.0-beta.0

    ./deb/gen-deb-ver . 22.06.0-beta0
    22.06.0~1.0.beta0 22.06.0-beta0

    ./deb/gen-deb-ver . 22.06.0-beta.0
    22.06.0~beta.0~3 22.06.0-beta.0

After:

    ./rpm/gen-rpm-ver . 22.06.0-beta0
    22.06.0 1.0.beta0 3091da7 22.06.0-beta0

    ./rpm/gen-rpm-ver . 22.06.0-beta.0
    22.06.0 1.0.beta.0 3091da7 22.06.0-beta.0

    ./deb/gen-deb-ver . 22.06.0-beta0
    22.06.0~1.0.beta0 22.06.0-beta0

    ./deb/gen-deb-ver . 22.06.0-beta.0
    22.06.0~1.0.beta.0 22.06.0-beta.0

