### PR TITLE
rpm: use SPDX identifier for License fields

### DIFF
--- a/rpm/SPECS/docker-buildx-plugin.spec
+++ b/rpm/SPECS/docker-buildx-plugin.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: buildx.tgz
 Summary: Docker Buildx plugin for the Docker CLI
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/buildx
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -6,7 +6,7 @@ Release: %{_release}%{?dist}
 Epoch: 1
 Summary: The open-source application container engine
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 Source0: cli.tgz
 URL: https://www.docker.com
 Vendor: Docker

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: engine.tgz
 Summary: Rootless support for Docker
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://docs.docker.com/engine/security/rootless/
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -7,7 +7,7 @@ Epoch: 3
 Source0: engine.tgz
 Summary: The open-source application container engine
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://www.docker.com
 Vendor: Docker
 Packager: Docker <support@docker.com>

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -7,7 +7,7 @@ Epoch: 0
 Source0: compose.tgz
 Summary: Docker Compose (V2) plugin for the Docker CLI
 Group: Tools/Docker
-License: ASL 2.0
+License: Apache-2.0
 URL: https://github.com/docker/compose/
 Vendor: Docker
 Packager: Docker <support@docker.com>


### PR DESCRIPTION
- closes https://github.com/docker/docker-ce-packaging/issues/1112


Update the license fields to use the (now recommented) SPDX identifier;

> https://docs.fedoraproject.org/en-US/legal/allowed-licenses/ lists
> Apache-2.0 as the SPDX identifier and ASL 2.0 as a "Legacy Abbreviation"
> for Apache License 2.0.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

