### PR TITLE
[23.0 backport] bump compose to v2.18.1

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_COMPOSE_REF ?= v2.17.3
+DOCKER_COMPOSE_REF ?= v2.18.1
 DOCKER_BUILDX_REF  ?= v0.10.4
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
- See #896 
- Supersedes #893 
- closes #893 
 