### PR TITLE
[20.10 backport] [deb] fixes for version generating

### DIFF
--- a/deb/build-deb
+++ b/deb/build-deb
@@ -40,8 +40,11 @@ debSource="$(awk -F ': ' '$1 == "Source" { print $2; exit }' debian/control)"
 debMaintainer="$(awk -F ': ' '$1 == "Maintainer" { print $2; exit }' debian/control)"
 debDate="$(date --rfc-2822)"
 
+# Note: on the 20.10 branch, we preserve the "~3" suffix that was removed in
+#       commit 8a720b28a5d0db8fc93423cca79ca21b9b69f1f1, and continue using the
+#       old version scheme for docker-ce, docker-ce-cli, and docker-rootless-extras.
 cat > "debian/changelog" <<-EOF
-$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}-0~${DISTRO}-${SUITE}) $SUITE; urgency=low
+$debSource (${EPOCH}${EPOCH_SEP}${DEB_VERSION}~3-0~${DISTRO}-${SUITE}) $SUITE; urgency=low
   * Version: $VERSION
  -- $debMaintainer  $debDate
 EOF

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -24,19 +24,19 @@ gen_deb_version() {
 	increment="$3"
 	testVersion="${fullVersion#*-$pattern}"
 	baseVersion="${fullVersion%-"$pattern"*}"
-	echo "$baseVersion-$increment.$testVersion.$pattern$testVersion"
+	echo "$baseVersion-$increment.${testVersion##.}.$pattern$testVersion"
 }
 
 case "$debVersion" in
 	*-dev)
 		;;
-	*-tp[0-9]*)
+	*-tp[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" tp 0)"
 		;;
-	*-beta[0-9]*)
+	*-beta[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" beta 1)"
 		;;
-	*-rc[0-9]*)
+	*-rc[.0-9]*)
 		debVersion="$(gen_deb_version "$debVersion" rc 2)"
 		;;
 	*)

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -13,39 +13,20 @@ GIT_COMMAND="git -C $REPO_DIR"
 origVersion="$VERSION"
 debVersion="${VERSION#v}"
 
-gen_deb_version() {
-	# Adds an increment to the deb version to get proper order
-	# 18.01.0-tp1   -> 18.01.0-0.1-tp1
-	# 18.01.0-beta1 -> 18.01.0-1.1-beta1
-	# 18.01.0-rc1   -> 18.01.0-2.1-rc1
-	# 18.01.0       -> 18.01.0-3
-	fullVersion="$1"
-	pattern="$2"
-	increment="$3"
-	testVersion="${fullVersion#*-$pattern}"
-	baseVersion="${fullVersion%-"$pattern"*}"
-	echo "$baseVersion-$increment.${testVersion##.}.$pattern$testVersion"
-}
-
-case "$debVersion" in
-	*-dev)
-		;;
-	*-tp[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" tp 0)"
-		;;
-	*-beta[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" beta 1)"
-		;;
-	*-rc[.0-9]*)
-		debVersion="$(gen_deb_version "$debVersion" rc 2)"
-		;;
-	*)
-		debVersion="$debVersion-3"
-		;;
-esac
-
-tilde='~'                            # ouch Bash 4.2 vs 4.3, you keel me
-debVersion="${debVersion//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
+# deb packages require a tilde (~) instead of a hyphen (-) as separator between
+# the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER
+# non-pre-release versions, which would prevent users from updating from a pre-
+# release version to the "ga" version.
+#
+# For details, see this thread on the Debian mailing list:
+# https://lists.debian.org/debian-policy/1998/06/msg00099.html
+#
+# The code below replaces hyphens with tildes. Note that an intermediate $tilde
+# variable is needed to make this work on all versions of Bash. In some versions
+# of Bash, the tilde would be substituted with $HOME (even when escaped (\~) or
+# quoted ('~').
+tilde='~'
+debVersion="${debVersion//-/$tilde}"
 
 # if we have a "-dev" suffix or have change in Git, this is a nightly build, and
 # we'll create a pseudo version based on commit-date and -sha.

--- a/deb/gen-deb-ver
+++ b/deb/gen-deb-ver
@@ -46,14 +46,11 @@ esac
 
 tilde='~'                            # ouch Bash 4.2 vs 4.3, you keel me
 debVersion="${debVersion//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
-# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
-if [[ "$VERSION" == *-dev ]]; then
-	export TZ=UTC
 
-	DATE_COMMAND="date"
-	if [[ $(uname) == "Darwin" ]]; then
-		DATE_COMMAND="docker run --rm alpine date"
-	fi
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
+	export TZ=UTC
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
 	#
@@ -65,11 +62,20 @@ if [[ "$VERSION" == *-dev ]]; then
 	# as a pre-release before version v0.0.0, so that the go command prefers any
 	# tagged release over any pseudo-version.
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
-	gitDate="$($DATE_COMMAND --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+
+	if [ "$(uname)" = "Darwin" ]; then
+		# Using BSD date (macOS), which doesn't support the --date option
+		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+	else
+		# Using GNU date (Linux)
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+	fi
+
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	debVersion="0.0.0-${gitDate}-${gitCommit}"
-	origVersion=$debVersion
+	origVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
+	debVersion="0.0.0~${gitDate}.${gitCommit}"  # (using tilde and periods)
 
 	# verify that nightly builds are always < actual releases
 	#

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -12,30 +12,66 @@ fi
 GIT_COMMAND="git -C $REPO_DIR"
 origVersion="$VERSION"
 rpmVersion="${VERSION#v}"
-rpmRelease=3
 
-# rpmRelease versioning is as follows
-# Docker 18.01.0-ce:  version=18.01.0.ce, release=3
-# Docker 18.01.0-ce-tp1: version=18.01.0.ce, release=0.1.tp1
-# Docker 18.01.0-ce-beta1: version=18.01.0.ce, release=1.1.beta1
-# Docker 18.01.0-ce-rc1: version=18.01.0.ce, release=2.1.rc1
-# Docker 18.01.0-ce-cs1: version=18.01.0.ce.cs1, release=1
-# Docker 18.01.0-ce-cs1-rc1: version=18.01.0.ce.cs1, release=0.1.rc1
-# Docker 18.01.0-ce-dev nightly: version=18.01.0.ce, release=0.0.YYYYMMDD.HHMMSS.gitHASH
+# rpm "Release:" field ($rpmRelease) is used to set the "_release" macro, which
+# is an incremental number for builds of the same release (Version: / #rpmVersion).
+#
+# This field can be:
+#
+# - Version: 0   : Package was built, but no matching upstream release (e.g., can be used for "nightly" builds)
+# - Version: 1   : Package was built for an upstream (pre)release version
+# - Version: > 1 : Only to be used for packaging-only changes (new package built for a version for which a package was already built/released)
+#
+# For details, see the Fedora packaging guide:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning_with_a_reasonable_upstream
+#
+# Note that older versions of the rpm spec allowed more traditional information
+# in this field, which is still allowed, but considered deprecated; see
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_complex_versioning_with_a_reasonable_upstream
+#
+# In our case, this means that all releases, except for "nightly" builds should
+# use "Version: 1". Only in an exceptional case, where we need to publish a new
+# package (build) for an existing release, "Version: 2" should be used; this script
+# does not currently account for that situation.
+#
+# Assuming all tagged version of rpmRelease correspond with an upstream release,
+# this means that versioning is as follows:
+#
+# Docker 22.06.0:         version=22.06.0, release=1
+# Docker 22.06.0-alpha.1: version=22.06.0, release=1
+# Docker 22.06.0-beta.1:  version=22.06.0, release=1
+# Docker 22.06.0-rc.1:    version=22.06.0, release=1
+# Docker 22.06.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
+rpmRelease=1
 
-if [[ "$rpmVersion" =~ .*-tp[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-tp}
-	rpmVersion=${rpmVersion%-tp*}
-	rpmRelease="0.${testVersion##.}.tp${testVersion}"
-elif [[ "$rpmVersion" =~ .*-beta[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-beta}
-	rpmVersion=${rpmVersion%-beta*}
-	rpmRelease="1.${testVersion##.}.beta${testVersion}"
-elif [[ "$rpmVersion" =~ .*-rc[.0-9]+$ ]]; then
-	testVersion=${rpmVersion#*-rc}
-	rpmVersion=${rpmVersion%-rc*}
-	rpmRelease="2.${testVersion##.}.rc${testVersion}"
-fi
+# rpm packages require a tilde (~) instead of a hyphen (-) as separator between
+# the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER
+# non-pre-release versions, which would prevent users from updating from a pre-
+# release version to the "ga" version.
+#
+# For details, see the Fedora packaging guide:
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret
+#
+# > The tilde symbol (‘~’) is used before a version component which must sort
+# > earlier than any non-tilde component. It is used for any pre-release versions
+# > which wouldn’t otherwise sort appropriately.
+# >
+# > For example, with upstream releases 0.4.0, 0.4.1, 0.5.0-rc1, 0.5.0-rc2, 0.5.0,
+# > the two "release candidates" should use 0.5.0~rc1 and 0.5.0~rc2 in the Version:
+# > field. Bugfix or "patchlevel" releases that some upstream make should be handled
+# > using simple versioning. The separator used by upstream may need to be replaced
+# > by a dot or dropped.
+# >
+# > For example, if the same upstream released 0.5.0-post1 as a bugfix version,
+# > this "post-release" should use 0.5.0.post1 in the Version: field. Note that
+# > 0.5.0.post1 sorts lower than both 0.5.1 and 0.5.0.1.
+#
+# The code below replaces hyphens with tildes. Note that an intermediate $tilde
+# variable is needed to make this work on all versions of Bash. In some versions
+# of Bash, the tilde would be substituted with $HOME (even when escaped (\~) or
+# quoted ('~').
+tilde='~'
+rpmVersion="${rpmVersion//-/$tilde}"
 
 DOCKER_GITCOMMIT=$($GIT_COMMAND rev-parse --short HEAD)
 if [ -n "$($GIT_COMMAND status --porcelain --untracked-files=no)" ]; then

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -42,14 +42,10 @@ if [ -n "$($GIT_COMMAND status --porcelain --untracked-files=no)" ]; then
 	DOCKER_GITCOMMIT="$DOCKER_GITCOMMIT-unsupported"
 fi
 
-# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
-if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
 	export TZ=UTC
-
-	DATE_COMMAND="date"
-	if [[ $(uname) == "Darwin" ]]; then
-		DATE_COMMAND="docker run --rm alpine date"
-	fi
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
 	#
@@ -61,14 +57,23 @@ if [[ "$rpmVersion" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; 
 	# as a pre-release before version v0.0.0, so that the go command prefers any
 	# tagged release over any pseudo-version.
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
-	gitDate="$($DATE_COMMAND --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+
+	if [ "$(uname)" = "Darwin" ]; then
+		# Using BSD date (macOS), which doesn't support the --date option
+		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+	else
+		# Using GNU date (Linux)
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+	fi
+
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	rpmVersion="0.0.0-${gitDate}-${gitCommit}"
-	rpmRelease="0"
-	origVersion=$rpmVersion
+	origVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
+	rpmVersion="0.0.0~${gitDate}.${gitCommit}"  # (using tilde and periods)
+	rpmRelease=0
 fi
 
-# Replace any other dashes with periods
+# Replace any remaining dashes with periods
 rpmVersion="${rpmVersion//-/.}"
 echo "$rpmVersion $rpmRelease $DOCKER_GITCOMMIT $origVersion"

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -23,18 +23,18 @@ rpmRelease=3
 # Docker 18.01.0-ce-cs1-rc1: version=18.01.0.ce.cs1, release=0.1.rc1
 # Docker 18.01.0-ce-dev nightly: version=18.01.0.ce, release=0.0.YYYYMMDD.HHMMSS.gitHASH
 
-if [[ "$rpmVersion" =~ .*-tp[0-9]+$ ]]; then
-	tpVersion=${rpmVersion#*-tp}
+if [[ "$rpmVersion" =~ .*-tp[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-tp}
 	rpmVersion=${rpmVersion%-tp*}
-	rpmRelease="0.${tpVersion}.tp${tpVersion}"
-elif [[ "$rpmVersion" =~ .*-beta[0-9]+$ ]]; then
-	betaVersion=${rpmVersion#*-beta}
+	rpmRelease="0.${testVersion##.}.tp${testVersion}"
+elif [[ "$rpmVersion" =~ .*-beta[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-beta}
 	rpmVersion=${rpmVersion%-beta*}
-	rpmRelease="1.${betaVersion}.beta${betaVersion}"
-elif [[ "$rpmVersion" =~ .*-rc[0-9]+$ ]]; then
-	rcVersion=${rpmVersion#*-rc}
+	rpmRelease="1.${testVersion##.}.beta${testVersion}"
+elif [[ "$rpmVersion" =~ .*-rc[.0-9]+$ ]]; then
+	testVersion=${rpmVersion#*-rc}
 	rpmVersion=${rpmVersion%-rc*}
-	rpmRelease="2.${rcVersion}.rc${rcVersion}"
+	rpmRelease="2.${testVersion##.}.rc${testVersion}"
 fi
 
 DOCKER_GITCOMMIT=$($GIT_COMMAND rev-parse --short HEAD)

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -42,7 +42,12 @@ rpmVersion="${VERSION#v}"
 # Docker 22.06.0-beta.1:  version=22.06.0, release=1
 # Docker 22.06.0-rc.1:    version=22.06.0, release=1
 # Docker 22.06.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
-rpmRelease=1
+# rpmRelease=1
+
+# Note: on the 20.10 branch, continue using "3" as default, which was removed in
+#       commit 8a720b28a5d0db8fc93423cca79ca21b9b69f1f1. 23.0.0 and up use "1"
+#       as default.
+rpmRelease=3
 
 # rpm packages require a tilde (~) instead of a hyphen (-) as separator between
 # the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER

--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -15,11 +15,6 @@ staticVersion="$VERSION"
 if [[ "$VERSION" == *-dev ]]; then
 	export TZ=UTC
 
-	DATE_COMMAND="date"
-	if [[ $(uname) == "Darwin" ]]; then
-		DATE_COMMAND="docker run --rm alpine date"
-	fi
-
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
 	#
 	# using a "pseudo-version" of the form v0.0.0-yyyymmddhhmmss-abcdefabcdef,
@@ -30,7 +25,16 @@ if [[ "$VERSION" == *-dev ]]; then
 	# as a pre-release before version v0.0.0, so that the go command prefers any
 	# tagged release over any pseudo-version.
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
-	gitDate="$($DATE_COMMAND --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+
+	if [ "$(uname)" = "Darwin" ]; then
+		# Using BSD date (macOS), which doesn't suppoort the --date option
+		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+		gitDate="$(TZ=UTC date -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+	else
+		# Using GNU date (Linux)
+		gitDate="$(TZ=UTC date --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+	fi
+
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
 	staticVersion="0.0.0-${gitDate}-${gitCommit}"

--- a/static/gen-static-ver
+++ b/static/gen-static-ver
@@ -11,8 +11,11 @@ fi
 
 GIT_COMMAND="git -C $REPO_DIR"
 
-staticVersion="$VERSION"
-if [[ "$VERSION" == *-dev ]]; then
+staticVersion="${VERSION#v}"
+
+# if we have a "-dev" suffix or have change in Git, this is a nightly build, and
+# we'll create a pseudo version based on commit-date and -sha.
+if [[ "$VERSION" == *-dev ]] || [ -n "$($GIT_COMMAND status --porcelain)" ]; then
 	export TZ=UTC
 
 	# based on golang's pseudo-version: https://groups.google.com/forum/#!topic/golang-dev/a5PqQuBljF4
@@ -27,17 +30,17 @@ if [[ "$VERSION" == *-dev ]]; then
 	gitUnix="$($GIT_COMMAND log -1 --pretty='%ct')"
 
 	if [ "$(uname)" = "Darwin" ]; then
-		# Using BSD date (macOS), which doesn't suppoort the --date option
+		# Using BSD date (macOS), which doesn't support the --date option
 		# date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
-		gitDate="$(TZ=UTC date -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
+		gitDate="$(TZ=UTC date -u -jf "%s" "$gitUnix" +'%Y%m%d%H%M%S')"
 	else
 		# Using GNU date (Linux)
-		gitDate="$(TZ=UTC date --utc --date "@$gitUnix" +'%Y%m%d%H%M%S')"
+		gitDate="$(TZ=UTC date -u --date "@$gitUnix" +'%Y%m%d%H%M%S')"
 	fi
 
 	gitCommit="$($GIT_COMMAND log -1 --pretty='%h')"
 	# generated version is now something like '0.0.0-20180719213702-cd5e2db'
-	staticVersion="0.0.0-${gitDate}-${gitCommit}"
+	staticVersion="0.0.0-${gitDate}-${gitCommit}" # (using hyphens)
 fi
 
 echo "$staticVersion"


### PR DESCRIPTION
Backports:

- https://github.com/docker/docker-ce-packaging/pull/677
- https://github.com/docker/docker-ce-packaging/pull/700
- https://github.com/docker/docker-ce-packaging/pull/701
    - :warning: not including the last commit: https://github.com/docker/docker-ce-packaging//commit/f8299f20216a4e2def617f7d3605eab1d68132ee
