### PR TITLE
deb: cleanup makefile, remove unused GITCOMMIT, and pass VERSION_ID through Dockerfile

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,7 +1,6 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
-GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,12 +1,12 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
-CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
-ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 EPOCH?=5
+GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
+ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
 BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
 

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -43,8 +43,6 @@ debSource="$(awk -F ': ' '$1 == "Source" { print $2; exit }' debian/control)"
 debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)"
 debDate="$(date --rfc-2822)"
 
-versionID="$(. /etc/os-release && echo "$VERSION_ID")"
-
 # Include an extra `.0` in the version, in case we ever would have to re-build an
 # already published release with a packaging-only change.
 pkgRevision=0
@@ -76,7 +74,7 @@ pkgRevision=0
 # docker-ce_22.10.6~beta.0-0~debian.11.0~bullseye_amd64.deb
 # docker-ce_22.10.6~beta.0-0~ubuntu.22.04.0~jammy_amd64.deb
 cat > "debian/changelog" <<-EOF
-$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}.${versionID}.${pkgRevision}~${SUITE}) $SUITE; urgency=low
+$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}.${VERSION_ID}.${pkgRevision}~${SUITE}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=bullseye
+ARG VERSION_ID=11
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -23,8 +24,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=buster
+ARG VERSION_ID=10
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -23,8 +24,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=bullseye
+ARG VERSION_ID=11
 ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -23,8 +24,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=buster
+ARG VERSION_ID=10
 ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -23,8 +24,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=bionic
+ARG VERSION_ID=18.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -23,8 +24,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=focal
+ARG VERSION_ID=20.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -29,8 +30,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=jammy
+ARG VERSION_ID=22.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -29,8 +30,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-kinetic/Dockerfile
+++ b/deb/ubuntu-kinetic/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=kinetic
+ARG VERSION_ID=22.10
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -29,8 +30,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/issues/814

### deb: remove unused GITCOMMIT make var

It doesn't appear to be used anywhere

### deb: Makefile: sort vars similar to rpm variant

For easier comparing :)

### deb: pass VERSION_ID through Dockerfile

We'll be using VERSION_ID in other places, so adding it in the Dockerfile makes
sure it's always present, without having to depend on /etc/os-release.
