### PR TITLE
RHEL PoC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,10 @@ def genBuildStep(LinkedHashMap pkg, String arch) {
             stage("build") {
                 checkout scm
                 sh "make clean"
-                sh "make REF=$branch ${pkg.target}"
+                sh "make REF=$branch ARCH=${arch} ${pkg.target}"
             }
             stage("verify") {
-                sh "make IMAGE=${pkg.image} verify"
+                sh "make IMAGE=${pkg.image} ARCH=${arch} verify"
             }
         }
     }

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -22,6 +22,7 @@ BUILD?=DOCKER_BUILDKIT=1 \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	--build-arg COMMON_FILES=$(COMMON_FILES) \
 	-t debbuild-$@/$(ARCH) \
+	--platform linux/$(ARCH) \
 	-f $@/Dockerfile \
 	.
 
@@ -33,6 +34,7 @@ RUN_FLAGS=
 # see https://github.com/docker/docker-ce-packaging/pull/1006#issuecomment-2006878743
 RUN?=docker run --rm \
 	--security-opt seccomp=unconfined \
+	--platform linux/$(ARCH) \
 	-e PLATFORM \
 	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(word 1, $(GEN_DEB_VER)) \

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -18,6 +18,7 @@ BUILD?=DOCKER_BUILDKIT=1 \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	-t rpmbuild-$@/$(ARCH) \
+	--platform linux/$(ARCH) \
 	-f $@/Dockerfile \
 	.
 
@@ -48,6 +49,7 @@ RUN_FLAGS=
 # https://github.com/docker/docker-ce-packaging/pull/1006#issuecomment-2006878743
 RUN?=docker run --rm \
 	--security-opt seccomp=unconfined \
+	--platform linux/$(ARCH) \
 	-e PLATFORM \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES:ro \
 	-v $(CURDIR)/rpmbuild/$@/RPMS:/root/rpmbuild/RPMS \

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -10,11 +10,15 @@ CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && 
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
 
+ifdef RH_USER
+	RH_FLAGS=--build-arg RH_USER=$(RH_USER) --build-arg RH_PASS=$(RH_PASS)
+endif
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)
 endif
 BUILD?=DOCKER_BUILDKIT=1 \
 	docker build \
+	$(RH_FLAGS) \
 	$(BUILD_IMAGE_FLAG) \
 	--build-arg GO_IMAGE=$(GO_IMAGE) \
 	-t rpmbuild-$@/$(ARCH) \
@@ -59,7 +63,7 @@ RUN?=docker run --rm \
 
 FEDORA_RELEASES ?= fedora-40 fedora-39
 CENTOS_RELEASES ?= centos-9
-RHEL_RELEASES ?=
+RHEL_RELEASES ?= rhel-8 rhel-9
 
 DISTROS := $(FEDORA_RELEASES) $(CENTOS_RELEASES) $(RHEL_RELEASES)
 BUNDLES := $(patsubst %,rpmbuild/bundles-ce-%-$(DPKG_ARCH).tar.gz,$(DISTROS))

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -11,7 +11,7 @@ ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docke
 BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
 
 ifdef RH_USER
-	RH_FLAGS=--build-arg RH_USER=$(RH_USER) --build-arg RH_PASS=$(RH_PASS)
+	RH_FLAGS=--secret id=rh-user,env=RH_USER --secret id=rh-pass,env=RH_PASS
 endif
 ifdef BUILD_IMAGE
 	BUILD_IMAGE_FLAG=--build-arg $(BUILD_IMAGE)

--- a/rpm/rhel-8/Dockerfile
+++ b/rpm/rhel-8/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE
+ARG DISTRO=rhel
+ARG SUITE=8
+ARG BUILD_IMAGE=registry.access.redhat.com/ubi8/ubi
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE} AS subscribed-image
+ARG RH_USER
+ARG RH_PASS
+RUN rm /etc/rhsm-host 
+RUN subscription-manager register --username=$RH_USER --password=$RH_PASS
+RUN subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
+# RUN dnf config-manager --set-enabled codeready-builder-for-rhel-8-$(arch)-rpms
+
+FROM subscribed-image
+
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS exclude_graphdriver_btrfs
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+RUN dnf install -y rpm-build rpmlint
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/rhel-8/Dockerfile
+++ b/rpm/rhel-8/Dockerfile
@@ -8,12 +8,20 @@ ARG BUILD_IMAGE=registry.access.redhat.com/ubi8/ubi
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE} AS subscribed-image
-ARG RH_USER
-ARG RH_PASS
-RUN rm /etc/rhsm-host 
-RUN subscription-manager register --username=$RH_USER --password=$RH_PASS
-RUN subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
-# RUN dnf config-manager --set-enabled codeready-builder-for-rhel-8-$(arch)-rpms
+RUN --mount=type=secret,id=rh-user --mount=type=secret,id=rh-pass <<-EOT
+	rm -f /etc/rhsm-host
+
+	if [ ! -f /run/secrets/rh-user ] || [ ! -f /run/secrets/rh-pass ]; then
+		echo "Either RH_USER or RH_PASS is not set. Running build without subscription."
+	else
+		subscription-manager register \
+			--username="$(cat /run/secrets/rh-user)" \
+			--password="$(cat /run/secrets/rh-pass)"
+
+		subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms
+		# dnf config-manager --set-enabled codeready-builder-for-rhel-8-$(arch)-rpms
+	fi
+EOT
 
 FROM subscribed-image
 

--- a/rpm/rhel-9/Dockerfile
+++ b/rpm/rhel-9/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE
+ARG DISTRO=rhel
+ARG SUITE=9
+ARG BUILD_IMAGE=registry.access.redhat.com/ubi9/ubi
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE} AS subscribed-image
+ARG RH_USER
+ARG RH_PASS
+RUN rm /etc/rhsm-host
+RUN subscription-manager register --username=$RH_USER --password=$RH_PASS
+RUN subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+# RUN dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms
+
+FROM subscribed-image
+
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH=/go
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ENV DOCKER_BUILDTAGS exclude_graphdriver_btrfs
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+RUN dnf install -y rpm-build rpmlint
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/rhel-9/Dockerfile
+++ b/rpm/rhel-9/Dockerfile
@@ -8,12 +8,20 @@ ARG BUILD_IMAGE=registry.access.redhat.com/ubi9/ubi
 FROM ${GO_IMAGE} AS golang
 
 FROM ${BUILD_IMAGE} AS subscribed-image
-ARG RH_USER
-ARG RH_PASS
-RUN rm /etc/rhsm-host
-RUN subscription-manager register --username=$RH_USER --password=$RH_PASS
-RUN subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
-# RUN dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms
+RUN --mount=type=secret,id=rh-user --mount=type=secret,id=rh-pass <<-EOT
+	rm -f /etc/rhsm-host
+
+	if [ ! -f /run/secrets/rh-user ] || [ ! -f /run/secrets/rh-pass ]; then
+		echo "Either RH_USER or RH_PASS is not set. Running build without subscription."
+	else
+		subscription-manager register \
+			--username="$(cat /run/secrets/rh-user)" \
+			--password="$(cat /run/secrets/rh-pass)"
+
+		subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
+		# dnf config-manager --set-enabled codeready-builder-for-rhel-9-$(arch)-rpms
+	fi
+EOT
 
 FROM subscribed-image
 


### PR DESCRIPTION
This is a PoC for building RHEL packages assuming that a RHEL username/password is available in the environment.

This is mostly intended for internal use by Docker, as it is assumed that the main utility is performing builds with a 'real RHEL' for enterprise customers.

However, when a unencumbered RHEL-equivalent distribution (e.g. Rocky) is supported, it will make sense to generalize the 'rhel' infrastructure in this repo.