### PR TITLE
[23.0] Add Ubuntu 23.04 "Lunar Lobster"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ def pkgs = [
     [target: "ubuntu-focal",             image: "ubuntu:focal",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [target: "ubuntu-jammy",             image: "ubuntu:jammy",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [target: "ubuntu-kinetic",           image: "ubuntu:kinetic",                         arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.10 (EOL: July, 2023)
+    [target: "ubuntu-lunar",             image: "ubuntu:lunar",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 23.04 (EOL: January, 2024)
 ]
 
 def genBuildStep(LinkedHashMap pkg, String arch) {

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -49,7 +49,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS ?= debian-buster debian-bullseye debian-bookworm
-UBUNTU_VERSIONS ?= ubuntu-bionic ubuntu-focal ubuntu-jammy ubuntu-kinetic
+UBUNTU_VERSIONS ?= ubuntu-bionic ubuntu-focal ubuntu-jammy ubuntu-kinetic ubuntu-lunar
 RASPBIAN_VERSIONS ?= raspbian-buster raspbian-bullseye raspbian-bookworm
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/deb/ubuntu-lunar/Dockerfile
+++ b/deb/ubuntu-lunar/Dockerfile
@@ -1,0 +1,43 @@
+ARG GO_IMAGE
+ARG DISTRO=ubuntu
+ARG SUITE=lunar
+ARG VERSION_ID=23.04
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+
+ARG COMMON_FILES
+COPY ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY sources/ /sources
+ARG DISTRO
+ARG SUITE
+ARG VERSION_ID
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
+
+COPY --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
- backport of https://github.com/docker/docker-ce-packaging/pull/875

Ubuntu 23.04 is planned to be released on April 20, but final betas are available now.


(cherry picked from commit e2990968104d18f7144de9526fe5a0a2e3b56a4b)