### PR TITLE
[27.x backport] install_rpm_containerd: add support for dnf5

### DIFF
--- a/install-containerd-helpers
+++ b/install-containerd-helpers
@@ -24,15 +24,17 @@ function install_rpm_containerd() {
 	# so this logic works for both cases.
 	# (See also same logic in install_debian_containerd)
 
-	if dnf --version; then
+	if command -v dnf; then
+		dnf --version
+
 		dnf config-manager --add-repo "${REPO_URL}"
-		dnf config-manager --set-disabled docker-ce-*
-		dnf config-manager --set-enabled docker-ce-test
+		dnf config-manager --set-disabled 'docker-ce-*'
+		dnf config-manager --set-enabled 'docker-ce-test'
 		dnf makecache
 	else
 		yum-config-manager --add-repo "${REPO_URL}"
-		yum-config-manager --disable docker-ce-*
-		yum-config-manager --enable docker-ce-test
+		yum-config-manager --disable 'docker-ce-*'
+		yum-config-manager --enable 'docker-ce-test'
 		yum makecache
 	fi
 }

--- a/install-containerd-helpers
+++ b/install-containerd-helpers
@@ -27,7 +27,12 @@ function install_rpm_containerd() {
 	if command -v dnf5; then
 		dnf --version
 
-		dnf config-manager addrepo --save-filename=docker-ce.repo --from-repofile="${REPO_URL}"
+		# FIXME(thaJeztah); strip empty lines as workaround for https://github.com/rpm-software-management/dnf5/issues/1603
+		TMP_REPO_FILE="$(mktemp --dry-run)"
+		curl -fsSL "${REPO_URL}" | tr -s '\n' > "${TMP_REPO_FILE}"
+		dnf config-manager addrepo --save-filename=docker-ce.repo  --overwrite --from-repofile="${TMP_REPO_FILE}"
+		rm -f "${TMP_REPO_FILE}"
+		# dnf config-manager addrepo --save-filename=docker-ce.repo --from-repofile="${REPO_URL}"
 		dnf config-manager setopt 'docker-ce-*.enabled=0'
 		dnf config-manager setopt 'docker-ce-test.enabled=1'
 		dnf makecache

--- a/install-containerd-helpers
+++ b/install-containerd-helpers
@@ -24,7 +24,14 @@ function install_rpm_containerd() {
 	# so this logic works for both cases.
 	# (See also same logic in install_debian_containerd)
 
-	if command -v dnf; then
+	if command -v dnf5; then
+		dnf --version
+
+		dnf config-manager addrepo --save-filename=docker-ce.repo --from-repofile="${REPO_URL}"
+		dnf config-manager setopt 'docker-ce-*.enabled=0'
+		dnf config-manager setopt 'docker-ce-test.enabled=1'
+		dnf makecache
+	elif command -v dnf; then
 		dnf --version
 
 		dnf config-manager --add-repo "${REPO_URL}"


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1059
- relates to https://github.com/docker/docker-ce-packaging/pull/1058
- relates to https://github.com/rpm-software-management/dnf5/issues/1603

### install_rpm_containerd: minor cleanup

- use command -v for detecting dnf instead of the --version
- quote repo-IDs to prevent globbing by the shell

### install_rpm_containerd: add support for dnf5

Fedora 41 and up use the new dnf5 as default, which is a rewrite of
the dnf commands with different options;

    + dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
    Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments.
    make: *** [Makefile:95: verify] Error 2
    script returned exit code 2

### install_rpm_containerd: add workaround for dnf5 addrepo bug

The addrepo command has a bug that causes it to fail if the `.repo` file
contains empty lines, causing it to fail;

    dnf config-manager addrepo --from-repofile="https://download.docker.com/linux/fedora/docker-ce.repo"
    Error in added repository configuration file. Cannot set repository option "#1=
    ": Option "#1" not found

Use a temporary file and strip empty lines as a workaround until the bug
is fixed.
