### PR TITLE
deb, rpm: set minimum containerd version to 1.6.24

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -25,7 +25,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
-Depends: containerd.io (>= 1.6.4),
+Depends: containerd.io (>= 1.6.24),
          docker-ce-cli,
          iptables,
          libseccomp2 (>= 2.3.0),

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -31,7 +31,7 @@ Requires: iptables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.6.4
+Requires: containerd.io >= 1.6.24
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/46778