### PR TITLE
[20.10] stop building deprecated docker app plugin for macOS

### DIFF
--- a/static/scripts/build-cli-plugins
+++ b/static/scripts/build-cli-plugins
@@ -7,6 +7,11 @@ shopt -s globstar
 # /plugins should be volume mounted from root plugins dir
 # /out should also be volume mounted from static/out/
 for installer in /plugins/*.installer; do
+	if [ "${installer##*/}" = "app.installer" ] && [ "$GOOS" = "darwin" ]; then
+		# skip building docker-app on macOS, because it's deprecated, and the
+		# vendored version of golang.org/x/sys is incompatible with go1.18 and up.
+		continue
+	fi
 	bash "${installer}" build
 	DESTDIR='/out' PREFIX="/" bash "${installer}" install_plugin
 done


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/740

Docker App has been deprecated after the initial 20.10 release, and so far we
continued packaging it (to not remove features as part of a patch release).
However, the current code for docker app uses a version of golang.org/x/sys
that is incompatible with go1.18 on macOS, causing the build to fail;

    go build -tags= -ldflags="-s -w -X github.com/docker/app/internal.GitCommit=9d2c67f8 -X github.com/docker/app/internal.Version=v0.9.1-beta3" -o bin/docker-app ./cmd/docker-app
    # github.com/docker/app/vendor/golang.org/x/sys/unix
    vendor/golang.org/x/sys/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
    vendor/golang.org/x/sys/unix/zsyscall_darwin_amd64.go:121:3: too many errors

This patch skips building the binary on macOS; given that docker app no longer
is shipping with Docker Desktop on macOS, and there may be only a very limited
number of users (if any) depending on this binary on macOS.

Users that need this binary can continue using the build from previous patch
releases (as the no updates were made in this plugin since).
