### PR TITLE
[20.10] update buildx to v0.10.1

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.10.0}"
+: "${BUILDX_COMMIT=v0.10.1}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
full diff: https://github.com/docker/buildx/compare/v0.10.0...v0.10.1

equivalent of b5546025934a5483171a590d79b7b09ae1b430eb (https://github.com/docker/docker-ce-packaging/pull/836) on master
