### PR TITLE
[master] static: cross-win: remove version from bundles source

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -83,8 +83,8 @@ cross-win: cross-win-engine
 	cd $(CLI_DIR) && VERSION=$(GEN_STATIC_VER) docker buildx bake --set binary.platform=windows/amd64 binary
 	mkdir -p build/win/amd64/docker
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/amd64/docker/docker.exe
-	cp $(ENGINE_DIR)/bundles/cross/windows/amd64-daemon/dockerd-$(GEN_STATIC_VER).exe build/win/amd64/docker/dockerd.exe
-	cp $(ENGINE_DIR)/bundles/cross/windows/amd64-daemon/docker-proxy-$(GEN_STATIC_VER).exe build/win/amd64/docker/docker-proxy.exe
+	cp $(ENGINE_DIR)/bundles/cross/windows/amd64-daemon/dockerd.exe build/win/amd64/docker/dockerd.exe
+	cp $(ENGINE_DIR)/bundles/cross/windows/amd64-daemon/docker-proxy.exe build/win/amd64/docker/docker-proxy.exe
 	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43762

Upstream moby no longer includes the version in the built binaries, so remving it here.
