### PR TITLE
[master] rpm: disable seccomp to prevent tar EPERM (Fedora 40 ppc64le on Debian)

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -41,7 +41,13 @@ RPMBUILD_FLAGS?=-ba\
 
 # Additional flags may be necessary at some point
 RUN_FLAGS=
+
+# FIXME(thaJeztah): disabling seccomp to handle (ppc64le) tar "chown / chmod"
+# failing when running in a Fedora 40 container on a Debian bookworm host;
+# see https://github.com/docker/docker-ce-packaging/issues/1012 and
+# https://github.com/docker/docker-ce-packaging/pull/1006#issuecomment-2006878743
 RUN?=docker run --rm \
+	--security-opt seccomp=unconfined \
 	-e PLATFORM \
 	-v $(CURDIR)/rpmbuild/SOURCES:/root/rpmbuild/SOURCES:ro \
 	-v $(CURDIR)/rpmbuild/$@/RPMS:/root/rpmbuild/RPMS \


### PR DESCRIPTION
- addresses / fixes https://github.com/docker/docker-ce-packaging/issues/1012
- relates to https://github.com/docker/docker-ce-packaging/pull/1007


commit 07b5d9031f18ad8317f23738c7ff4ce9f77e3ee3 disabled seccomp for the deb-builds because `chmod` failed tar was failing with an EPERM (Ubuntu 24.04 armhf on 20.04 host).

It looks like the same problem happens when running Fedora 40 on a Debian bookworm host on ppc64le.

That issue was confirmed to be related to `fchmodat2(2)`, which is a new syscall that's not supported on the host, and therefore gets the seccomp's default EPERM;

    fchmodat2(AT_FDCWD, "docker", 0775, AT_SYMLINK_NOFOLLOW) = -1 EPERM (Operation not permitted)
    tar: docker: Cannot change mode to rwxrwxr-x: Operation not permitted
    tar: Exiting with failure status due to previous errors

Ultimately we need to update the libseccomp profile to use ENOSYS (see moby ticket 42871) to allow it to degrade gracefully;

    fchmodat2(AT_FDCWD, "docker", 0775, AT_SYMLINK_NOFOLLOW) = -1 ENOSYS (Function not implemented)

**- A picture of a cute animal (not mandatory but encouraged)**

