### PR TITLE
Add docker.socket to the %preun section

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -114,7 +114,7 @@ if ! getent group docker > /dev/null; then
 fi
 
 %preun
-%systemd_preun docker.service
+%systemd_preun docker.service docker.socket
 
 %postun
 %systemd_postun_with_restart docker.service


### PR DESCRIPTION
This PR adds `docker.socket` to the `%preun` section of the `docker-ce` spec, in order to disable the socket upon uninstall.

Fixes #851 