### PR TITLE
[23.0 backport] bump compose version to v2.17.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_SCAN_REF    ?= v0.23.0
-DOCKER_COMPOSE_REF ?= v2.17.1
+DOCKER_COMPOSE_REF ?= v2.17.2
 DOCKER_BUILDX_REF  ?= v0.10.4
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/866

https://github.com/docker/compose/releases/tag/v2.17.2

(cherry picked from commit 5e20a7d5b17ece92dceda023f9dc88e2c3210f9d)