### PR TITLE
Dockerfile: Fix legacy `ENV key value` format

### DIFF
--- a/deb/debian-bookworm/Dockerfile
+++ b/deb/debian-bookworm/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/raspbian-bookworm/Dockerfile
+++ b/deb/raspbian-bookworm/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-focal/Dockerfile
+++ b/deb/ubuntu-focal/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-noble/Dockerfile
+++ b/deb/ubuntu-noble/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y curl devscripts equivs git
 
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
-ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian


### PR DESCRIPTION
Replace legacy `ENV key value` syntax with `ENV key=value`.
This fixes the build linter warning LegacyKeyValueFormat.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>