### PR TITLE
[23.0 backport] update buildx to v0.10.4

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
 DOCKER_COMPOSE_REF ?= v2.16.0
-DOCKER_BUILDX_REF  ?= v0.10.3
+DOCKER_BUILDX_REF  ?= v0.10.4
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/853


full diff: https://github.com/docker/buildx/compare/v0.10.3...v0.10.4


(cherry picked from commit d1ff577bfcf0bf9447220255504c6568b3ae5973)