### PR TITLE
[20.10 backport] update buildx to v0.10.3

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.10.2}"
+: "${BUILDX_COMMIT=v0.10.3}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
"backport" of https://github.com/docker/docker-ce-packaging/pull/846 in case we need to do another 20.10 build

full diff: https://github.com/docker/buildx/compare/v0.10.2...v0.10.3

equivalent of ec8cadf15d30621e391126801dd3a19e641a24c6