### PR TITLE
[master] buildx: fix missing git-commit in version

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -9,6 +9,7 @@ GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 EPOCH?=5
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
+BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
@@ -34,6 +35,7 @@ RUN?=docker run --rm \
 	-e CLI_GITCOMMIT=$(CLI_GITCOMMIT) \
 	-e ENGINE_GITCOMMIT=$(ENGINE_GITCOMMIT) \
 	-e BUILDX_VERSION=$(DOCKER_BUILDX_REF) \
+	-e BUILDX_GITCOMMIT=$(BUILDX_GITCOMMIT) \
 	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
 	-e SCAN_VERSION=$(DOCKER_SCAN_REF) \
 	-e SCAN_GITCOMMIT=$(SCAN_GITCOMMIT) \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -19,7 +19,7 @@ override_dh_auto_build:
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \
 	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
-	&& CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o /usr/libexec/docker/cli-plugins/docker-buildx -ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(git rev-parse HEAD) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" ./cmd/buildx
+	&& CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o /usr/libexec/docker/cli-plugins/docker-buildx -ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(BUILDX_GITCOMMIT) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" ./cmd/buildx
 
 	# Build the compose plugin
 	cd /go/src/github.com/docker/compose \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -19,7 +19,14 @@ override_dh_auto_build:
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \
 	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
-	&& CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o /usr/libexec/docker/cli-plugins/docker-buildx -ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(BUILDX_GITCOMMIT) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" ./cmd/buildx
+	&& GO111MODULE=on \
+		CGO_ENABLED=0 \
+			go build \
+				-mod=vendor \
+				-trimpath \
+				-ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(BUILDX_GITCOMMIT) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
+				-o "/usr/libexec/docker/cli-plugins/docker-buildx" \
+				./cmd/buildx
 
 	# Build the compose plugin
 	cd /go/src/github.com/docker/compose \

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -10,6 +10,7 @@ GEN_SCAN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/do
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
+BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
@@ -38,6 +39,7 @@ RPMBUILD_FLAGS?=-ba\
 	--define '_origversion $(word 4, $(GEN_RPM_VER))' \
 	--define '_buildx_rpm_version $(word 1,$(GEN_BUILDX_RPM_VER))' \
 	--define '_buildx_version $(word 4,$(GEN_BUILDX_RPM_VER))' \
+	--define '_buildx_gitcommit $(BUILDX_GITCOMMIT)' \
 	--define '_compose_rpm_version $(word 1,$(GEN_COMPOSE_RPM_VER))' \
 	--define '_compose_version $(word 4,$(GEN_COMPOSE_RPM_VER))' \
 	--define '_scan_rpm_version $(word 1,$(GEN_SCAN_RPM_VER))' \

--- a/rpm/SPECS/docker-buildx-plugin.spec
+++ b/rpm/SPECS/docker-buildx-plugin.spec
@@ -22,7 +22,14 @@ Docker Buildx plugin for the Docker CLI.
 
 %build
 pushd ${RPM_BUILD_DIR}/src/buildx
-bash -c 'CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o bin/docker-buildx -ldflags "-X github.com/docker/buildx/version.Version=%{_buildx_version} -X github.com/docker/buildx/version.Revision=%{_buildx_gitcommit} -X github.com/docker/buildx/version.Package=github.com/docker/buildx" ./cmd/buildx'
+	GO111MODULE=on \
+	CGO_ENABLED=0 \
+		go build \
+			-mod=vendor \
+			-trimpath \
+			-ldflags="-X github.com/docker/buildx/version.Version=%{_buildx_version} -X github.com/docker/buildx/version.Revision=%{_buildx_gitcommit} -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
+			-o "bin/docker-buildx" \
+			./cmd/buildx
 popd
 
 %check


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/749


### rpm: buildx: fix missing %{_buildx_gitcommit}

The Makefile did not set a `%{_buildx_gitcommit}` variable, causing the version
output to show as:

    docker buildx version
    github.com/docker/buildx v0.9.1 %{_buildx_gitcommit}


### deb: buildx: fix missing git-commit in version

The version output was missing the git-commit, because the deb build
tried to do a ``, but the source files used in the deb builds don't
include the git repository.

Before this:

    + docker buildx version
    github.com/docker/buildx v0.9.1

With this patch

    + docker buildx version
    github.com/docker/buildx v0.9.1 ed00243

### buildx: don't use bash, and enable "trimpath"

Don't use bash to compile buildx, re-format the build script to match
other parts, and enable trimpath.

We could also consider enabling `-s -w` to strip debugging symbols, as
we do for other binaries.

