### PR TITLE
rpm: patch RLIMIT_NOFILE for EL 7 systems

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -92,6 +92,11 @@ $(DISTROS): sources
 
 .PHONY: sources
 sources: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/buildx.tgz rpmbuild/SOURCES/compose.tgz
+sources: rpmbuild/SOURCES/01-rlimit_nofile-rhel7.patch
+
+rpmbuild/SOURCES/%.patch:
+	mkdir -p $(@D)
+	cp $(CURDIR)/patches/$(@F) $@
 
 rpmbuild/SOURCES/engine.tgz:
 	mkdir -p $(@D)

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -5,6 +5,7 @@ Version: %{_version}
 Release: %{_release}%{?dist}
 Epoch: 3
 Source0: engine.tgz
+Patch0: 01-rlimit_nofile-rhel7.patch
 Summary: The open-source application container engine
 Group: Tools/Docker
 License: ASL 2.0
@@ -71,6 +72,9 @@ depending on a particular stack or provider.
 
 %prep
 %setup -q -c -n src -a 0
+%if 0%{?rhel} == 7
+%patch -p1 -P 0
+%endif
 
 %build
 

--- a/rpm/patches/01-rlimit_nofile-rhel7.patch
+++ b/rpm/patches/01-rlimit_nofile-rhel7.patch
@@ -1,0 +1,15 @@
+diff --git i/engine/contrib/init/systemd/docker.service w/engine/contrib/init/systemd/docker.service
+index d8c7867057..b73ecf7363 100644
+--- i/engine/contrib/init/systemd/docker.service
++++ w/engine/contrib/init/systemd/docker.service
+@@ -30,6 +30,10 @@ StartLimitInterval=60s
+ # in the kernel. We recommend using cgroups to do container-local accounting.
+ LimitNPROC=infinity
+ LimitCORE=infinity
++# Older systemd versions default to a LimitNOFILE of 1024:1024, which is insufficient for many
++# applications including dockerd itself and will be inherited. Raise the hard limit, while
++# preserving the soft limit for select(2).
++LimitNOFILE=1024:524288
+ 
+ # Comment TasksMax if your systemd version does not support it.
+ # Only systemd 226 and above support this option.


### PR DESCRIPTION
RLIMIT_NOFILE defaults to an unusable value on EL 7 systems, but more modern systems have sane defaults. As such, patch the systemd unit only on EL 7 systems to ensure correct behaviour.