### PR TITLE
[23.0] remove scan-cli-plugin as recommends/required dependency

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -61,10 +61,8 @@ Description: Docker: the open-source application container engine
 Package: docker-ce-cli
 Architecture: linux-any
 Depends: ${shlibs:Depends}
-# TODO change once we support scan-plugin on other architectures
 Recommends: docker-buildx-plugin,
-            docker-compose-plugin,
-            docker-scan-plugin [amd64]
+            docker-compose-plugin
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker-engine-cs,

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -28,19 +28,6 @@ Recommends: docker-buildx-plugin
 Recommends: docker-compose-plugin
 %endif
 
-# TODO change once we support scan-plugin on other architectures
-%ifarch x86_64
-# CentOS 7 and RHEL 7 do not yet support weak dependencies
-#
-# Note that we're not using <= 7 here, to account for other RPM distros, such
-# as Fedora, which would not have the rhel macro set (so default to 0).
-%if 0%{?rhel} == 7
-Requires: docker-scan-plugin(x86-64)
-%else
-Recommends: docker-scan-plugin(x86-64)
-%endif
-%endif
-
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel
 BuildRequires: git


### PR DESCRIPTION
The scan-cli-plugin has been deprecated, and will no longer receive updates, so we don't want it to be automatically installed as a dependency; https://github.com/docker/scan-cli-plugin/blob/b69ac460a6c23243b858326f0e26f6bd202ca781/internal/deprecation.go#L13-L15
