### PR TITLE
deb, rpm: use GOTOOLCHAIN=local

### DIFF
--- a/deb/debian-bookworm/Dockerfile
+++ b/deb/debian-bookworm/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/debian-buster/Dockerfile
+++ b/deb/debian-buster/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/raspbian-bookworm/Dockerfile
+++ b/deb/raspbian-bookworm/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/raspbian-buster/Dockerfile
+++ b/deb/raspbian-buster/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/deb/ubuntu-lunar/Dockerfile
+++ b/deb/ubuntu-lunar/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES

--- a/rpm/fedora-37/Dockerfile
+++ b/rpm/fedora-37/Dockerfile
@@ -11,6 +11,7 @@ FROM ${BUILD_IMAGE}
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ARG DISTRO

--- a/rpm/fedora-38/Dockerfile
+++ b/rpm/fedora-38/Dockerfile
@@ -11,6 +11,7 @@ FROM ${BUILD_IMAGE}
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ARG DISTRO

--- a/rpm/fedora-39/Dockerfile
+++ b/rpm/fedora-39/Dockerfile
@@ -11,6 +11,7 @@ FROM ${BUILD_IMAGE}
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH /go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ARG DISTRO


### PR DESCRIPTION
- relates to https://github.com/docker-library/golang/issues/472

Make sure we don't get unexpected updates of the go toolchain when building.
