### PR TITLE
bump compose version to v2.19.1

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_COMPOSE_REF ?= v2.19.0
+DOCKER_COMPOSE_REF ?= v2.19.1
 DOCKER_BUILDX_REF  ?= v0.11.0
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
https://github.com/docker/compose/releases/tag/v2.19.1