### PR TITLE
[master] verify: remove workaround for containerd-shim 1.6's missing "-v" flag

### DIFF
--- a/verify
+++ b/verify
@@ -33,9 +33,7 @@ function verify_binaries() {
 	docker-proxy --version
 	containerd --version
 	ctr --version
-	# containerd-shim v1.6.x does not have a -v flag.
-	# TODO(thaJeztah): use -v once we switch to containerd 1.7 (see https://github.com/containerd/containerd/pull/6495)
-	containerd-shim --help
+	containerd-shim -v
 	containerd-shim-runc-v1 -v
 	containerd-shim-runc-v2 -v
 	runc --version


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/819
- relates to https://github.com/containerd/containerd/pull/6495


The containerd-shim binary that's shipped with containerd 1.6 did not provide a `-v` flag to show the version, so f1f6f220e6f6070f8e481d7b60101816526f8bf8 used `--help` as alternative.

Now that we package containerd 1.7, we can use the `-v` flag instead;

    containerd-shim -v
    containerd-shim
      Version:  1.7.19
      Revision: 2bf793ef6dc9a18e00cb12efb64355c2c9d5eb41
      Go version: go1.21.12

