### PR TITLE
[23.0 backport] Update dockerfiles to use COPY --link

### DIFF
--- a/deb/debian-bookworm/Dockerfile
+++ b/deb/debian-bookworm/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=bookworm
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=bullseye
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=debian
 ARG SUITE=buster
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-bookworm/Dockerfile
+++ b/deb/raspbian-bookworm/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=bookworm
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=bullseye
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=raspbian
 ARG SUITE=buster
@@ -17,11 +19,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -29,7 +31,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=focal
@@ -23,11 +25,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -35,7 +37,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=jammy
@@ -23,11 +25,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -35,7 +37,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-kinetic/Dockerfile
+++ b/deb/ubuntu-kinetic/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=kinetic
@@ -23,11 +25,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -35,7 +37,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/deb/ubuntu-lunar/Dockerfile
+++ b/deb/ubuntu-lunar/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=ubuntu
 ARG SUITE=lunar
@@ -23,11 +25,11 @@ ENV GOPATH /go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
-COPY ${COMMON_FILES} /root/build-deb/debian
+COPY --link ${COMMON_FILES} /root/build-deb/debian
 RUN apt-get update \
  && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
 
-COPY sources/ /sources
+COPY --link sources/ /sources
 ARG DISTRO
 ARG SUITE
 ARG VERSION_ID
@@ -35,7 +37,7 @@ ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 ENV VERSION_ID=${VERSION_ID}
 
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 
 WORKDIR /root/build-deb
 COPY build-deb /root/build-deb/build-deb

--- a/rpm/centos-7/Dockerfile
+++ b/rpm/centos-7/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=centos
 ARG SUITE=7
@@ -22,8 +24,8 @@ ENV SUITE=${SUITE}
 # failing, so replace the URL.
 RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-8/Dockerfile
+++ b/rpm/centos-8/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=centos
 ARG SUITE=8
@@ -29,8 +31,8 @@ RUN if [ -f /etc/yum.repos.d/CentOS-Stream-PowerTools.repo ]; then sed -i 's/ena
 # https://access.redhat.com/solutions/3720351
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=centos
 ARG SUITE=9
@@ -25,8 +27,8 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
 RUN dnf config-manager --set-enabled crb
 
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-37/Dockerfile
+++ b/rpm/fedora-37/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=fedora
 ARG SUITE=37
@@ -16,8 +18,8 @@ ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-38/Dockerfile
+++ b/rpm/fedora-38/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=fedora
 ARG SUITE=38
@@ -16,8 +18,8 @@ ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/rhel-7/Dockerfile
+++ b/rpm/rhel-7/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG GO_IMAGE
 ARG DISTRO=rhel
 ARG SUITE=7
@@ -21,8 +23,8 @@ ENV CC=gcc
 # failing, so replace the URL.
 RUN if [ -f /etc/yum.repos.d/CentOS-Sources.repo ]; then sed -i 's/altarch/centos/g' /etc/yum.repos.d/CentOS-Sources.repo; fi
 RUN yum install -y rpm-build rpmlint
-COPY SPECS /root/rpmbuild/SPECS
+COPY --link SPECS /root/rpmbuild/SPECS
 RUN yum-builddep -y /root/rpmbuild/SPECS/*.spec
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --link --from=golang /usr/local/go /usr/local/go
 WORKDIR /root/rpmbuild
 ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/913

Use COPY --link for steps that don't depend on the base image or prior steps, to allow for better sharing of build-cache.


(cherry picked from commit 297fa1524db43c36685218e271ea86d9955982fe)