### PR TITLE
[20.10 backport] deb: scan: include packaging revision and distro version in version

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -118,7 +118,7 @@ override_dh_gencontrol:
 	# TODO override "Source" field in control as well (to point to scan-cli-plugin, as it doesn't match the package name)
 	# TODO change once we support scan-plugin on other architectures (see dpkg-architecture -L)
 	if [ "$(TARGET_ARCH)" = "amd64" ]; then \
-		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_DEB_VERSION#v}~$${DISTRO}-$${SUITE}; \
+		dh_gencontrol -pdocker-scan-plugin -- -v$${SCAN_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}~$${SUITE}; \
 	fi
 	dh_gencontrol --remaining-packages
 


### PR DESCRIPTION
- [x] depends on https://github.com/docker/docker-ce-packaging/pull/825
- [ ] depends on https://github.com/docker/docker-ce-packaging/pull/823
- [ ]  depends on a new version of scan-plugin to be released (we don't want to re-publish the same version)

Aligning the plugin's version with the format used for docker-ce and
docker-ce-cli, as updated in 39772a761dfdf810cc23a1ec6084ea3100e6abf0

Before this patch:

    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0-1~ubuntu.22.04-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-compose-plugin_2.15.1-1~ubuntu.22.04-jammy_arm64.deb
        └── docker-scan-plugin_0.23.0~ubuntu-jammy_arm64.deb

With this patch:

    deb/debbuild/
    └── ubuntu-jammy
        ├── docker-buildx-plugin_0.10.0-1~ubuntu.22.04-jammy_arm64.deb
        ├── docker-ce-cli_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce-rootless-extras_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-ce_23.0.0~rc.2-1~ubuntu.22.04~jammy_arm64.deb
        ├── docker-compose-plugin_2.15.1-1~ubuntu.22.04-jammy_arm64.deb
        └── docker-scan-plugin_0.23.0-1~ubuntu.22.04-jammy_arm64.deb
