### PR TITLE
[20.10 backport] rpm: add Fedora 37

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ def pkgs = [
     [target: "debian-bullseye",          image: "debian:bullseye",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (Next stable)
     [target: "fedora-35",                image: "fedora:35",                              arches: ["amd64", "aarch64"]],          // EOL: November 30, 2022
     [target: "fedora-36",                image: "fedora:36",                              arches: ["amd64", "aarch64"]],          // EOL: May 24, 2023
+    [target: "fedora-37",                image: "fedora:37",                              arches: ["amd64", "aarch64"]],          // EOL: TBD
     [target: "raspbian-buster",          image: "balenalib/rpi-raspbian:buster",          arches: ["armhf"]],                     // Debian/Raspbian 10 (EOL: 2024)
     [target: "raspbian-bullseye",        image: "balenalib/rpi-raspbian:bullseye",        arches: ["armhf"]],                     // Debian/Raspbian 11 (Next stable)
     [target: "ubuntu-bionic",            image: "ubuntu:bionic",                          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 18.04 LTS (End of support: April, 2023. EOL: April, 2028)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -54,7 +54,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-36 fedora-35
+FEDORA_RELEASES ?= fedora-37 fedora-36 fedora-35
 CENTOS_RELEASES ?= centos-7 centos-8 centos-9
 ifeq ($(ARCH),s390x)
 RHEL_RELEASES ?= rhel-7

--- a/rpm/fedora-37/Dockerfile
+++ b/rpm/fedora-37/Dockerfile
@@ -1,0 +1,33 @@
+ARG GO_IMAGE
+ARG DISTRO=fedora
+ARG SUITE=37
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS seccomp selinux
+ENV RUNC_BUILDTAGS seccomp selinux
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY SPECS /root/rpmbuild/SPECS
+
+# TODO change once we support scan-plugin on other architectures
+RUN \
+  if [ "$(uname -m)" = "x86_64" ]; then \
+    dnf builddep -y /root/rpmbuild/SPECS/*.spec; \
+  else \
+    dnf builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
+  fi
+
+COPY --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
- similar to https://github.com/docker/docker-ce-packaging/pull/729

not yet released, but pre-release images are available

similar to https://github.com/docker/docker-ce-packaging/commit/042e08aabc7669a4d544c9e451ff8ba50818f0a6, but with some differences for the 20.10 branch;

- added back DOCKER_BUILDTAGS, RUNC_BUILDTAGS
- removed `docker-b*.spec` in Dockerfile
