### PR TITLE
[27.x] update buildx to v0.20.1

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -43,7 +43,7 @@ DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_COMPOSE_REF ?= v2.32.4
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
-DOCKER_BUILDX_REF  ?= v0.20.0
+DOCKER_BUILDX_REF  ?= v0.20.1
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
- backport: https://github.com/docker/docker-ce-packaging/pull/1151
