### PR TITLE
[23.0 backport] bump compose version to v2.19.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_COMPOSE_REF ?= v2.18.1
+DOCKER_COMPOSE_REF ?= v2.19.0
 DOCKER_BUILDX_REF  ?= v0.10.5
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
(cherry picked from commit 6afed50ff6e237abc6ddd3d5805cb4d3bb3a8d21)
Signed-off-by: Guillaume Lours <705411+glours@users.noreply.github.com>