### PR TITLE
deb: fix plugin versions to have correct format for deb packages

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -5,6 +5,9 @@ GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 EPOCH?=5
 GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+GEN_BUILDX_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/buildx) "$(DOCKER_BUILDX_REF)")
+GEN_COMPOSE_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
+GEN_SCAN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) "$(DOCKER_SCAN_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
@@ -34,9 +37,12 @@ RUN?=docker run --rm \
 	-e CLI_GITCOMMIT=$(CLI_GITCOMMIT) \
 	-e ENGINE_GITCOMMIT=$(ENGINE_GITCOMMIT) \
 	-e BUILDX_VERSION=$(DOCKER_BUILDX_REF) \
+	-e BUILDX_DEB_VERSION=$(word 1, $(GEN_BUILDX_DEB_VER)) \
 	-e BUILDX_GITCOMMIT=$(BUILDX_GITCOMMIT) \
 	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
+	-e COMPOSE_DEB_VERSION=$(word 1, $(GEN_COMPOSE_DEB_VER)) \
 	-e SCAN_VERSION=$(DOCKER_SCAN_REF) \
+	-e SCAN_DEB_VERSION=$(word 1, $(GEN_SCAN_DEB_VER)) \
 	-e SCAN_GITCOMMIT=$(SCAN_GITCOMMIT) \
 	-v $(CURDIR)/debbuild/$@:/build \
 	$(RUN_FLAGS) \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -111,17 +111,17 @@ override_dh_install:
 override_dh_gencontrol:
 	# Use separate version for the buildx-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to buildx, as it doesn't match the package name)
-	dh_gencontrol -pdocker-buildx-plugin -- -v$${BUILDX_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-buildx-plugin -- -v$${BUILDX_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
 
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
-	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
 
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)
 	# TODO change once we support scan-plugin on other architectures (see dpkg-architecture -L)
 	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
-		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_VERSION#v}~$${DISTRO}-$${SUITE}; \
+		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_DEB_VERSION#v}~$${DISTRO}-$${SUITE}; \
 	fi
 	dh_gencontrol --remaining-packages
 


### PR DESCRIPTION
- relates to / addresses https://github.com/docker/docker-ce-packaging/issues/814


We already had code for this in the RPM packages, but were missing this in the deb variants. Because of this, pre-release packages used a hyphen (-) as separator for pre-releases, which get sorted as a "higher" version than a non-pre-release:

    dpkg --compare-versions "0.10.0" ">>" "0.10.0-rc2" && echo "OK" || echo "KO"
    KO

With this patch, the packages have a correctly formatted version, using a tilde (~) as separator for the pre-release suffix:

    make DOCKER_CLI_REF=f163d2441e214176db89c63ffc557012113e28d8 DOCKER_ENGINE_REF=9fd3a437a6027637301b0952f7578644d7dff321 VERSION=23.0.0-rc.2 ubuntu-jammy

    tree deb/debbuild/
    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0~rc2~ubuntu-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-0~ubuntu.22.04.0~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-0~ubuntu.22.04.0~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-0~ubuntu.22.04.0~jammy.dsc
        ├── docker-ce_23.0.0~rc.2-0~ubuntu.22.04.0~jammy.tar.gz
        ├── docker-ce_23.0.0~rc.2-0~ubuntu.22.04.0~jammy_arm64.buildinfo
        ├── docker-ce_23.0.0~rc.2-0~ubuntu.22.04.0~jammy_arm64.changes
        ├── docker-ce_23.0.0~rc.2-0~ubuntu.22.04.0~jammy_arm64.deb
        └── docker-compose-plugin_2.15.1~ubuntu-jammy_arm64.deb

Using a tilde makes sure that pre-releases are sorted correctly:

    dpkg --compare-versions "0.10.0" ">>" "0.10.0~rc2" && echo "OK" || echo "KO"
    OK

The version reported through `docker buildx version` still uses the version as tagged in the repository (using a hyphen (-));

    make IMAGE=ubuntu:jammy verify

    + verify_binaries
    ...
    + docker buildx version
    github.com/docker/buildx v0.10.0-rc2 64e4c19
    ...

