### PR TITLE
[27.x backport] bump compose to v2.29.5

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 # DOCKER_COMPOSE_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_COMPOSE_REPO.
-DOCKER_COMPOSE_REF ?= v2.29.4
+DOCKER_COMPOSE_REF ?= v2.29.5
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.17.1


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1081

release-notes: https://github.com/docker/compose/releases/tag/v2.29.5


(cherry picked from commit 3497b371654642556e78565b40befff1ee39eaef)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Update compose [to v2.29.5](https://github.com/docker/compose/releases/tag/v2.29.5)
```


**- A picture of a cute animal (not mandatory but encouraged)**

