### PR TITLE
[master] verify: rpm: force release-version for Fedora pre-releases

### DIFF
--- a/verify
+++ b/verify
@@ -125,6 +125,13 @@ function verify_rpm() {
 	# install all non-source packages
 	(
 		set -x
+		product_version=$(source /etc/os-release; echo "${REDHAT_SUPPORT_PRODUCT_VERSION:-}")
+		if [ "$product_version" = 'rawhide' ]; then
+				# force $releasever to account for Fedora pre-release images, as they
+				# may still be using "rawhide", which is not present on our package
+				# repositories on download.docker.com.
+				export DNF_VAR_releasever="$DIST_VERSION"
+		fi
 		${pkg_manager} install -y ${packages}
 	)
 


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/729

On pre-releases of Fedora, the image may still have `rawhide` as distro-version,
which causes the verify script to fail (as download.docker.com does not have a
"rawhide" channel)

This patch forces the verify script to use the DIST_VERSION as specified in the
Dockerfile.
