### PR TITLE
debian: add explicit GOARM for raspbian

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -6,6 +6,13 @@ TARGET_ARCH = $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 PKG_REVISION ?= 1
 export PKG_REVISION
 
+# FIXME: quick hardcoding of GOARM for raspbian; replace with a holistic
+# refactoring of how we handle target architecture
+distribution := $(shell . /etc/os-release; echo "$${ID}")
+ifeq ($(distribution),raspbian)
+	export GOARM=6
+endif
+
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'
 override_dh_builddeb:


### PR DESCRIPTION
This is a quick band-aid; we need to overhaul how we handle architectures in these scripts (and use the Debian base images for Raspbian); but for now this should ensure we force ARMv6 for Raspbian targets.