### PR TITLE
[23.0 backport] bump compose version to v2.17.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
-DOCKER_COMPOSE_REF ?= v2.16.0
+DOCKER_COMPOSE_REF ?= v2.17.0
 DOCKER_BUILDX_REF  ?= v0.10.4
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/860

(cherry picked from commit f1df0f5f9b30dcb1be647c3558ede77e923a854f)