### PR TITLE
Fix package version generation

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -43,8 +43,40 @@ debSource="$(awk -F ': ' '$1 == "Source" { print $2; exit }' debian/control)"
 debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)"
 debDate="$(date --rfc-2822)"
 
+versionID="$(. /etc/os-release && echo "$VERSION_ID")"
+
+# Include an extra `.0` in the version, in case we ever would have to re-build an
+# already published release with a packaging-only change.
+pkgRevision=0
+
+# Generate changelog. The version/name of the generated packages are based on this.
+#
+# Resulting packages are formatted as;
+#
+# - name of the package (e.g., "docker-ce")
+# - version (e.g., "22.10.6~beta.0")
+# - "-0" (mostly "best practice", and allows updating for specific situations)
+# - distro (e.g., "ubuntu")
+# - VERSION_ID (e.g. "22.04" or "11") this must be "sortable" to make sure that
+#   packages are upgraded when upgrading to a newer distro version ("codename"
+#   cannot be used for this, as they're not sorted)
+# - pkgRevision (usually "0", see above)
+# - SUITE ("codename"), e.g. "jammy" or "bullseye". This is mostly for convenience,
+#   because some places refer to distro versions by codename, others by version.
+#   we prefix the codename with a tilde (~), which effectively excludes it from
+#   version comparison.
+#
+# Note that while the `${EPOCH}${EPOCH_SEP}` is part of the version, it is not
+# included in the package's *filename*. (And if you're wondering: we needed the
+# EPOCH because of our use of CalVer, which made version comparing not work in
+# some cases).
+#
+# Examples:
+#
+# docker-ce_22.10.6~beta.0-0~debian.11.0~bullseye_amd64.deb
+# docker-ce_22.10.6~beta.0-0~ubuntu.22.04.0~jammy_amd64.deb
 cat > "debian/changelog" <<-EOF
-$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}-${SUITE}) $SUITE; urgency=low
+$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}.${versionID}.${pkgRevision}~${SUITE}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -13,39 +13,20 @@ GIT_COMMAND="git -C $REPO_DIR"
 origVersion="$VERSION"
 debVersion="${VERSION#v}"
 
-gen_deb_version() {
-	# Adds an increment to the deb version to get proper order
-	# 18.01.0-tp1   -> 18.01.0-0.1-tp1
-	# 18.01.0-beta1 -> 18.01.0-1.1-beta1
-	# 18.01.0-rc1   -> 18.01.0-2.1-rc1
-	# 18.01.0       -> 18.01.0-3
-	fullVersion="$1"
-	pattern="$2"
-	increment="$3"
-	testVersion="${fullVersion#*-$pattern}"
-	baseVersion="${fullVersion%-"$pattern"*}"
-	echo "$baseVersion-$increment.${testVersion##.}.$pattern$testVersion"
-}
-
-case "$debVersion" in
-	*-dev)
-		;;
-	*-tp[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" tp 0)"
-		;;
-	*-beta[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" beta 1)"
-		;;
-	*-rc[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" rc 2)"
-		;;
-	*)
-		debVersion="$debVersion-3"
-		;;
-esac
-
-tilde='~'                            # ouch Bash 4.2 vs 4.3, you keel me
-debVersion="${debVersion//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
+# deb packages require a tilde (~) instead of a hyphen (-) as separator between
+# the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER
+# non-pre-release versions, which would prevent users from updating from a pre-
+# release version to the "ga" version.
+#
+# For details, see this thread on the Debian mailing list:
+# https://lists.debian.org/debian-policy/1998/06/msg00099.html
+#
+# The code below replaces hyphens with tildes. Note that an intermediate $tilde
+# variable is needed to make this work on all versions of Bash. In some versions
+# of Bash, the tilde would be substituted with $HOME (even when escaped (\~) or
+# quoted ('~').
+tilde='~'
+debVersion="${debVersion//-/$tilde}"
 
 # if we have a "-dev" suffix or have change in Git, this is a nightly build, and
 # we'll create a pseudo version based on commit-date and -sha.

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -46,14 +46,11 @@ esac
 
 tilde='~'                            # ouch Bash 4.2 vs 4.3, you keel me
 debVersion="${debVersion//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
-# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
-if [[ "$VERSION" == *-dev ]]; then
-	export TZ=UTC
 
-	DATE_COMMAND="date"
-	if [[ $(uname) == "Darwin" ]]; then
-		DATE_COMMAND="docker run --rm alpine date"
-	fi
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
+	export TZ=UTC
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
 	#
@@ -65,11 +62,20 @@ if [[ "$VERSION" == *-dev ]]; then
 	# as a pre-release before version v0.0.0, so that the go command prefers any
 	# tagged release over any pseudo-version.
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
-	gitDate="$($DATE_COMMAND --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+
+	if [ "$(uname)" = "Darwin" ]; then
+		# Using BSD date (macOS), which doesn't support the --date option
+		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+	else
+		# Using GNU date (Linux)
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+	fi
+
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	debVersion="0.0.0-${gitDate}-${gitCommit}"
-	origVersion=$debVersion
+	origVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
+	debVersion="0.0.0~${gitDate}.${gitCommit}"  # (using tilde and periods)
 
 	# verify that nightly builds are always < actual releases
 	#

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -12,30 +12,66 @@ fi
 GIT_COMMAND="git -C $REPO_DIR"
 origVersion="$VERSION"
 rpmVersion="${VERSION#v}"
-rpmRelease=3
 
-# rpmRelease versioning is as follows
-# Docker 18.01.0-ce:  version=18.01.0.ce, release=3
-# Docker 18.01.0-ce-tp1: version=18.01.0.ce, release=0.1.tp1
-# Docker 18.01.0-ce-beta1: version=18.01.0.ce, release=1.1.beta1
-# Docker 18.01.0-ce-rc1: version=18.01.0.ce, release=2.1.rc1
-# Docker 18.01.0-ce-cs1: version=18.01.0.ce.cs1, release=1
-# Docker 18.01.0-ce-cs1-rc1: version=18.01.0.ce.cs1, release=0.1.rc1
-# Docker 18.01.0-ce-dev nightly: version=18.01.0.ce, release=0.0.YYYYMMDD.HHMMSS.gitHASH
+# rpm "Release:" field ($rpmRelease) is used to set the "_release" macro, which
+# is an incremental number for builds of the same release (Version: / #rpmVersion).
+#
+# This field can be:
+#
+# - Version: 0   : Package was built, but no matching upstream release (e.g., can be used for "nightly" builds)
+# - Version: 1   : Package was built for an upstream (pre)release version
+# - Version: > 1 : Only to be used for packaging-only changes (new package built for a version for which a package was already built/released)
+#
+# For details, see the Fedora packaging guide:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning_with_a_reasonable_upstream
+#
+# Note that older versions of the rpm spec allowed more traditional information
+# in this field, which is still allowed, but considered deprecated; see
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning_with_a_reasonable_upstream
+#
+# In our case, this means that all releases, except for "nightly" builds should
+# use "Version: 1". Only in an exceptional case, where we need to publish a new
+# package (build) for an existing release, "Version: 2" should be used; this script
+# does not currently account for that situation.
+#
+# Assuming all tagged version of rpmRelease correspond with an upstream release,
+# this means that versioning is as follows:
+#
+# Docker 22.06.0:         version=22.06.0, release=1
+# Docker 22.06.0-alpha.1: version=22.06.0, release=1
+# Docker 22.06.0-beta.1:  version=22.06.0, release=1
+# Docker 22.06.0-rc.1:    version=22.06.0, release=1
+# Docker 22.06.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
+rpmRelease=1
 
-if [[ "$rpmVersion" =~ .*-tp[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-tp}
-	rpmVersion=${rpmVersion%-tp*}
-	rpmRelease="0.${testVersion##.}.tp${testVersion}"
-elif [[ "$rpmVersion" =~ .*-beta[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-beta}
-	rpmVersion=${rpmVersion%-beta*}
-	rpmRelease="1.${testVersion##.}.beta${testVersion}"
-elif [[ "$rpmVersion" =~ .*-rc[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-rc}
-	rpmVersion=${rpmVersion%-rc*}
-	rpmRelease="2.${testVersion##.}.rc${testVersion}"
-fi
+# rpm packages require a tilde (~) instead of a hyphen (-) as separator between
+# the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER
+# non-pre-release versions, which would prevent users from updating from a pre-
+# release version to the "ga" version.
+#
+# For details, see the Fedora packaging guide:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret
+#
+# > The tilde symbol (‘~’) is used before a version component which must sort
+# > earlier than any non-tilde component. It is used for any pre-release versions
+# > which wouldn’t otherwise sort appropriately.
+# >
+# > For example, with upstream releases 0.4.0, 0.4.1, 0.5.0-rc1, 0.5.0-rc2, 0.5.0,
+# > the two "release candidates" should use 0.5.0~rc1 and 0.5.0~rc2 in the Version:
+# > field. Bugfix or "patchlevel" releases that some upstream make should be handled
+# > using simple versioning. The separator used by upstream may need to be replaced
+# > by a dot or dropped.
+# >
+# > For example, if the same upstream released 0.5.0-post1 as a bugfix version,
+# > this "post-release" should use 0.5.0.post1 in the Version: field. Note that
+# > 0.5.0.post1 sorts lower than both 0.5.1 and 0.5.0.1.
+#
+# The code below replaces hyphens with tildes. Note that an intermediate $tilde
+# variable is needed to make this work on all versions of Bash. In some versions
+# of Bash, the tilde would be substituted with $HOME (even when escaped (\~) or
+# quoted ('~').
+tilde='~'
+rpmVersion="${rpmVersion//-/$tilde}"
 
 DOCKER_GITCOMMIT=$($GIT_COMMAND rev-parse --short HEAD)
 if [ -n "$($GIT_COMMAND status --porcelain --untracked-files=no)" ]; then

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -42,14 +42,10 @@ if [ -n "$($GIT_COMMAND status --porcelain --untracked-files=no)" ]; then
 	DOCKER_GITCOMMIT="$DOCKER_GITCOMMIT-unsupported"
 fi
 
-# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
-if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
 	export TZ=UTC
-
-	DATE_COMMAND="date"
-	if [[ $(uname) == "Darwin" ]]; then
-		DATE_COMMAND="docker run --rm alpine date"
-	fi
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
 	#
@@ -61,14 +57,23 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
 	# as a pre-release before version v0.0.0, so that the go command prefers any
 	# tagged release over any pseudo-version.
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
-	gitDate="$($DATE_COMMAND --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+
+	if [ "$(uname)" = "Darwin" ]; then
+		# Using BSD date (macOS), which doesn't support the --date option
+		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+	else
+		# Using GNU date (Linux)
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+	fi
+
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	rpmVersion="0.0.0-${gitDate}-${gitCommit}"
-	rpmRelease="0"
-	origVersion=$rpmVersion
+	origVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
+	rpmVersion="0.0.0~${gitDate}.${gitCommit}"  # (using tilde and periods)
+	rpmRelease=0
 fi
 
-# Replace any other dashes with periods
+# Replace any remaining dashes with periods
 rpmVersion="${rpmVersion//-/.}"
 echo "$rpmVersion $rpmRelease $DOCKER_GITCOMMIT $origVersion"

--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -11,8 +11,11 @@ fi
 
 GIT_COMMAND="git -C $REPO_DIR"
 
-staticVersion="$VERSION"
-if [[ "$VERSION" == *-dev ]]; then
+staticVersion="${VERSION#v}"
+
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
 	export TZ=UTC
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
@@ -27,17 +30,17 @@ if [[ "$VERSION" == *-dev ]]; then
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
 
 	if [ "$(uname)" = "Darwin" ]; then
-		# Using BSD date (macOS), which doesn't suppoort the --date option
+		# Using BSD date (macOS), which doesn't support the --date option
 		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
-		gitDate="$(TZ=UTC date -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
 	else
 		# Using GNU date (Linux)
-		gitDate="$(TZ=UTC date --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
 	fi
 
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	staticVersion="0.0.0-${gitDate}-${gitCommit}"
+	staticVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
 fi
 
 echo "$staticVersion"


### PR DESCRIPTION
### unify code for pseudo-versions (nightly), and fix for macOS

This unifies the logic/code for generating pseudo-versions for
nightly builds;

- Generate pseudo-version if the source repository has uncommitted changes
- Fix code to work on macOS
- Strip "v" prefix if the passed VERSION has one

### deb, rpm: generate versions without special numbers for pre-releases

The script had special handling for pre-releases, because at some point we
used `-tp` ("technical preview") as suffix for pre-releases instead of the
standard `-alpha`, `-beta`, `-rc`.

The problem arised because of that, was that comparing versions wouldn't work,
as these suffixes are compared in _alphabetical_ order (which meant that `tp`
would come "after" `beta` and `rc`). To work around this, some custom code
was added to insert a numeric version _before_ the `tp`, `beta`, and `rc`.

We no longer plan to use `-tp` for pre-releases, and instead to just use the
common `alpha[.number]`, `beta[.number]`, `rc[.number]` suffixes.

This patch removes the custom handling for pre-releases, to simplify the version
that's generated.

Before:

    ./rpm/gen-rpm-ver . 22.06.0-beta.0
    22.06.0 1.0.beta.0 3091da7 22.06.0-beta.0

    ./deb/gen-deb-ver . 22.06.0-beta.0
    22.06.0~1.0.beta.0 22.06.0-beta.0

After:

    ./rpm/gen-rpm-ver . 22.06.0-beta.0
    22.06.0~beta.0 1 0b5a1ae 22.06.0-beta.0

    ./deb/gen-deb-ver . 22.06.0-beta.0
    22.06.0~beta.0 22.06.0-beta.0

### deb: fix version to allow for distro upgrades

The existing version format for our packages use `distro-codename` in the version.
Unfortunately, `codename` cannot be used to compare versions, which means that
when a user upgrades their distro to a new version, the package won't be updated
until a new release happens.

This patch changes the format of the version to include `VERSION_ID`, which is
numeric, and can be used in version comparison.

While we're making changes, this also adds an extra `pkgRevision` number in the
version, which can allow us to do a new build/release of a package in between
upstream releases. This version is not yet configurable (which can be changed
in future).

Resulting packages are now formatted as;

- name of the package (e.g., "docker-ce")
- version (e.g., "22.10.6~beta.0")
- "-0" (mostly "best practice", and allows updating for specific situations)
- distro (e.g., "ubuntu")
- VERSION_ID (e.g. "22.04" or "11") this must be "sortable" to make sure that
  packages are upgraded when upgrading to a newer distro version ("codename"
  cannot be used for this, as they're not sorted)
- pkgRevision (usually "0", see above)
- SUITE ("codename"), e.g. "jammy" or "bullseye". This is mostly for convenience,
  because some places refer to distro versions by codename, others by version.
  we prefix the codename with a tilde (~), which effectively excludes it from
  version comparison.

Note that while the `${EPOCH}${EPOCH_SEP}` is part of the version, it is not
included in the package's *filename*.

Examples:

    docker-ce_22.10.6~beta.0-0~debian.11.0~bullseye_amd64.deb
    docker-ce_22.10.6~beta.0-0~ubuntu.22.04.0~jammy_amd64.deb
