### PR TITLE
[master] bump compose version to v2.22.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -38,7 +38,7 @@ DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
 REF                ?= HEAD
 DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
-DOCKER_COMPOSE_REF ?= v2.21.0
+DOCKER_COMPOSE_REF ?= v2.22.0
 DOCKER_BUILDX_REF  ?= v0.11.2
 
 # Use "stage" to install dependencies from download-stage.docker.com during the


### PR DESCRIPTION
https://github.com/docker/compose/releases/tag/v2.22.0