### PR TITLE
[master] verify: add minimal check for compose, buildx, scan

### DIFF
--- a/verify
+++ b/verify
@@ -25,6 +25,20 @@ function verify() {
 	fi
 }
 
+function verify_binaries() {
+	docker --version
+	if [ "$(uname -m)" = "x86_64" ]; then
+		# FIXME this tries to connect to the docker daemon, which isn't started
+		# docker scan --accept-license --version;
+		docker scan --help
+	fi
+	docker buildx version
+	docker compose version
+	dockerd --version
+	containerd --version
+	runc --version
+}
+
 function verify_deb() {
 	# First install prerequisites for our script and dpkg and apt to run correctly.
 	# This list SHOULD NOT include dependencies of docker itself, otherwise we would
@@ -83,14 +97,8 @@ function verify_deb() {
 		# shellcheck disable=SC2086
 		apt-get -y install --no-install-recommends --no-upgrade --fix-broken ${packages}
 	)
-	docker --version
-	# FIXME this tries to connect to the docker daemon, which isn't started
-	#if [ "$(uname -m)" = "x86_64" ]; then
-	#	docker scan --accept-license --version;
-	#fi
-	dockerd --version
-	containerd --version
-	runc --version
+
+	verify_binaries
 }
 
 function verify_rpm() {
@@ -135,15 +143,7 @@ function verify_rpm() {
 		${pkg_manager} install -y ${packages}
 	)
 
-	docker --version
-	# FIXME this tries to connect to the docker daemon, which isn't started
-	#if [ "$(uname -m)" = "x86_64" ]; then
-	#	docker scan --accept-license --version;
-	#fi
-	dockerd --version
-	containerd --version
-	runc --version
-
+	verify_binaries
 }
 
 verify


### PR DESCRIPTION
With this patch;

```
+ docker --version
Docker version 0.0.0-20220820144233-1163b46, build 1163b46
++ uname -m
+ '[' x86_64 = x86_64 ']'
+ docker scan --help

Usage:  docker scan [OPTIONS] IMAGE

A tool to scan your images

Options:
      --accept-license    Accept using a third party scanning provider
      --dependency-tree   Show dependency tree with scan results
      --exclude-base      Exclude base image from vulnerability scanning
                          (requires --file)
  -f, --file string       Dockerfile associated with image, provides more
                          detailed results
      --group-issues      Aggregate duplicated vulnerabilities and group
                          them to a single one (requires --json)
      --json              Output results in JSON format
      --login             Authenticate to the scan provider using an
                          optional token (with --token), or web base
                          token if empty
      --reject-license    Reject using a third party scanning provider
      --severity string   Only report vulnerabilities of provided level
                          or higher (low|medium|high)
      --token string      Authentication token to login to the third
                          party scanning provider
      --version           Display version of the scan plugin
+ docker buildx version
github.com/docker/buildx v0.9.1 %{_buildx_gitcommit}
+ docker compose version
Docker Compose version v2.10.0
+ dockerd --version
Docker version 0.0.0-20220820144233-1163b46, build ab37723
+ containerd --version
containerd containerd.io 1.6.7 0197261a30bf81f1ee8e6a4dd2dea0ef95d67ccb
+ runc --version
runc version 1.1.3
commit: v1.1.3-0-g6724737
spec: 1.0.2-dev
go: go1.17.13
libseccomp: 2.5.3
```