### PR TITLE
[master] update buildx to v0.10.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
 DOCKER_COMPOSE_REF ?= v2.15.1
-DOCKER_BUILDX_REF  ?= v0.10.1
+DOCKER_BUILDX_REF  ?= v0.10.2
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
full diff: https://github.com/docker/buildx/compare/v0.10.1...v0.10.2

Signed-off-by: Romain Geissler <romain.geissler@amadeus.com>