### PR TITLE
[20.10] remove leftovers for building plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean-src:
 	$(RM) -r src
 
 .PHONY: src
-src: src/github.com/docker/cli src/github.com/docker/docker src/github.com/docker/compose src/github.com/docker/scan-cli-plugin ## clone source
+src: src/github.com/docker/cli src/github.com/docker/docker ## clone source
 
 ifdef CLI_DIR
 src/github.com/docker/cli:
@@ -37,15 +37,6 @@ src/github.com/docker/docker:
 	git -C $@ remote add origin "$(DOCKER_ENGINE_REPO)"
 endif
 
-src/github.com/docker/compose:
-	git init $@
-	git -C $@ remote add origin "$(DOCKER_COMPOSE_REPO)"
-
-src/github.com/docker/scan-cli-plugin:
-	git init $@
-	git -C $@ remote add origin "$(DOCKER_SCAN_REPO)"
-
-
 .PHONY: checkout-cli
 checkout-cli: src/github.com/docker/cli
 	./scripts/checkout.sh src/github.com/docker/cli "$(DOCKER_CLI_REF)"
@@ -54,16 +45,8 @@ checkout-cli: src/github.com/docker/cli
 checkout-docker: src/github.com/docker/docker
 	./scripts/checkout.sh src/github.com/docker/docker "$(DOCKER_ENGINE_REF)"
 
-.PHONY: checkout-compose
-checkout-compose: src/github.com/docker/compose
-	./scripts/checkout.sh src/github.com/docker/compose "$(DOCKER_COMPOSE_REF)"
-
-.PHONY: checkout-scan-cli-plugin
-checkout-scan-cli-plugin: src/github.com/docker/scan-cli-plugin
-	./scripts/checkout.sh src/github.com/docker/scan-cli-plugin "$(DOCKER_SCAN_REF)"
-
 .PHONY: checkout
-checkout: checkout-cli checkout-docker checkout-compose checkout-scan-cli-plugin ## checkout source at the given reference(s)
+checkout: checkout-cli checkout-docker ## checkout source at the given reference(s)
 
 .PHONY: clean
 clean: clean-src ## remove build artifacts

--- a/common.mk
+++ b/common.mk
@@ -25,8 +25,6 @@ VERSION?=0.0.1-dev
 # the source from. These can be overridden to build from a fork.
 DOCKER_CLI_REPO     ?= https://github.com/docker/cli.git
 DOCKER_ENGINE_REPO  ?= https://github.com/docker/docker.git
-DOCKER_SCAN_REPO    ?= https://github.com/docker/scan-cli-plugin.git
-DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 
 # REF can be used to specify the same branch or tag to use for *both* the CLI
 # and Engine source code. This can be useful if both the CLI and Engine have a
@@ -37,8 +35,6 @@ DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_SCAN_REF    ?= v0.23.0
-DOCKER_COMPOSE_REF ?= v2.15.1
 
 export BUILDTIME
 export DEFAULT_PRODUCT_LICENSE

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -5,11 +5,8 @@ GO_BASE_IMAGE=golang
 GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-buster
 EPOCH?=5
 GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
-GEN_COMPOSE_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
-GEN_SCAN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) "$(DOCKER_SCAN_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
-SCAN_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin) && git rev-parse --short HEAD)
 
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
@@ -34,11 +31,6 @@ RUN?=docker run --rm \
 	-e VERSION=$(word 2, $(GEN_DEB_VER)) \
 	-e CLI_GITCOMMIT=$(CLI_GITCOMMIT) \
 	-e ENGINE_GITCOMMIT=$(ENGINE_GITCOMMIT) \
-	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
-	-e COMPOSE_DEB_VERSION=$(word 1, $(GEN_COMPOSE_DEB_VER)) \
-	-e SCAN_VERSION=$(DOCKER_SCAN_REF) \
-	-e SCAN_DEB_VERSION=$(word 1, $(GEN_SCAN_DEB_VER)) \
-	-e SCAN_GITCOMMIT=$(SCAN_GITCOMMIT) \
 	-v $(CURDIR)/debbuild/$@:/build \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
@@ -81,7 +73,7 @@ $(DISTROS): sources
 	$(CHOWN) -R $(shell id -u):$(shell id -g) "debbuild/$@"
 
 .PHONY: sources
-sources: sources/cli.tgz sources/engine.tgz sources/compose.tgz sources/scan-cli-plugin.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz
+sources: sources/cli.tgz sources/engine.tgz sources/docker.service sources/docker.socket sources/plugin-installers.tgz
 
 sources/engine.tgz:
 	mkdir -p $(@D)
@@ -98,22 +90,6 @@ sources/cli.tgz:
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/cli.tgz --exclude .git cli
-
-sources/compose.tgz:
-	mkdir -p $(@D)
-	docker run --rm -w /v \
-		-v $(realpath $(CURDIR)/../src/github.com/docker/compose):/compose \
-		-v $(CURDIR)/$(@D):/v \
-		alpine \
-		tar -C / -c -z -f /v/compose.tgz --exclude .git compose
-
-sources/scan-cli-plugin.tgz:
-	mkdir -p $(@D)
-	docker run --rm -w /v \
-		-v $(realpath $(CURDIR)/../src/github.com/docker/scan-cli-plugin):/scan-cli-plugin \
-		-v $(CURDIR)/$(@D):/v \
-		alpine \
-		tar -C / -c -z -f /v/scan-cli-plugin.tgz --exclude .git scan-cli-plugin
 
 sources/docker.service: ../systemd/docker.service
 	mkdir -p $(@D)

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -7,17 +7,11 @@ mkdir -p /root/build-deb/engine
 tar -C /root/build-deb -xzf /sources/engine.tgz
 mkdir -p /root/build-deb/cli
 tar -C /root/build-deb -xzf /sources/cli.tgz
-mkdir -p /root/build-deb/compose
-tar -C /root/build-deb -xzf /sources/compose.tgz
-mkdir -p /root/build-deb/scan-cli-plugin
-tar -C /root/build-deb -xzf /sources/scan-cli-plugin.tgz
 
 # link them to their canonical path
 mkdir -p /go/src/github.com/docker
 ln -snf /root/build-deb/engine /go/src/github.com/docker/docker
 ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
-ln -snf /root/build-deb/compose /go/src/github.com/docker/compose
-ln -snf /root/build-deb/scan-cli-plugin /go/src/github.com/docker/scan-cli-plugin
 
 EPOCH="${EPOCH:-}"
 EPOCH_SEP=""
@@ -53,9 +47,6 @@ EOF
 # Give the script a git commit because it wants it
 export CLI_GITCOMMIT=${CLI_GITCOMMIT-$(cd cli; $GIT_COMMAND rev-parse --short HEAD)}
 export ENGINE_GITCOMMIT=${ENGINE_GITCOMMIT-$(cd engine; $GIT_COMMAND rev-parse --short HEAD)}
-
-# Scan plugin
-export SCAN_GITCOMMIT=${SCAN_GITCOMMIT-$(cd scan-cli-plugin; $GIT_COMMAND rev-parse --short HEAD)}
 
 echo VERSION BBB $VERSION
 dpkg-buildpackage -uc -us -I.git

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -24,15 +24,7 @@ ENV SUITE=${SUITE}
 RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    yum-builddep -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    yum-builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -31,15 +31,7 @@ RUN if [ -f /etc/yum.repos.d/CentOS-Stream-PowerTools.repo ]; then sed -i 's/ena
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -27,15 +27,7 @@ RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 RUN dnf config-manager --set-enabled crb
 
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN dnf builddep --define '_without_btrfs 1' -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-36/Dockerfile
+++ b/rpm/fedora-36/Dockerfile
@@ -19,15 +19,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    dnf builddep -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    dnf builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-37/Dockerfile
+++ b/rpm/fedora-37/Dockerfile
@@ -19,15 +19,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    dnf builddep -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    dnf builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/rhel-7/Dockerfile
+++ b/rpm/rhel-7/Dockerfile
@@ -24,15 +24,7 @@ ENV CC=gcc
 RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint
 COPY SPECS /root/rpmbuild/SPECS
-
-# TODO change once we support scan-plugin on other architectures
-RUN \
-  if [ "$(uname -m)" = "x86_64" ]; then \
-    yum-builddep -y /root/rpmbuild/SPECS/*.spec; \
-  else \
-    yum-builddep -y /root/rpmbuild/SPECS/docker-c*.spec; \
-  fi
-
+RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
commit 7e0ffd93153a254b08c0d63b4941745adcbf5c93 (https://github.com/docker/docker-ce-packaging/pull/827) removed the code to build the plugins (which is now handled as part of the 23.0.x and 24.0.x releases), but I didn't remove other code related to plugins, such as checking out source.

Obviously that's a bit of a waste of time if we won't be building these, so let's remove that as well ':D