### PR TITLE
[23.0 backport] bump compose version to v2.16.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
-DOCKER_COMPOSE_REF ?= v2.15.1
+DOCKER_COMPOSE_REF ?= v2.16.0
 DOCKER_BUILDX_REF  ?= v0.10.2
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
(cherry picked from commit ea3720b0c0f8fd955dc9fddeeab411dc06bd0aa8)
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>