### PR TITLE
[20.10 backport] Update GOPROXY to use default with fallback

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -28,7 +28,6 @@ BUILD?=DOCKER_BUILDKIT=1 \
 RUN_FLAGS=
 RUN?=docker run --rm \
 	-e PLATFORM \
-	-e GOPROXY=https://proxy.golang.org \
 	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(word 1, $(GEN_DEB_VER)) \
 	-e VERSION=$(word 2, $(GEN_DEB_VER)) \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -19,12 +19,10 @@ override_dh_auto_build:
 		LDFLAGS='' DISABLE_WARN_OUTSIDE_CONTAINER=1 make VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) dynbinary manpages
 
 	# Build the compose plugin
-	# FIXME: using GOPROXY, to work around:
-	# go: github.com/Azure/azure-sdk-for-go@v48.2.0+incompatible: reading github.com/Azure/azure-sdk-for-go/go.mod at revision v48.2.0: unknown revision v48.2.0
 	cd /go/src/github.com/docker/compose \
-	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download \
+	&& GO111MODULE=on go mod download \
 	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
-	&& GOPROXY="https://proxy.golang.org" GO111MODULE=on \
+	&& GO111MODULE=on \
 		CGO_ENABLED=0 \
 			go build \
 				-trimpath \

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BUILD_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BUILD_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BUILD_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BUILD_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -10,7 +10,7 @@ FROM ${BUILD_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -16,7 +16,7 @@ RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -16,7 +16,7 @@ RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl devscripts equivs git
 
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -47,7 +47,6 @@ RPMBUILD_FLAGS?=-ba\
 RUN_FLAGS=
 RUN?=docker run --rm \
 	-e PLATFORM \
-	-e GOPROXY=https://proxy.golang.org \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES:ro \
 	-v $(CURDIR)/rpmbuild/$@/RPMS:/root/rpmbuild/RPMS \
 	-v $(CURDIR)/rpmbuild/$@/SRPMS:/root/rpmbuild/SRPMS \

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -27,10 +27,8 @@ Docker Compose V1 ('docker-compose').
 
 %build
 pushd ${RPM_BUILD_DIR}/src/compose
-    # FIXME: using GOPROXY, to work around:
-    # go: github.com/Azure/azure-sdk-for-go@v48.2.0+incompatible: reading github.com/Azure/azure-sdk-for-go/go.mod at revision v48.2.0: unknown revision v48.2.0
-    GOPROXY="https://proxy.golang.org" GO111MODULE=on go mod download
-    GOPROXY="https://proxy.golang.org" GO111MODULE=on \
+    GO111MODULE=on go mod download
+    GO111MODULE=on \
     CGO_ENABLED=0 \
         go build \
             -trimpath \

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -7,11 +7,7 @@ FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
 
-# Using goproxy instead of "direct" to work around an issue in go mod
-# not working with older git versions (default version on CentOS 7 is
-# git 1.8), see https://github.com/golang/go/issues/38373, and
-# https://github.com/docker/docker-ce-packaging/pull/631#issuecomment-1059363763
-ENV GOPROXY=https://proxy.golang.org
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/fedora-35/Dockerfile
+++ b/rpm/fedora-35/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/fedora-36/Dockerfile
+++ b/rpm/fedora-36/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/fedora-37/Dockerfile
+++ b/rpm/fedora-37/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin

--- a/rpm/rhel-7/Dockerfile
+++ b/rpm/rhel-7/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_IMAGE=dockereng/${DISTRO}:${SUITE}-s390x
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE}
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/745


Use the default proxy, to assist with LTS distros that use old git versions
but fallback on any error (instead of only on 404 and 410).

From the Go documentation; https://go.dev/ref/mod#goproxy-protocol

> List elements may be separated by commas (,) or pipes (|), which determine error
> fallback behavior. When a URL is followed by a comma, the go command falls back
> to later sources only after a 404 (Not Found) or 410 (Gone) response. When a URL
> is followed by a pipe, the go command falls back to later sources after any error,
> including non-HTTP errors such as timeouts. This error handling behavior lets a
> proxy act as a gatekeeper for unknown modules. For example, a proxy could respond
> with error 403 (Forbidden) for modules not on an approved list (see Private proxy
> serving private modules).

(cherry picked from commit 72d51db78ec3a5254bfa94bb201acc2912188ff9)
