### PR TITLE
[master] deb,rpm: use cobra generated completions

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -27,7 +27,7 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 
 	# Build the CLI
-	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages
+	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages shell-completion
 
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \
@@ -99,9 +99,9 @@ override_dh_auto_install:
 	# [1]: https://manpages.debian.org/bookworm/bash-completion/dh_bash-completion.1.en.html
 	# [2]: https://manpages.debian.org/testing/dh-shell-completions/dh_shell_completions.1.en.html
 	# [3]: https://github.com/PowerShell/PowerShell/issues/17582
-	install -D -p -m 0644 cli/contrib/completion/bash/docker debian/docker-ce-cli/usr/share/bash-completion/completions/docker
-	install -D -p -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
-	install -D -p -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
+	install -D -p -m 0644 cli/build/completion/bash/docker debian/docker-ce-cli/usr/share/bash-completion/completions/docker
+	install -D -p -m 0644 cli/build/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
+	install -D -p -m 0644 cli/build/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 
 	# docker-ce install
 	install -D -p -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -47,7 +47,7 @@ depending on a particular stack or provider.
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
-make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
+make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages shell-completion
 
 %check
 ver="$(cli/build/docker --version)"; \
@@ -58,9 +58,9 @@ ver="$(cli/build/docker --version)"; \
 install -D -p -m 755 cli/build/docker ${RPM_BUILD_ROOT}%{_bindir}/docker
 
 # add bash, zsh, and fish completions
-install -D -p -m 644 cli/contrib/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
-install -D -p -m 644 cli/contrib/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
-install -D -p -m 644 cli/contrib/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
+install -D -p -m 644 cli/build/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
+install -D -p -m 644 cli/build/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
+install -D -p -m 644 cli/build/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
 
 # install manpages
 # Note: we need to create destination dirs first (instead "install -D") due to wildcards used.


### PR DESCRIPTION
- supersedes   / closes https://github.com/docker/docker-ce-packaging/pull/1156
- depends on https://github.com/docker/cli/pull/5770


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replace the CLI completions (located in `cli/contrib/completions` with cobra generated ones.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

