### PR TITLE
[master] verify: rpm: don't perform dnf upgrade

### DIFF
--- a/verify
+++ b/verify
@@ -102,7 +102,7 @@ function verify_rpm() {
 	if dnf --version; then
 		pkg_manager="dnf"
 		pkg_config_manager="dnf config-manager"
-		dnf clean all && dnf upgrade -y
+		dnf clean all
 		${pkg_manager} install -y 'dnf-command(config-manager)'
 	fi
 


### PR DESCRIPTION
This was added as part of 6dfaf9cc43198e7f0d0f87b7bcc1d78525662882, which came
from our internal repositories, but the original commits from there didn't have
context why an upgrade was performed.

In general, it's best practice to not perform a (dist-)upgrade inside the image,
and just depend on the image maintainers to have the image being up-to-date, so
removing this step.
