### PR TITLE
[20.10 backport] fix plugin package versioning for compose

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,7 +1,6 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
-GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -5,6 +5,8 @@ GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 EPOCH?=5
 GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+GEN_COMPOSE_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
+GEN_SCAN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) "$(DOCKER_SCAN_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
@@ -33,7 +35,9 @@ RUN?=docker run --rm \
 	-e CLI_GITCOMMIT=$(CLI_GITCOMMIT) \
 	-e ENGINE_GITCOMMIT=$(ENGINE_GITCOMMIT) \
 	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
+	-e COMPOSE_DEB_VERSION=$(word 1, $(GEN_COMPOSE_DEB_VER)) \
 	-e SCAN_VERSION=$(DOCKER_SCAN_REF) \
+	-e SCAN_DEB_VERSION=$(word 1, $(GEN_SCAN_DEB_VER)) \
 	-e SCAN_GITCOMMIT=$(SCAN_GITCOMMIT) \
 	-v $(CURDIR)/debbuild/$@:/build \
 	$(RUN_FLAGS) \

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -1,12 +1,12 @@
 include ../common.mk
 
 PLUGINS_DIR=$(realpath $(CURDIR)/../plugins)
-CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
-ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
-GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 EPOCH?=5
+GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
+CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
+ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -112,7 +112,7 @@ override_dh_install:
 override_dh_gencontrol:
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
-	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}-$${SUITE}
 
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -112,7 +112,7 @@ override_dh_install:
 override_dh_gencontrol:
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
-	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}-$${SUITE}
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}~$${SUITE}
 
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -109,13 +109,13 @@ override_dh_install:
 override_dh_gencontrol:
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
-	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_VERSION#v}~$${DISTRO}-$${SUITE}
+	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}~$${DISTRO}-$${SUITE}
 
 	# Use separate version for the scan-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)
 	# TODO change once we support scan-plugin on other architectures (see dpkg-architecture -L)
 	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
-		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_VERSION#v}~$${DISTRO}-$${SUITE}; \
+		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_DEB_VERSION#v}~$${DISTRO}-$${SUITE}; \
 	fi
 	dh_gencontrol --remaining-packages
 

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -2,6 +2,9 @@
 
 VERSION ?= $(shell cat engine/VERSION)
 TARGET_ARCH = $(shell dpkg-architecture -qDEB_TARGET_ARCH)
+# TODO(thaJeztah): allow passing this version when building.
+PKG_REVISION ?= 1
+export PKG_REVISION
 
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=bullseye
+ARG VERSION_ID=11
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -25,8 +26,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=buster
+ARG VERSION_ID=10
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -25,8 +26,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=bullseye
+ARG VERSION_ID=11
 ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -25,8 +26,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=buster
+ARG VERSION_ID=10
 ARG BUILD_IMAGE=balenalib/rpi-raspbian:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -25,8 +26,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-bionic/Dockerfile
+++ b/deb/ubuntu-bionic/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=bionic
+ARG VERSION_ID=18.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -25,8 +26,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=focal
+ARG VERSION_ID=20.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -31,8 +32,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=jammy
+ARG VERSION_ID=22.04
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -31,8 +32,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 

--- a/deb/ubuntu-kinetic/Dockerfile
+++ b/deb/ubuntu-kinetic/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=kinetic
+ARG VERSION_ID=22.10
 ARG BUILD_IMAGE=${DISTRO}:${SUITE}
 
 FROM ${GO_IMAGE} AS golang
@@ -31,8 +32,10 @@ RUN apt-get update \
 COPY sources/ /sources
 ARG DISTRO
 ARG SUITE
+ARG VERSION_ID
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
 
 COPY --from=golang /usr/local/go /usr/local/go
 


### PR DESCRIPTION
Partial (as buildx package is not built in this branch) backports of:

- https://github.com/docker/docker-ce-packaging/pull/817
- https://github.com/docker/docker-ce-packaging/pull/820
- https://github.com/docker/docker-ce-packaging/pull/822
- https://github.com/docker/docker-ce-packaging/pull/828