### PR TITLE
Move "docker-init" into appropriate "libexec" directory

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -78,7 +78,7 @@ override_dh_auto_install:
 	install -D -m 0644 engine/contrib/init/systemd/docker.socket debian/docker-ce/lib/systemd/system/docker.socket
 	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd
 	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/docker-proxy) debian/docker-ce/usr/bin/docker-proxy
-	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/bin/docker-init
+	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/libexec/docker/docker-init
 
 	# docker-buildx-plugin install
 	install -D -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -90,7 +90,7 @@ ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
 %install
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) ${RPM_BUILD_ROOT}%{_bindir}/dockerd
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/docker-proxy) ${RPM_BUILD_ROOT}%{_bindir}/docker-proxy
-install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_bindir}/docker-init
+install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_libexecdir}/docker/docker-init
 
 # install systemd scripts
 install -D -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
@@ -102,7 +102,7 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/docker
 %files
 %{_bindir}/dockerd
 %{_bindir}/docker-proxy
-%{_bindir}/docker-init
+%{_libexecdir}/docker/docker-init
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
 %dir /etc/docker


### PR DESCRIPTION
See https://github.com/moby/moby/commit/6caaa8cadc9e4f1e122b7b2bb4451500bbec6086 / https://github.com/moby/moby/pull/45198