### PR TITLE
[23.0] update buildx to v0.11.0 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -39,7 +39,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_COMPOSE_REF ?= v2.18.1
-DOCKER_BUILDX_REF  ?= v0.10.5
+DOCKER_BUILDX_REF  ?= v0.11.0
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.11.0

@thaJeztah mentioned that "perhaps we should cherry-pick it into the 23.0 branch in case we need to still do a new release for that one (but not likely)."