### PR TITLE
[27.x backport] Add Ubuntu 24.10 "Oracular Oriole"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - ubuntu-focal
           - ubuntu-jammy
           - ubuntu-noble
+          - ubuntu-oracular
     steps:
       -
         name: Checkout

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def pkgs = [
     [target: "ubuntu-focal",             image: "ubuntu:focal",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 20.04 LTS (End of support: April, 2025. EOL: April, 2030)
     [target: "ubuntu-jammy",             image: "ubuntu:jammy",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 22.04 LTS (End of support: June,  2027. EOL: April, 2032)
     [target: "ubuntu-noble",             image: "ubuntu:noble",                           arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.04 LTS (End of support: June,  2029. EOL: April, 2034)
+    [target: "ubuntu-oracular",          image: "ubuntu:oracular",                        arches: ["amd64", "aarch64", "armhf"]], // Ubuntu 24.10 (EOL: July, 2025)
 ]
 
 def genBuildStep(LinkedHashMap pkg, String arch) {

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -51,7 +51,7 @@ RUN?=docker run --rm \
 	debbuild-$@/$(ARCH)
 
 DEBIAN_VERSIONS ?= debian-bullseye debian-bookworm
-UBUNTU_VERSIONS ?= ubuntu-focal ubuntu-jammy ubuntu-noble
+UBUNTU_VERSIONS ?= ubuntu-focal ubuntu-jammy ubuntu-noble ubuntu-oracular
 RASPBIAN_VERSIONS ?= raspbian-bullseye raspbian-bookworm
 DISTROS := $(DEBIAN_VERSIONS) $(UBUNTU_VERSIONS) $(RASPBIAN_VERSIONS)
 

--- a/deb/ubuntu-oracular/Dockerfile
+++ b/deb/ubuntu-oracular/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE=golang:latest
+ARG DISTRO=ubuntu
+ARG SUITE=oracular
+ARG VERSION_ID=24.10
+ARG BUILD_IMAGE=${DISTRO}:${SUITE}
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+
+# Remove diverted man binary to prevent man-pages being replaced with "minimized" message. See docker/for-linux#639
+RUN if  [ "$(dpkg-divert --truename /usr/bin/man)" = "/usr/bin/man.REAL" ]; then \
+        rm -f /usr/bin/man; \
+        dpkg-divert --quiet --remove --rename /usr/bin/man; \
+    fi
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y curl devscripts equivs git
+
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+
+ARG COMMON_FILES
+COPY --link ${COMMON_FILES} /root/build-deb/debian
+RUN apt-get update \
+ && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i /root/build-deb/debian/control
+
+COPY --link sources/ /sources
+ARG DISTRO
+ARG SUITE
+ARG VERSION_ID
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+ENV VERSION_ID=${VERSION_ID}
+
+COPY --link --from=golang /usr/local/go /usr/local/go
+
+WORKDIR /root/build-deb
+COPY build-deb /root/build-deb/build-deb
+
+ENTRYPOINT ["/root/build-deb/build-deb"]


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1070

Ubuntu 24.10 is planned to be released on October 10. https://discourse.ubuntu.com/t/oracular-oriole-release-schedule/36460


(cherry picked from commit a7c8523ab23777253966fe41f7cf2b97774b2493)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add Ubuntu 24.10 "Oracular Oriole"

**- A picture of a cute animal (not mandatory but encouraged)**

