### PR TITLE
update buildx to v0.11.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -39,7 +39,7 @@ REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_COMPOSE_REF ?= v2.20.0
-DOCKER_BUILDX_REF  ?= v0.11.1
+DOCKER_BUILDX_REF  ?= v0.11.2
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.11.2