### PR TITLE
Build Fedora 40 RPM packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ def pkgs = [
     [target: "debian-bookworm",          image: "debian:bookworm",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (Next stable)
     [target: "fedora-38",                image: "fedora:38",                              arches: ["amd64", "aarch64"]],          // EOL: May 14, 2024
     [target: "fedora-39",                image: "fedora:39",                              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024
+    [target: "fedora-40",                image: "fedora:40",                              arches: ["amd64", "aarch64"]],          // EOL: May 13, 2025
     [target: "raspbian-buster",          image: "balenalib/rpi-raspbian:buster",          arches: ["armhf"]],                     // Debian/Raspbian 10 (EOL: 2024)
     [target: "raspbian-bullseye",        image: "balenalib/rpi-raspbian:bullseye",        arches: ["armhf"]],                     // Debian/Raspbian 11 (stable)
     [target: "raspbian-bookworm",        image: "balenalib/rpi-raspbian:bookworm",        arches: ["armhf"]],                     // Debian/Raspbian 12 (next stable)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -49,7 +49,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-39 fedora-38
+FEDORA_RELEASES ?= fedora-40 fedora-39 fedora-38
 CENTOS_RELEASES ?= centos-7 centos-8 centos-9
 ifeq ($(ARCH),s390x)
 RHEL_RELEASES ?= rhel-7

--- a/rpm/fedora-40/Dockerfile
+++ b/rpm/fedora-40/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE
+ARG DISTRO=fedora
+ARG SUITE=40
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV GOTOOLCHAIN=local
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
A near identical PR to my previous one which enabled Fedora 39 RPMs ([here](https://github.com/docker/docker-ce-packaging/pull/940)).
I understand this likely cannot be merged until the [containerd packaging is enabled](https://github.com/docker/containerd-packaging/pull/330), but this should be ready any day now.

Would be great to get both PRs merged before the F40 release next month so users are able to run these pre-release Fedora versions.

I have ran `make fedora-40` locally, and this completed successfully.
Partial build log:

<details>

```
+ LDFLAGS='-Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes '
+ export LDFLAGS
+ LT_SYS_LIBRARY_PATH=/usr/lib64:
+ export LT_SYS_LIBRARY_PATH
+ CC=gcc
+ export CC
+ CXX=g++
+ export CXX
+ cd src
++ /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/libexec/docker/cli-plugins/docker-compose docker-cli-plugin-metadata
++ awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }'
+ ver=v2.24.6
+ test v2.24.6 = v2.24.6
+ echo 'PASS: docker-compose version OK'
+ RPM_EC=0
PASS: docker-compose version OK
++ jobs -p
+ exit 0
Processing files: docker-compose-plugin-2.24.6-0.fc40.x86_64
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.dx6i3L
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd src
+ DOCDIR=/root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ export LC_ALL=
+ LC_ALL=
+ export DOCDIR
+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/LICENSE /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/MAINTAINERS /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/NOTICE /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/README.md /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/doc/docker-compose-plugin
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(%license): /bin/sh -e /var/tmp/rpm-tmp.2gwzBv
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd src
+ LICENSEDIR=/root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/licenses/docker-compose-plugin
+ export LC_ALL=
+ LC_ALL=
+ export LICENSEDIR
+ /usr/bin/mkdir -p /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/licenses/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/LICENSE /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/licenses/docker-compose-plugin
+ cp -pr /root/rpmbuild/BUILD/src/docker-compose-plugin-docs/NOTICE /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/share/licenses/docker-compose-plugin
+ RPM_EC=0
++ jobs -p
+ exit 0
warning: Missing build-id in /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/libexec/docker/cli-plugins/docker-compose
Provides: docker-compose-plugin = 0:2.24.6-0.fc40 docker-compose-plugin(x86-64) = 0:2.24.6-0.fc40
Requires(interp): /bin/sh /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(post): /bin/sh
Requires(preun): /bin/sh
Requires(postun): /bin/sh
Requires: libc.so.6()(64bit) libc.so.6(GLIBC_2.2.5)(64bit) libc.so.6(GLIBC_2.3.2)(64bit) libc.so.6(GLIBC_2.32)(64bit) libc.so.6(GLIBC_2.34)(64bit) libresolv.so.2()(64bit)
Enhances: docker-ce-cli
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64
Wrote: /root/rpmbuild/SRPMS/docker-compose-plugin-2.24.6-0.fc40.src.rpm
Wrote: /root/rpmbuild/RPMS/x86_64/docker-compose-plugin-2.24.6-0.fc40.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.PnoRGe
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd src
+ /usr/bin/rm -rf /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(rmbuild): /bin/sh -e /var/tmp/rpm-tmp.zXsyck
+ umask 022
+ cd /root/rpmbuild/BUILD
+ rm -rf /root/rpmbuild/BUILD/src-SPECPARTS
+ rm -rf src src.gemspec
+ RPM_EC=0
++ jobs -p
+ exit 0

RPM build warnings:
    line 65: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-ce-selinux
    line 66: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine-selinux
    line 67: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine
    source_date_epoch_from_changelog set but %changelog is missing
    Missing build-id in /root/rpmbuild/BUILDROOT/docker-ce-0.0.0~20240301173358.35e6a41-0.fc40.x86_64/usr/bin/docker-proxy
    source_date_epoch_from_changelog set but %changelog is missing
    source_date_epoch_from_changelog set but %changelog is missing
    source_date_epoch_from_changelog set but %changelog is missing
    Missing build-id in /root/rpmbuild/BUILDROOT/docker-buildx-plugin-0.12.1-0.fc40.x86_64/usr/libexec/docker/cli-plugins/docker-buildx
    source_date_epoch_from_changelog set but %changelog is missing
    Missing build-id in /root/rpmbuild/BUILDROOT/docker-compose-plugin-2.24.6-0.fc40.x86_64/usr/libexec/docker/cli-plugins/docker-compose
docker run --rm -v /Users/admin/Repos/p5/docker-ce-packaging/feature/enable-fedora-40-builds/rpm:/v -w /v alpine chown -R 501:20 "rpmbuild/fedora-40"
```

</details>