### PR TITLE
verify: check more binaries

### DIFF
--- a/verify
+++ b/verify
@@ -35,7 +35,14 @@ function verify_binaries() {
 	docker buildx version
 	docker compose version
 	dockerd --version
+	docker-proxy --version
 	containerd --version
+	ctr --version
+	# containerd-shim v1.6.x does not have a -v flag.
+	# TODO(thaJeztah): use -v once we switch to containerd 1.7 (see https://github.com/containerd/containerd/pull/6495)
+	containerd-shim --help
+	containerd-shim-runc-v1 -v
+	containerd-shim-runc-v2 -v
 	runc --version
 }
 


### PR DESCRIPTION
This verification is still very "bare boned", but makes sure that the binaries are not completely defunct, and that installation of the package installs the expected binaries.

    make IMAGE=ubuntu:jammy verify
    # ...

    + verify_binaries
    + docker --version
    Docker version 23.0.0-rc.2, build f163d24
    ++ uname -m
    + '[' aarch64 = x86_64 ']'
    + docker buildx version
    github.com/docker/buildx v0.10.0 8764628
    + docker compose version
    Docker Compose version v2.15.1
    + dockerd --version
    Docker version 23.0.0-rc.2, build 9fd3a437
    + docker-proxy --version
    docker-proxy (commit 9fd3a437) version 23.0.0-rc.2
    + containerd --version
    containerd containerd.io 1.6.15 5b842e528e99d4d4c1686467debf2bd4b88ecd86
    + ctr --version
    ctr containerd.io 1.6.15
    + containerd-shim --help
    Usage of containerd-shim:
      -address string
            grpc address back to main containerd
      -containerd-binary containerd publish
            path to containerd binary (used for containerd publish) (default "containerd")
      -criu string
            path to criu binary
      -debug
            enable debug output in logs
      -namespace string
            namespace that owns the shim
      -runtime-root string
            root directory for the runtime (default "/run/containerd/runc")
      -socket string
            socket path to serve
      -systemd-cgroup
            set runtime to use systemd-cgroup
      -workdir string
            path used to storge large temporary data
    + containerd-shim-runc-v1 -v
    containerd-shim-runc-v1:
      Version:  1.6.15
      Revision: 5b842e528e99d4d4c1686467debf2bd4b88ecd86
      Go version: go1.18.9

    + containerd-shim-runc-v2 -v
    containerd-shim-runc-v2:
      Version:  1.6.15
      Revision: 5b842e528e99d4d4c1686467debf2bd4b88ecd86
      Go version: go1.18.9

    + runc --version
    runc version 1.1.4
    commit: v1.1.4-0-g5fd4c4d
    spec: 1.0.2-dev
    go: go1.18.9
    libseccomp: 2.5.3

