### PR TITLE
[master] deb: buildx, compose: include packaging revision and distro version in version

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -118,7 +118,7 @@ override_dh_gencontrol:
 
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
-	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}-$${SUITE}
 
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -114,7 +114,7 @@ override_dh_install:
 override_dh_gencontrol:
 	# Use separate version for the buildx-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to buildx, as it doesn't match the package name)
-	dh_gencontrol -pdocker-buildx-plugin -- -v$${BUILDX_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-buildx-plugin -- -v$${BUILDX_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}-$${SUITE}
 
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -2,6 +2,9 @@
 
 VERSION ?= $(shell cat engine/VERSION)
 TARGET_ARCH = $(shell dpkg-architecture -qDEB_TARGET_ARCH)
+# TODO(thaJeztah): allow passing this version when building.
+PKG_REVISION ?= 1
+export PKG_REVISION
 
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'


### PR DESCRIPTION
- fixes https://github.com/docker/docker-ce-packaging/issues/814


### deb: introduce PKG_REVISION variable

This variable can be used as packaging-revision in package versions

### deb: buildx: include packaging revision and distro version in version

Aligning the plugin's version with the format used for docker-ce and
docker-ce-cli, as updated in https://github.com/docker/docker-ce-packaging/commit/39772a761dfdf810cc23a1ec6084ea3100e6abf0

Before this patch:

    tree deb/debbuild/
    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0~ubuntu-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        └── docker-compose-plugin_2.15.1~ubuntu-jammy_arm64.deb

With this patch:

    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0-1~ubuntu.22.04-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        └── docker-compose-plugin_2.15.1~ubuntu-jammy_arm64.deb

### deb: compose: include packaging revision and distro version in version

Aligning the plugin's version with the format used for docker-ce and
docker-ce-cli, as updated in https://github.com/docker/docker-ce-packaging/commit/39772a761dfdf810cc23a1ec6084ea3100e6abf0

Before this patch:

    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0-1~ubuntu.22.04-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        └── docker-compose-plugin_2.15.1~ubuntu-jammy_arm64.deb

With this patch:

    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0-1~ubuntu.22.04-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        └── docker-compose-plugin_2.15.1-1~ubuntu.22.04-jammy_arm64.deb