### PR TITLE
debian: build armv6 binaries for armhf

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -1,17 +1,19 @@
 #!/usr/bin/make -f
 
+# Include default Makefile variables.
+include /usr/share/dpkg/default.mk
+
+# Build all armhf binaries as ARMv6 with hard float, to support both
+# Debian armhf and Raspbian armhf.
+ifeq ($(DEB_TARGET_ARCH),armhf)
+	export CFLAGS += -marm -march=armv6+fp
+	export GOARM := 6
+endif
+
 VERSION ?= $(shell cat engine/VERSION)
-TARGET_ARCH = $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 # TODO(thaJeztah): allow passing this version when building.
 PKG_REVISION ?= 1
 export PKG_REVISION
-
-# FIXME: quick hardcoding of GOARM for raspbian; replace with a holistic
-# refactoring of how we handle target architecture
-distribution := $(shell . /etc/os-release; echo "$${ID}")
-ifeq ($(distribution),raspbian)
-	export GOARM=6
-endif
 
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use
 # zstd compression, which is non-standard, and breaks 'dpkg-sig --verify'


### PR DESCRIPTION
Debian armhf is armv7 and hard-float, and Raspbian is a rebuild of Debian with armv6 and hard-float. This is done to make use of the BCM2835 FPU, as while the Debian armel (armv5 and soft-float) port works, it does not make full use of the CPU's hardware.

By making this change, our 'armhf' binaries will work on both armv6 and armv7 systems.