### PR TITLE
deb, rpm: inline go build for compose

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -27,8 +27,13 @@ override_dh_auto_build:
 	cd /go/src/github.com/docker/compose \
 	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download \
 	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
-	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on GIT_TAG=$(COMPOSE_VERSION) \
-		make COMPOSE_BINARY=/usr/libexec/docker/cli-plugins/docker-compose -f builder.Makefile compose-plugin
+	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on \
+		CGO_ENABLED=0 \
+			go build \
+				-trimpath \
+				-ldflags="-s -w -X github.com/docker/compose/v2/internal.Version=$(COMPOSE_VERSION)" \
+				-o "/usr/libexec/docker/cli-plugins/docker-compose" \
+				./cmd
 
 	# Build the scan-plugin
 	# TODO change once we support scan-plugin on other architectures

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -38,8 +38,13 @@ pushd ${RPM_BUILD_DIR}/src/compose
     # FIXME: using GOPROXY, to work around:
     # go: github.com/Azure/azure-sdk-for-go@v48.2.0+incompatible: reading github.com/Azure/azure-sdk-for-go/go.mod at revision v48.2.0: unknown revision v48.2.0
     GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download
-    GOPROXY="https://proxy.golang.org" GO111MODULE=on GIT_TAG="%{_compose_version}" \
-        make COMPOSE_BINARY="bin/docker-compose" -f builder.Makefile compose-plugin
+    GOPROXY="https://proxy.golang.org" GO111MODULE=on \
+    CGO_ENABLED=0 \
+        go build \
+            -trimpath \
+            -ldflags="-s -w -X github.com/docker/compose/v2/internal.Version=%{_compose_version}" \
+            -o "bin/docker-compose" \
+            ./cmd
 popd
 
 %check


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/9744
- relates to https://github.com/docker/compose/pull/9771
- relates to https://github.com/docker/docker-ce-packaging/pull/742


The build.Makefile was removed from the compose repository, so copying the code to build the plugin here.
