### PR TITLE
add conflicts, replaces and breaks section to deprecate docker-compos…

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -113,6 +113,9 @@ Package: docker-compose-plugin
 Priority: optional
 Architecture: linux-any
 Enhances: docker-ce-cli
+Conflicts: docker-compose
+Replaces: docker-compose
+Breaks: docker-compose
 Description: Docker Compose (V2) plugin for the Docker CLI.
  .
  This plugin provides the 'docker compose' subcommand.


### PR DESCRIPTION
…e package in favor of docker-compose-plugin

As Debian `docker-compose` package still install `v1.29.x` deprecated version of Compose, we could conflict when a user will try to install the 2 version, so users will be able to either:
-  remove an existing `docker-compose` package before installing `docker-compose-plugin`
- block install of a `docker-compose` package if `docker-compose-plugin` is already installed

https://docker.atlassian.net/browse/ENV-226