### PR TITLE
[master] update buildx to v0.10.0-rc2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
 DOCKER_COMPOSE_REF ?= v2.14.1
-DOCKER_BUILDX_REF  ?= v0.10.0-rc1
+DOCKER_BUILDX_REF  ?= v0.10.0-rc2
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.10.0-rc2
