### PR TITLE
[master] feat: build Fedora 41 RPM packages (carry #1055)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ def pkgs = [
     [target: "debian-bookworm",          image: "debian:bookworm",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (Next stable)
     [target: "fedora-39",                image: "fedora:39",                              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024
     [target: "fedora-40",                image: "fedora:40",                              arches: ["amd64", "aarch64"]],          // EOL: May 13, 2025
+    [target: "fedora-41",                image: "fedora:41",                              arches: ["amd64", "aarch64"]],          // EOL: November, 2025
     [target: "raspbian-bullseye",        image: "balenalib/rpi-raspbian:bullseye",        arches: ["armhf"]],                     // Debian/Raspbian 11 (stable)
     [target: "raspbian-bookworm",        image: "balenalib/rpi-raspbian:bookworm",        arches: ["armhf"]],                     // Debian/Raspbian 12 (next stable)
     [target: "ubuntu-focal",             image: "ubuntu:focal",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -61,7 +61,7 @@ RUN?=docker run --rm \
 	$(RUN_FLAGS) \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
-FEDORA_RELEASES ?= fedora-40 fedora-39
+FEDORA_RELEASES ?= fedora-39 fedora-40 fedora-41
 CENTOS_RELEASES ?= centos-9
 RHEL_RELEASES ?= rhel-8 rhel-9
 

--- a/rpm/fedora-41/Dockerfile
+++ b/rpm/fedora-41/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE=golang:latest
+ARG DISTRO=fedora
+ARG SUITE=41
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH=1
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]

--- a/rpm/fedora-41/Dockerfile
+++ b/rpm/fedora-41/Dockerfile
@@ -19,6 +19,30 @@ ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+# FIXME(thaJeztah): workaround for building on Fedora 41 on arm64
+#
+# This is the equivalent of https://github.com/docker/containerd-packaging/pull/390
+# for containerd packages, but unlike for containerd packages, we currently do
+# not run into this issue when building docker-ce packages. We're installing
+# this as a precaution, but perhaps it's not needed.
+#
+# go1.21 and up have a patch that enforces the use of ld.gold to work around
+# a bug in GNU binutils. See;
+# - https://github.com/golang/go/issues/22040.
+# - https://github.com/golang/go/commit/cd77738198ffe0c4a1db58352c89f9b2d2a4e85e
+#
+# Fedora 41 and up has a fixed version of binutils, and no longer requires that
+# patch, but may fail without ld.gold installed;
+#
+#   /usr/bin/gcc -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-1738353519/go.o /tmp/go-link-1738353519/000000.o /tmp/go-link-1738353519/000001.o /tmp/go-link-1738353519/000002.o /tmp/go-link-1738353519/000003.o /tmp/go-link-1738353519/000004.o /tmp/go-link-1738353519/000005.o /tmp/go-link-1738353519/000006.o /tmp/go-link-1738353519/000007.o /tmp/go-link-1738353519/000008.o /tmp/go-link-1738353519/000009.o /tmp/go-link-1738353519/000010.o /tmp/go-link-1738353519/000011.o /tmp/go-link-1738353519/000012.o /tmp/go-link-1738353519/000013.o /tmp/go-link-1738353519/000014.o /tmp/go-link-1738353519/000015.o /tmp/go-link-1738353519/000016.o /tmp/go-link-1738353519/000017.o /tmp/go-link-1738353519/000018.o /tmp/go-link-1738353519/000019.o /tmp/go-link-1738353519/000020.o /tmp/go-link-1738353519/000021.o /tmp/go-link-1738353519/000022.o /tmp/go-link-1738353519/000023.o /tmp/go-link-1738353519/000024.o -O2 -g -lresolv -O2 -g -lpthread -O2 -g -ldl -O2 -g
+#   collect2: fatal error: cannot find 'ld'
+#
+# Fedora's build of Go carries a patch for that, but it's not (yet) in upstream;
+# - https://src.fedoraproject.org/rpms/golang/blob/a867bd88a656c1d6e91e7b18bab696dc3fcf1e77/f/0006-Default-to-ld.bfd-on-ARM64.patch
+# - https://src.fedoraproject.org/rpms/golang/c/a867bd88a656c1d6e91e7b18bab696dc3fcf1e77?branch=rawhide
+#
+# As a workaround; install binutils-gold
+RUN if [ "$(arch)" = 'aarch64' ]; then dnf -y install binutils-gold; fi
 COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --link --from=golang /usr/local/go /usr/local/go


### PR DESCRIPTION
- [x] depends on https://github.com/docker/docker-ce-packaging/pull/1059
- carries https://github.com/docker/docker-ce-packaging/pull/1055
- closes https://github.com/docker/docker-ce-packaging/pull/1055

**- What I did**

It's nearing that time again.  A new Fedora release.
This is part 2 of 2 for packaging Docker CE for Fedora 41.  [Part 1](https://github.com/docker/containerd-packaging/pull/388) is awaiting review in the [docker/containerd-packaging](https://github.com/docker/containerd-packaging) repository.

Fedora have not (yet) set a concrete date for the EOL of Fedora 41, however it will be in or around November 2025.

**- How I did it**

The same as the previous two releases - added a line for Fedora 41 in the Jenkinsfile, updated the list of OSes in the Makefile and created a new Dockerfile using the new Fedora 41 image.

**- How to verify it**

I have ran `make fedora` from the `./rpms` directory, and a RPM file was successfully created.

**- Description for the changelog**
Enable Docker CE builds for Fedora 41


**- A picture of a cute animal (not mandatory but encouraged)**

![kali](https://github.com/user-attachments/assets/2c48449b-01b6-4423-a5f6-ec1dfff275a7)

