### PR TITLE
compose: bump version to v2.11.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.17.0
-DOCKER_COMPOSE_REF ?= v2.11.0
+DOCKER_COMPOSE_REF ?= v2.11.2
 DOCKER_BUILDX_REF  ?= v0.9.1
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
https://github.com/docker/compose/releases/tag/v2.11.2