### PR TITLE
[20.10 backport] compose: use updated makefile

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -20,15 +20,7 @@ override_dh_auto_build:
 
 	# Build the compose plugin
 	cd /go/src/github.com/docker/compose \
-	&& GO111MODULE=on go mod download \
-	&& mkdir -p /usr/libexec/docker/cli-plugins/ \
-	&& GO111MODULE=on \
-		CGO_ENABLED=0 \
-			go build \
-				-trimpath \
-				-ldflags="-s -w -X github.com/docker/compose/v2/internal.Version=$(COMPOSE_VERSION)" \
-				-o "/usr/libexec/docker/cli-plugins/docker-compose" \
-				./cmd
+	&& make VERSION=$(COMPOSE_VERSION) DESTDIR=/usr/libexec/docker/cli-plugins build
 
 	# Build the scan-plugin
 	# TODO change once we support scan-plugin on other architectures

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -27,14 +27,7 @@ Docker Compose V1 ('docker-compose').
 
 %build
 pushd ${RPM_BUILD_DIR}/src/compose
-    GO111MODULE=on go mod download
-    GO111MODULE=on \
-    CGO_ENABLED=0 \
-        go build \
-            -trimpath \
-            -ldflags="-s -w -X github.com/docker/compose/v2/internal.Version=%{_compose_version}" \
-            -o "bin/docker-compose" \
-            ./cmd
+    make VERSION=%{_compose_version} DESTDIR=./bin build
 popd
 
 %check


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/748

compose v2.10.1 comes with an updated Makefile, allowing us again
to use the makefile for building as part of the rpm/deb scripts.

(cherry picked from commit b0621bde559156e37044da4d6f5d6f71ec739d9f)
