### PR TITLE
[Master] Add Ubuntu 23.10 "Mantic Minotaur"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ def pkgs = [
     [target: "ubuntu-focal",             image: "ubuntu:focal",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [target: "ubuntu-jammy",             image: "ubuntu:jammy",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: April, 2027. EOL: April, 2032)
     [target: "ubuntu-lunar",             image: "ubuntu:lunar",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 23.04 (EOL: January, 2024)
+    [target: "ubuntu-mantic",            image: "ubuntu:mantic",                          arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 23.04 (EOL: January, 2024)
 ]
 
 def genBuildStep(LinkedHashMap pkg, String arch) {

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -44,7 +44,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS ?= debian-buster debian-bullseye debian-bookworm
-UBUNTU_VERSIONS ?= ubuntu-focal ubuntu-jammy ubuntu-lunar
+UBUNTU_VERSIONS ?= ubuntu-focal ubuntu-jammy ubuntu-lunar ubuntu-mantic
 RASPBIAN_VERSIONS ?= raspbian-buster raspbian-bullseye raspbian-bookworm
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/deb/ubuntu-mantic/Dockerfile
+++ b/deb/ubuntu-mantic/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE
+ARG DISTRO=ubuntu
+ARG SUITE=mantic
+ARG VERSION_ID=23.10
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV GOTOOLCHAIN=local
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+
+ARG COMMON_FILES
+COPY --link ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY --link sources/ /sources
+ARG DISTRO
+ARG SUITE
+ARG VERSION_ID
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
+
+COPY --link --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
relates to https://github.com/docker/packaging/pull/166
relates to https://github.com/docker/containerd-packaging/commit/68ea3734399c7701623f94d3c88794117185d8bb - https://github.com/docker/containerd-packaging/pull/328

Ubuntu 23.10 is planned to be released on October 12, 2023, but final betas are available now.