### PR TITLE
[master] disable seccomp to prevent tar EPERM (Ubuntu 24.04 armhf on 20.04 host)

### DIFF
--- a/deb/Makefile
+++ b/deb/Makefile
@@ -27,7 +27,12 @@ BUILD?=DOCKER_BUILDKIT=1 \
 
 # Additional flags may be necessary at some point
 RUN_FLAGS=
+
+# FIXME(thaJeztah): disabling seccomp to handle (armhf) tar "chown / chmod" failing
+# when running in a Ubuntu 24.04 container on a Ubuntu 20.04.6 host (kernel 5.15.0-1053-aws);
+# see https://github.com/docker/docker-ce-packaging/pull/1006#issuecomment-2006878743
 RUN?=docker run --rm \
+	--security-opt seccomp=unconfined \
 	-e PLATFORM \
 	-e EPOCH='$(EPOCH)' \
 	-e DEB_VERSION=$(word 1, $(GEN_DEB_VER)) \


### PR DESCRIPTION
- addresses https://github.com/docker/docker-ce-packaging/pull/1006#issuecomment-2006878743

tar is failing to apply permissions, but only on `armhf` if seccomp is enabled

    docker run --rm -e PLATFORM -e EPOCH='5' -e DEB_VERSION=0.0.0~20240319100031.2356372 -e VERSION=0.0.0-20240319100031-2356372 -e CLI_GITCOMMIT=2356372 -e ENGINE_GITCOMMIT=23e1af4 -e BUILDX_VERSION=v0.13.1 -e BUILDX_DEB_VERSION=0.13.1 -e BUILDX_GITCOMMIT=7884339 -e COMPOSE_VERSION=v2.25.0 -e COMPOSE_DEB_VERSION=2.25.0 -v /home/ubuntu/workspace/docker-ce-packaging_PR-1006/deb/debbuild/ubuntu-noble:/build  debbuild-ubuntu-noble/aarch64
    + set -e
    + mkdir -p /root/build-deb/engine
    + tar -C /root/build-deb -xzf /sources/engine.tgz
    tar: engine/daemon/config: Cannot change mode to rwxrwxr-x: Operation not permitted
    tar: engine/daemon/stats: Cannot change mode to rwxrwxr-x: Operation not permitted
    tar: engine/daemon/images: Cannot change mode to rwxrwxr-x: Operation not permitted
    tar: engine/daemon/containerd: Cannot change mode to rwxrwxr-x: Operation not permitted
    ...
    tar: engine/integration-cli: Cannot change mode to rwxrwxr-x: Operation not permitted
    tar: Exiting with failure status due to previous errors
    make[1]: *** [Makefile:80: ubuntu-noble] Error 2
    make[1]: Leaving directory '/home/ubuntu/workspace/docker-ce-packaging_PR-1006/deb'
    make: *** [Makefile:83: ubuntu-noble] Error 2
    script returned exit code 2

This is failing when the ubuntu 24.04 armhf container runs on a ubuntu 20.04 host;

    Client: Docker Engine - Community
     Version:           25.0.3
     API version:       1.44
     Go version:        go1.21.6
     Git commit:        4debf41
     Built:             Tue Feb  6 21:22:23 2024
     OS/Arch:           linux/arm
     Context:           default

    Server: Docker Engine - Community
     Engine:
      Version:          25.0.3
      API version:      1.44 (minimum version 1.24)
      Go version:       go1.21.6
      Git commit:       f417435
      Built:            Tue Feb  6 21:22:23 2024
      OS/Arch:          linux/arm
      Experimental:     true
     containerd:
      Version:          1.6.28
      GitCommit:        ae07eda36dd25f8a1b98dfbf587313b99c0190bb
     runc:
      Version:          1.1.12
      GitCommit:        v1.1.12-0-g51d5e94
     docker-init:
      Version:          0.19.0
      GitCommit:        de40ad0

    Client: Docker Engine - Community
     Version:    25.0.3
     Context:    default
     Debug Mode: false
     Plugins:
      buildx: Docker Buildx (Docker Inc.)
        Version:  v0.12.1
        Path:     /usr/libexec/docker/cli-plugins/docker-buildx
      compose: Docker Compose (Docker Inc.)
        Version:  v2.24.5
        Path:     /usr/libexec/docker/cli-plugins/docker-compose

    Server:
     Containers: 0
      Running: 0
      Paused: 0
      Stopped: 0
     Images: 5
     Server Version: 25.0.3
     Storage Driver: overlay2
      Backing Filesystem: extfs
      Supports d_type: true
      Using metacopy: false
      Native Overlay Diff: true
      userxattr: false
     Logging Driver: json-file
     Cgroup Driver: cgroupfs
     Cgroup Version: 1
     Plugins:
      Volume: local
      Network: bridge host ipvlan macvlan null overlay
      Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
     Swarm: inactive
     Runtimes: runc io.containerd.runc.v2
     Default Runtime: runc
     Init Binary: docker-init
     containerd version: ae07eda36dd25f8a1b98dfbf587313b99c0190bb
     runc version: v1.1.12-0-g51d5e94
     init version: de40ad0
     Security Options:
      apparmor
      seccomp
       Profile: builtin
     Kernel Version: 5.15.0-1053-aws
     Operating System: Ubuntu 20.04.6 LTS
     OSType: linux
     Architecture: armv8l
     CPUs: 2
     Total Memory: 7.559GiB
     Name: ip-10-100-72-215
     ID: e901fd37-4acc-4712-8a91-b41a94767d78
     Docker Root Dir: /var/lib/docker
     Debug Mode: false
     Username: dockerbuildbot
     Experimental: true
     Insecure Registries:
      127.0.0.0/8
     Live Restore Enabled: true

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

