### PR TITLE
[master] fix some minor nits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ src/github.com/docker/cli:
 	cp -r "$(CLI_DIR)" $@
 else
 src/github.com/docker/cli:
-	git init $@
+	git init --initial-branch=master $@
 	git -C $@ remote add origin "$(DOCKER_CLI_REPO)"
 endif
 
@@ -33,20 +33,20 @@ src/github.com/docker/docker:
 	cp -r "$(ENGINE_DIR)" $@
 else
 src/github.com/docker/docker:
-	git init $@
+	git init --initial-branch=master $@
 	git -C $@ remote add origin "$(DOCKER_ENGINE_REPO)"
 endif
 
 src/github.com/docker/buildx:
-	git init $@
+	git init --initial-branch=master $@
 	git -C $@ remote add origin "$(DOCKER_BUILDX_REPO)"
 
 src/github.com/docker/compose:
-	git init $@
+	git init --initial-branch=master $@
 	git -C $@ remote add origin "$(DOCKER_COMPOSE_REPO)"
 
 src/github.com/docker/scan-cli-plugin:
-	git init $@
+	git init --initial-branch=master $@
 	git -C $@ remote add origin "$(DOCKER_SCAN_REPO)"
 
 

--- a/static/Makefile
+++ b/static/Makefile
@@ -5,8 +5,8 @@ ENGINE_DIR=$(realpath $(CURDIR)/../src/github.com/docker/docker)
 BUILDX_DIR=$(realpath $(CURDIR)/../src/github.com/docker/buildx)
 
 GEN_STATIC_VER=$(shell ./gen-static-ver $(CLI_DIR) $(VERSION))
-HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
-DIR_TO_HASH:=build/linux
+HASH_CMD=docker run -v $(CURDIR):/sum -w /sum alpine sh hash_files
+DIR_TO_HASH:=build
 DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
 
 DOCKER_BUILD_OPTS=


### PR DESCRIPTION
### static: create hashes for all files, not just linux

Also switching to alpine, instead of debian:jessy, which is EOL

### Makefile: set initial branch name

Set an initial branch name so that git does not create additional noise
about the default not being configured. Using "master" for now, which
was the previous default; we can probably safely change it to "main",
but leaving that for a future exercise.
