### PR TITLE
feat: build Fedora 41 RPM packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ def pkgs = [
     [target: "debian-bookworm",          image: "debian:bookworm",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (Next stable)
     [target: "fedora-39",                image: "fedora:39",                              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024
     [target: "fedora-40",                image: "fedora:40",                              arches: ["amd64", "aarch64"]],          // EOL: May 13, 2025
+    [target: "fedora-41",                image: "fedora:41",                              arches: ["amd64", "aarch64"]],          // EOL: November, 2025
     [target: "raspbian-bullseye",        image: "balenalib/rpi-raspbian:bullseye",        arches: ["armhf"]],                     // Debian/Raspbian 11 (stable)
     [target: "raspbian-bookworm",        image: "balenalib/rpi-raspbian:bookworm",        arches: ["armhf"]],                     // Debian/Raspbian 12 (next stable)
     [target: "ubuntu-focal",             image: "ubuntu:focal",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -61,7 +61,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-40 fedora-39
+FEDORA_RELEASES ?= fedora-39 fedora-40 fedora-41
 CENTOS_RELEASES ?= centos-9
 RHEL_RELEASES ?= rhel-8 rhel-9
 

--- a/rpm/fedora-41/Dockerfile
+++ b/rpm/fedora-41/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE
+ARG DISTRO=fedora
+ARG SUITE=41
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH /go
+ENV GOTOOLCHAIN=local
+ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH 1
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
**- What I did**

It's nearing that time again.  A new Fedora release.
This is part 2 of 2 for packaging Docker CE for Fedora 41.  [Part 1](https://github.com/docker/containerd-packaging/pull/388) is awaiting review in the [docker/containerd-packaging](https://github.com/docker/containerd-packaging) repository.

Fedora have not (yet) set a concrete date for the EOL of Fedora 41, however it will be in or around November 2025.

**- How I did it**

The same as the previous two releases - added a line for Fedora 41 in the Jenkinsfile, updated the list of OSes in the Makefile and created a new Dockerfile using the new Fedora 41 image.

**- How to verify it**

I have ran `make fedora` from the `./rpms` directory, and a RPM file was successfully created.

**- Description for the changelog**
Enable Docker CE builds for Fedora 41


**- A picture of a cute animal (not mandatory but encouraged)**

![kali](https://github.com/user-attachments/assets/2c48449b-01b6-4423-a5f6-ec1dfff275a7)
