### PR TITLE
[WIP] [master] add PKG_REVISION to static builds

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -22,6 +22,10 @@ PLATFORM=Docker Engine - Community
 SHELL:=/bin/bash
 VERSION?=0.0.1-dev
 
+# PKG_REVISION is used for packaging-only releases. This variable is used
+# when constructing the deb, rpm, and static versions.
+PKG_REVISION ?= 1
+
 # DOCKER_CLI_REPO and DOCKER_ENGINE_REPO define the source repositories to clone
 # the source from. These can be overridden to build from a fork.
 DOCKER_CLI_REPO     ?= https://github.com/docker/cli.git
@@ -53,4 +57,5 @@ VERIFY_PLATFORM ?=
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE
 export PACKAGER_NAME
+export PKG_REVISION
 export PLATFORM

--- a/static/Makefile
+++ b/static/Makefile
@@ -46,7 +46,7 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 	for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
 		cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker/$$f; \
 	done
-	tar -C build/linux -c -z -f build/linux/docker-$(GEN_STATIC_VER).tgz docker
+	tar -C build/linux -c -z -f build/linux/docker-$(GEN_STATIC_VER)-$(PKG_REVISION).tgz docker
 
 	# extra binaries for running rootless
 	mkdir -p build/linux/docker-rootless-extras
@@ -55,10 +55,10 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 			cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker-rootless-extras/$$f; \
 		fi \
 	done
-	tar -C build/linux -c -z -f build/linux/docker-rootless-extras-$(GEN_STATIC_VER).tgz docker-rootless-extras
+	tar -C build/linux -c -z -f build/linux/docker-rootless-extras-$(GEN_STATIC_VER)-$(PKG_REVISION).tgz docker-rootless-extras
 
 	# buildx
-	tar -C $(BUILDX_DIR)/bin -c -z -f build/linux/docker-buildx-plugin-$(DOCKER_BUILDX_REF:v%=%).tgz docker-buildx
+	tar -C $(BUILDX_DIR)/bin -c -z -f build/linux/docker-buildx-plugin-$(DOCKER_BUILDX_REF:v%=%)-$(PKG_REVISION).tgz docker-buildx
 
 .PHONY: hash_files
 hash_files:
@@ -76,7 +76,7 @@ cross-mac: buildx
 		arch=$$(echo $$platform | cut -d_ -f2); \
 		mkdir -p $$dest/$$arch/docker; \
 		cp $$platform/docker-darwin-* $$dest/$$arch/docker/docker && \
-		tar -C $$dest/$$arch -c -z -f $$dest/$$arch/docker-$(GEN_STATIC_VER).tgz docker; \
+		tar -C $$dest/$$arch -c -z -f $$dest/$$arch/docker-$(GEN_STATIC_VER)-$(PKG_REVISION).tgz docker; \
 	done
 
 .PHONY: cross-win
@@ -86,14 +86,14 @@ cross-win: cross-win-engine
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/amd64/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/win/dockerd.exe build/win/amd64/docker/dockerd.exe
 	cp $(ENGINE_DIR)/bundles/cross/win/docker-proxy.exe build/win/amd64/docker/docker-proxy.exe
-	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
+	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER)-$(PKG_REVISION).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 
 .PHONY: cross-arm
 cross-arm: cross-all-cli ## create tgz with linux armhf client only
 	mkdir -p build/arm/docker
 	cp $(CLI_DIR)/build/docker-linux-arm build/arm/docker/docker
-	tar -C build/arm -c -z -f build/arm/docker-$(GEN_STATIC_VER).tgz docker
+	tar -C build/arm -c -z -f build/arm/docker-$(GEN_STATIC_VER)-$(PKG_REVISION).tgz docker
 
 .PHONY: static-cli
 static-cli:


### PR DESCRIPTION
This is still failing, and needs work;

```
 => [linux/arm/v6 binary 1/1] COPY --from=build /out .                                                                                                                                                          0.0s
 => [linux/arm64->amd64 build 2/3] RUN [ ! -f /etc/alpine-release ] && xx-info is-cross && [ "$(xx-info arch)" = "arm64" ] && XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple || true                     0.1s
 => [linux/arm64->amd64 build 3/3] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=from=dockercore/golang-cross:xx-sdk-extras,target=/xx-sdk,src=/xx-sdk     --mount=  2.7s
 => [linux/s390x binary 1/1] COPY --from=build /out .                                                                                                                                                           0.0s
 => [darwin/amd64 binary 1/1] COPY --from=build /out .                                                                                                                                                          0.0s
 => [linux/amd64 binary 1/1] COPY --from=build /out .                                                                                                                                                           0.0s
 => [darwin/arm64 binary 1/1] COPY --from=build /out .                                                                                                                                                          0.0s
 => exporting to client directory                                                                                                                                                                               3.4s
 => => copying files windows/arm64 33.12MB                                                                                                                                                                      3.3s
 => => copying files linux/riscv64 33.48MB                                                                                                                                                                      3.3s
 => => copying files darwin/arm64 35.03MB                                                                                                                                                                       3.4s
 => => copying files linux/arm64 33.18MB                                                                                                                                                                        3.3s
 => => copying files linux/arm/v6 33.26MB                                                                                                                                                                       3.2s
 => => copying files darwin/amd64 36.81MB                                                                                                                                                                       3.4s
 => => copying files linux/amd64 34.48MB                                                                                                                                                                        3.4s
 => => copying files linux/ppc64le 32.76MB                                                                                                                                                                      3.2s
 => => copying files linux/arm/v7 33.21MB                                                                                                                                                                       3.2s
 => => copying files linux/s390x 34.66MB                                                                                                                                                                        3.4s
 => => copying files windows/amd64 34.41MB                                                                                                                                                                      3.3s
mkdir -p build/arm/docker
cp /Users/thajeztah/go/src/github.com/docker/docker-ce-packaging/src/github.com/docker/cli/build/docker-linux-arm build/arm/docker/docker
cp: /Users/thajeztah/go/src/github.com/docker/docker-ce-packaging/src/github.com/docker/cli/build/docker-linux-arm: No such file or directory
make[1]: *** [cross-arm] Error 1
make: *** [static] Error 2
```

```
tree static/build
static/build
├── arm
│   └── docker
├── linux
│   ├── docker
│   │   ├── containerd
│   │   ├── containerd-shim-runc-v2
│   │   ├── ctr
│   │   ├── docker
│   │   ├── docker-init
│   │   ├── docker-proxy
│   │   ├── dockerd
│   │   └── runc
│   ├── docker-23.0.0-rc.2-1.tgz
│   ├── docker-buildx-plugin-0.10.0-1.tgz
│   ├── docker-rootless-extras
│   │   ├── dockerd-rootless-setuptool.sh
│   │   ├── dockerd-rootless.sh
│   │   ├── rootlesskit
│   │   ├── rootlesskit-docker-proxy
│   │   └── vpnkit
│   └── docker-rootless-extras-23.0.0-rc.2-1.tgz
├── mac
│   ├── amd64
│   │   ├── docker
│   │   │   └── docker
│   │   └── docker-23.0.0-rc.2-1.tgz
│   ├── arm
│   │   └── docker
│   ├── arm64
│   │   ├── docker
│   │   │   └── docker
│   │   └── docker-23.0.0-rc.2-1.tgz
│   ├── docker
│   │   └── docker
│   ├── docker-linux-arm64
│   │   └── docker
│   ├── docker-windows-amd64.exe
│   │   └── docker
│   ├── ppc64le
│   │   └── docker
│   ├── riscv64
│   │   └── docker
│   └── s390x
│       └── docker
└── win
    └── amd64
        ├── docker
        │   ├── docker-proxy.exe
        │   ├── docker.exe
        │   └── dockerd.exe
        └── docker-23.0.0-rc.2-1.zip

27 directories, 24 files

```
