### PR TITLE
[20.10 backport] update buildx to v0.10.4

### DIFF
--- a/plugins/buildx.installer
+++ b/plugins/buildx.installer
@@ -6,7 +6,7 @@ source "$(dirname "$0")/.common"
 PKG=github.com/docker/buildx
 GOPATH=$(go env GOPATH)
 REPO=https://${PKG}.git
-: "${BUILDX_COMMIT=v0.10.3}"
+: "${BUILDX_COMMIT=v0.10.4}"
 DEST=${GOPATH}/src/${PKG}
 
 build() {


### PR DESCRIPTION
"backport" of https://github.com/docker/docker-ce-packaging/pull/853 in case we need to do another 20.10 build


full diff: https://github.com/docker/buildx/compare/v0.10.3...v0.10.4

(equivalent of commit d1ff577bfcf0bf9447220255504c6568b3ae5973)