### PR TITLE
[23.0 backport] update buildx to v0.10.3

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
 DOCKER_COMPOSE_REF ?= v2.16.0
-DOCKER_BUILDX_REF  ?= v0.10.2
+DOCKER_BUILDX_REF  ?= v0.10.3
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
backport of https://github.com/docker/docker-ce-packaging/pull/846

full diff: https://github.com/docker/buildx/compare/v0.10.2...v0.10.3


(cherry picked from commit ec8cadf15d30621e391126801dd3a19e641a24c6)