### PR TITLE
[27.x backport] rpm: remove rpmlint from Dockerfiles as it's not used

### DIFF
--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -25,7 +25,7 @@ ENV SUITE=${SUITE}
 # https://forums.centos.org/viewtopic.php?f=54&t=72574, and
 # https://access.redhat.com/solutions/3720351
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+RUN dnf install -y rpm-build dnf-plugins-core
 RUN dnf config-manager --set-enabled crb
 
 COPY --link SPECS /root/rpmbuild/SPECS

--- a/rpm/fedora-39/Dockerfile
+++ b/rpm/fedora-39/Dockerfile
@@ -18,7 +18,7 @@ ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
-RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+RUN dnf install -y rpm-build dnf-plugins-core
 COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --link --from=golang /usr/local/go /usr/local/go

--- a/rpm/fedora-40/Dockerfile
+++ b/rpm/fedora-40/Dockerfile
@@ -18,7 +18,7 @@ ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
-RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+RUN dnf install -y rpm-build dnf-plugins-core
 COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --link --from=golang /usr/local/go /usr/local/go

--- a/rpm/fedora-41/Dockerfile
+++ b/rpm/fedora-41/Dockerfile
@@ -18,7 +18,7 @@ ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
-RUN dnf install -y rpm-build rpmlint dnf-plugins-core
+RUN dnf install -y rpm-build dnf-plugins-core
 # FIXME(thaJeztah): workaround for building on Fedora 41 on arm64
 #
 # This is the equivalent of https://github.com/docker/containerd-packaging/pull/390

--- a/rpm/rhel-8/Dockerfile
+++ b/rpm/rhel-8/Dockerfile
@@ -37,7 +37,7 @@ ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 
-RUN dnf install -y rpm-build rpmlint
+RUN dnf install -y rpm-build
 COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --link --from=golang /usr/local/go /usr/local/go

--- a/rpm/rhel-9/Dockerfile
+++ b/rpm/rhel-9/Dockerfile
@@ -37,7 +37,7 @@ ARG SUITE
 ENV DISTRO=${DISTRO}
 ENV SUITE=${SUITE}
 
-RUN dnf install -y rpm-build rpmlint
+RUN dnf install -y rpm-build
 COPY --link SPECS /root/rpmbuild/SPECS
 RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
 COPY --link --from=golang /usr/local/go /usr/local/go


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1105

Commit 784a53cec5061e6a718acc3a7104c61215c15078 added `rpmlint` to the Dockerfiles and added a step in the Dockerfile to validate the SPEC files. The validation step was removed in c245ce12c1e0a092ef21094b287b8cb94a51ee1e, but didn't remove the step to install the package.

The `rpmlint` package is also being removed from CentOS Stream 10 ("CS10");

- https://issues.redhat.com/browse/CS-2451
- https://issues.redhat.com/browse/CS-2453

Remove the package as it's not used currently.


(cherry picked from commit 38309c1b6020246bdad19b14116c08b40c72c7c8)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

