### PR TITLE
[master] static: remove unused docker-proxy.exe binary from Windows packages

### DIFF
--- a/static/Makefile
+++ b/static/Makefile
@@ -85,7 +85,6 @@ cross-win: cross-win-engine
 	mkdir -p build/win/amd64/docker
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/amd64/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/win/dockerd.exe build/win/amd64/docker/dockerd.exe
-	cp $(ENGINE_DIR)/bundles/cross/win/docker-proxy.exe build/win/amd64/docker/docker-proxy.exe
 	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/554
- relates to https://github.com/docker/docker-ce-packaging/pull/578
- slightly related to https://github.com/docker/docker-ce-packaging/pull/1037
- slightly related to https://github.com/moby/moby/pull/48132

The `docker-proxy.exe` binary was added to the static Windows packages through commit 09541b553c2f7646626efcc2797bd92ee48a66d0 (which introduced a bug, later fixed through fc5379fee869e8fa0e9a2569a66083e61e83de18).

It looks like that commit added the `docker-proxy.exe` binary with the assumption that it's used on Windows (given that its also built in upstream), but recent discussions revealed that's not the case.

This patch removes binary from the static packages for Windows, because it's not used.

A quick look at Docker Desktop's build scripts show that it's not included in those packages, and installation instructions for static binaries on Windows do not mention this binary https://docs.docker.com/engine/install/binaries/#install-server-and-client-binaries-on-windows), so no further changes should be needed.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Remove unused `docker-proxy.exe` binary from Windows packages
```


**- A picture of a cute animal (not mandatory but encouraged)**

