### PR TITLE
[20.10] update buildx to v0.10.0

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.9.1}"
+: "${BUILDX_COMMIT=v0.10.0}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
equivalent of https://github.com/docker/docker-ce-packaging/pull/812 for 20.10


- release notes: https://github.com/docker/buildx/releases/tag/v0.10.0
- full diff: https://github.com/docker/buildx/compare/v0.10.0-rc2...v0.10.0
