### PR TITLE
[27.x backport] Use the final CentOS Stream 10 OCI image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
 
 def pkgs = [
     [target: "centos-9",                 image: "quay.io/centos/centos:stream9",          arches: ["amd64", "aarch64"]],
-    [target: "centos-10",                image: "quay.io/centos/centos:stream10-development",         arches: ["amd64", "aarch64"]], // CentOS Stream 10 (EOL: 2030)
+    [target: "centos-10",                image: "quay.io/centos/centos:stream10",         arches: ["amd64", "aarch64"]],          // CentOS Stream 10 (EOL: 2030)
     [target: "debian-bullseye",          image: "debian:bullseye",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 11 (stable)
     [target: "debian-bookworm",          image: "debian:bookworm",                        arches: ["amd64", "aarch64", "armhf"]], // Debian 12 (Next stable)
     [target: "fedora-39",                image: "fedora:39",                              arches: ["amd64", "aarch64"]],          // EOL: November 12, 2024

--- a/rpm/centos-10/Dockerfile
+++ b/rpm/centos-10/Dockerfile
@@ -3,7 +3,7 @@
 ARG GO_IMAGE=golang:latest
 ARG DISTRO=centos
 ARG SUITE=10
-ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}-development
+ARG BUILD_IMAGE=quay.io/centos/${DISTRO}:stream${SUITE}
 
 FROM ${GO_IMAGE} AS golang
 


### PR DESCRIPTION
@thaJeztah Yesterday RHEL 10 Beta was officially released, and it seems at the same time Red Hat has renamed the CentOS Stream 10 image name to it's final name. See https://quay.io/repository/centos/centos?tab=tags&tag=latest