### PR TITLE
[27.x backport] Add CentOS Stream 10.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ def branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
 
 def pkgs = [
     [target: "centos-9",                 image: "quay.io/centos/centos:stream9",          arches: ["amd64", "aarch64"]],
+    [target: "centos-10",                image: "quay.io/centos/centos:stream10-development",         arches: ["amd64", "aarch64"]], // CentOS Stream 10 (EOL: 2030)
     [target: "debian-bullseye",          image: "debian:bullseye",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (stable)
     [target: "debian-bookworm",          image: "debian:bookworm",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (Next stable)
     [target: "fedora-39",                image: "fedora:39",                              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -62,7 +62,7 @@ RUN?=docker run --rm \
 	rpmbuild-$@/$(ARCH) $(RPMBUILD_FLAGS)
 
 FEDORA_RELEASES ?= fedora-39 fedora-40 fedora-41
-CENTOS_RELEASES ?= centos-9
+CENTOS_RELEASES ?= centos-9 centos-10
 RHEL_RELEASES ?= rhel-8 rhel-9
 
 DISTROS := $(FEDORA_RELEASES) $(CENTOS_RELEASES) $(RHEL_RELEASES)

--- a/rpm/centos-10/Dockerfile
+++ b/rpm/centos-10/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_IMAGE=golang:latest
+ARG DISTRO=centos
+ARG SUITE=10
+ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}-development
+
+FROM ${GO_IMAGE} AS golang
+
+FROM ${BUILD_IMAGE}
+ENV GOPROXY=https://proxy.golang.org|direct
+ENV GO111MODULE=off
+ENV GOPATH=/go
+ENV GOTOOLCHAIN=local
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV AUTO_GOPATH=1
+ENV DOCKER_BUILDTAGS=exclude_graphdriver_btrfs
+ARG DISTRO
+ARG SUITE
+ENV DISTRO=${DISTRO}
+ENV SUITE=${SUITE}
+
+# RHEL8 / CentOS 8 changed behavior and no longer "rpm --import" or
+# "rpmkeys --import"as part of rpm package's %post scriplet. See
+# https://forums.centos.org/viewtopic.php?f=54&t=72574, and
+# https://access.redhat.com/solutions/3720351
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+RUN dnf install -y rpm-build dnf-plugins-core
+RUN dnf config-manager --set-enabled crb
+
+COPY --link SPECS /root/rpmbuild/SPECS
+RUN dnf builddep -y /root/rpmbuild/SPECS/*.spec
+COPY --link --from=golang /usr/local/go /usr/local/go
+WORKDIR /root/rpmbuild
+ENTRYPOINT ["/bin/rpmbuild"]


### PR DESCRIPTION
- backport https://github.com/docker/docker-ce-packaging/pull/1104

Use image "stream10-development" for now, after the release we should remove the "-development" suffix.

(cherry picked from commit beae6320cd136adfb86632cf1aaf2af786e1848f)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

