### PR TITLE
[27.x backport] rpm: fix missing GOTOOLCHAIN=local in centos, rhel Dockerfiles

### DIFF
--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -11,6 +11,7 @@ FROM ${BUILD_IMAGE}
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS exclude_graphdriver_btrfs

--- a/rpm/rhel-8/Dockerfile
+++ b/rpm/rhel-8/Dockerfile
@@ -28,6 +28,7 @@ FROM subscribed-image
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS exclude_graphdriver_btrfs

--- a/rpm/rhel-9/Dockerfile
+++ b/rpm/rhel-9/Dockerfile
@@ -28,6 +28,7 @@ FROM subscribed-image
 ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH 1
 ENV DOCKER_BUILDTAGS exclude_graphdriver_btrfs


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1062


Commit a4090a0e198517b9e7603db375a283c3df3ec4f7 added GOTOOLCHAIN=local, but for some reason missed the centos Dockerfiles.

The env-var is set to make sure we don't get unexpected updates of the go toolchain when building. We need to set this env-var, because we're not using the official golang image as base-image, but instead copy the binaries into a distro-image.

This patch adds the missing GOTOOLCHAIN env-vars.


(cherry picked from commit dc175c09fd68aee12ca0752f83aff16a7a51fef2)

