### PR TITLE
Remove 'rootlesskit-docker-proxy'

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -85,7 +85,6 @@ override_dh_auto_install:
 
 	# docker-ce-rootless-extras install
 	install -D -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
-	install -D -m 0755 /usr/local/bin/rootlesskit-docker-proxy debian/docker-ce-rootless-extras/usr/bin/rootlesskit-docker-proxy
 	install -D -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
 	install -D -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
 	# TODO: how can we install vpnkit?

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -48,13 +48,11 @@ TMP_GOPATH="/go" ${RPM_BUILD_DIR}/src/engine/hack/dockerfile/install/install.sh 
 install -D -p -m 0755 engine/contrib/dockerd-rootless.sh ${RPM_BUILD_ROOT}%{_bindir}/dockerd-rootless.sh
 install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh ${RPM_BUILD_ROOT}%{_bindir}/dockerd-rootless-setuptool.sh
 install -D -p -m 0755 /usr/local/bin/rootlesskit ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit
-install -D -p -m 0755 /usr/local/bin/rootlesskit-docker-proxy ${RPM_BUILD_ROOT}%{_bindir}/rootlesskit-docker-proxy
 
 %files
 %{_bindir}/dockerd-rootless.sh
 %{_bindir}/dockerd-rootless-setuptool.sh
 %{_bindir}/rootlesskit
-%{_bindir}/rootlesskit-docker-proxy
 
 %post
 

--- a/static/Makefile
+++ b/static/Makefile
@@ -50,7 +50,7 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 
 	# extra binaries for running rootless
 	mkdir -p build/linux/docker-rootless-extras
-	for f in rootlesskit rootlesskit-docker-proxy dockerd-rootless.sh dockerd-rootless-setuptool.sh vpnkit; do \
+	for f in rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh vpnkit; do \
 		if [ -f $(ENGINE_DIR)/bundles/binary/$$f ]; then \
 			cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker-rootless-extras/$$f; \
 		fi \


### PR DESCRIPTION
**- What I did**

Depends on:
- https://github.com/moby/moby/pull/48132

With that PR, `rootlesskit-docker-proxy` is no longer used or built.

**- How I did it**

Removed commands for installing `rootlesskit-docker-proxy`.

**- How to verify it**

Interesting question!

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The executable `rootlesskit-docker-proxy` is no longer required and has been removed.
