### PR TITLE
[master] compose: upgrade to v2.12.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.21.0
-DOCKER_COMPOSE_REF ?= v2.12.0
+DOCKER_COMPOSE_REF ?= v2.12.2
 DOCKER_BUILDX_REF  ?= v0.9.1
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
- closes #774

Supersedes #774 - v2.12.1 included a dependency that required Go 1.19 to build; v2.12.2 was released to use a fixed version of the dependency that retains Go 1.18 compatibility (needed by packaging for some versions).

https://github.com/docker/compose/releases/tag/v2.12.2