### PR TITLE
[master] Bump compose version to v2.29.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 # DOCKER_COMPOSE_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_COMPOSE_REPO.
-DOCKER_COMPOSE_REF ?= v2.29.1
+DOCKER_COMPOSE_REF ?= v2.29.2
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.16.2


### PR DESCRIPTION
- carries https://github.com/docker/docker-ce-packaging/pull/1049
- closes https://github.com/docker/docker-ce-packaging/pull/1049

