### PR TITLE
update example versions

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -52,7 +52,7 @@ pkgRevision=0
 # Resulting packages are formatted as;
 #
 # - name of the package (e.g., "docker-ce")
-# - version (e.g., "22.10.6~beta.0")
+# - version (e.g., "23.0.0~beta.0")
 # - "-0" (mostly "best practice", and allows updating for specific situations)
 # - distro (e.g., "ubuntu")
 # - VERSION_ID (e.g. "22.04" or "11") this must be "sortable" to make sure that
@@ -71,8 +71,8 @@ pkgRevision=0
 #
 # Examples:
 #
-# docker-ce_22.10.6~beta.0-0~debian.11.0~bullseye_amd64.deb
-# docker-ce_22.10.6~beta.0-0~ubuntu.22.04.0~jammy_amd64.deb
+# docker-ce_23.0.0~beta.0-0~debian.11.0~bullseye_amd64.deb
+# docker-ce_23.0.0~beta.0-0~ubuntu.22.04.0~jammy_amd64.deb
 cat > "debian/changelog" <<-EOF
 $debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}.${VERSION_ID}.${pkgRevision}~${SUITE}) $SUITE; urgency=low
   * Version: $VERSION

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -37,11 +37,11 @@ rpmVersion="${VERSION#v}"
 # Assuming all tagged version of rpmRelease correspond with an upstream release,
 # this means that versioning is as follows:
 #
-# Docker 22.06.0:         version=22.06.0, release=1
-# Docker 22.06.0-alpha.1: version=22.06.0, release=1
-# Docker 22.06.0-beta.1:  version=22.06.0, release=1
-# Docker 22.06.0-rc.1:    version=22.06.0, release=1
-# Docker 22.06.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
+# Docker 23.0.0:         version=23.0.0, release=1
+# Docker 23.0.0-alpha.1: version=23.0.0, release=1
+# Docker 23.0.0-beta.1:  version=23.0.0, release=1
+# Docker 23.0.0-rc.1:    version=23.0.0, release=1
+# Docker 23.0.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
 rpmRelease=1
 
 # rpm packages require a tilde (~) instead of a hyphen (-) as separator between


### PR DESCRIPTION
Starting with Docker 23.0.0, we're moving away from CalVer, instead using SemVer(ish) versions. This aptch updates some examples used to match the new format.
