### PR TITLE
[23.0 backport] deb, rpm: add /etc/docker directory

### DIFF
--- a/deb/common/docker-ce.dirs
+++ b/deb/common/docker-ce.dirs
@@ -1,0 +1,1 @@
+/etc/docker

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -96,12 +96,16 @@ install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_bindir}/doc
 install -D -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
 install -D -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
+# create the config directory
+mkdir -p ${RPM_BUILD_ROOT}/etc/docker
+
 %files
 %{_bindir}/dockerd
 %{_bindir}/docker-proxy
 %{_bindir}/docker-init
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
+%dir /etc/docker
 
 %post
 %systemd_post docker.service


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/841
- relates to https://github.com/jpetazzo/container.training/pull/625
- relates to https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/merge_requests/102


Previous versions of the engine created this directory as a side-effect of the (legacy) "key.json" file. With the removal of libtrust (and the key.json) file, that directory is no longer created.

While the precence of this directory is not needed for the daemon to function, users may expect it to be there, so it there should be no harm in creating it.

This patch adds a .dirs file to create the directory on installation for .deb; https://www.debian.org/doc/manuals/maint-guide/dother.en.html#dirs

And adds a %dirs directive for .rpm packages:
http://ftp.rpm.org/max-rpm/s1-rpm-inside-files-list-directives.html#S3-RPM-INSIDE-DIR-DIRECTIVE

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 86f8d3cb8c4282bfff8cbdee946f8ea968377d18)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>