### PR TITLE
rpm: recommend, not require  "docker-ce-rootless-extras" where possible

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -14,7 +14,15 @@ Packager: Docker <support@docker.com>
 
 Requires: /usr/sbin/groupadd
 Requires: docker-ce-cli
+# CentOS 7 and RHEL 7 do not yet support weak dependencies
+#
+# Note that we're not using <= 7 here, to account for other RPM distros, such
+# as Fedora, which would not have the rhel macro set (so default to 0).
+%if 0%{?rhel} == 7
 Requires: docker-ce-rootless-extras
+%else
+Recommends: docker-ce-rootless-extras
+%endif
 Requires: container-selinux >= 2:2.74
 Requires: libseccomp >= 2.3
 Requires: systemd


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/issues/915#issuecomment-1728187098


The deb pacakges have this dependency as "recommends", but older versions of yum (RHEL7 / CentOS 7) do not support this. and only support "requires".

This patch uses a similar approach as bb4bd31ab60fe5bc496021d2606882db913c5bad did for the CLI, and changes the dependency to be "recommends" where possible, falling back to "requires" for older rpm versions.