### PR TITLE
[27.x backport] update buildx to v0.18.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -43,7 +43,7 @@ DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_COMPOSE_REF ?= v2.30.1
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
-DOCKER_BUILDX_REF  ?= v0.17.1
+DOCKER_BUILDX_REF  ?= v0.18.0
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1093

(cherry picked from commit 32b967f8a6cf0d82fdaeb1564eaddfa719eee050)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
update buildx to v0.18.0
```


**- A picture of a cute animal (not mandatory but encouraged)**

