### PR TITLE
[20.10 backport] update scan-cli-plugin to v0.22.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -37,7 +37,7 @@ DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_SCAN_REF    ?= v0.21.0
+DOCKER_SCAN_REF    ?= v0.22.0
 DOCKER_COMPOSE_REF ?= v2.12.2
 
 export BUILDTIME


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/783

dep: bump snyk to v1.1054.0

full diff: https://github.com/docker/scan-cli-plugin/compare/v0.21.0...v0.22.0

(cherry picked from commit 6096cdbd5c70a3dbbdc8ed63f82d988db71861eb)
