### PR TITLE
[master] deb, rpm:  slight refactor / cleanup

### DIFF
--- a/deb/common/docker-ce-cli.bash-completion
+++ b/deb/common/docker-ce-cli.bash-completion
@@ -1,1 +1,0 @@
-cli/contrib/completion/bash/docker

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -69,9 +69,11 @@ override_dh_dwz:
 
 override_dh_auto_install:
 	# docker-ce-cli install
+	install -D -p -m 0755 cli/build/docker debian/docker-ce-cli/usr/bin/docker
+
+	# docker-ce-cli shell-completion
 	install -D -p -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -p -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
-	install -D -p -m 0755 cli/build/docker debian/docker-ce-cli/usr/bin/docker
 
 	# docker-ce install
 	install -D -p -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -26,7 +26,8 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 	# Build the CLI
-	cd /go/src/github.com/docker/cli && VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' GO_LINKMODE=dynamic ./scripts/build/binary && DISABLE_WARN_OUTSIDE_CONTAINER=1 LDFLAGS='' make manpages
+	cd /go/src/github.com/docker/cli \
+		&& make DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages
 
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -69,25 +69,25 @@ override_dh_dwz:
 
 override_dh_auto_install:
 	# docker-ce-cli install
-	install -D -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
-	install -D -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
-	install -D -m 0755 cli/build/docker debian/docker-ce-cli/usr/bin/docker
+	install -D -p -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
+	install -D -p -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
+	install -D -p -m 0755 cli/build/docker debian/docker-ce-cli/usr/bin/docker
 
 	# docker-ce install
-	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd
-	install -D -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/docker-proxy) debian/docker-ce/usr/bin/docker-proxy
-	install -D -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/libexec/docker/docker-init
+	install -D -p -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd
+	install -D -p -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/docker-proxy) debian/docker-ce/usr/bin/docker-proxy
+	install -D -p -m 0755 /usr/local/bin/docker-init debian/docker-ce/usr/libexec/docker/docker-init
 
 	# docker-buildx-plugin install
-	install -D -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx
+	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-buildx debian/docker-buildx-plugin/usr/libexec/docker/cli-plugins/docker-buildx
 
 	# docker-compose-plugin install
-	install -D -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
+	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
 
 	# docker-ce-rootless-extras install
-	install -D -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
-	install -D -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
-	install -D -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
+	install -D -p -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
+	install -D -p -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
+	install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
 	# TODO: how can we install vpnkit?
 
 override_dh_installinit:

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -72,6 +72,35 @@ override_dh_auto_install:
 	install -D -p -m 0755 cli/build/docker debian/docker-ce-cli/usr/bin/docker
 
 	# docker-ce-cli shell-completion
+	#
+	# We are manually installing bash completions instead of using the "dh_bash-completion"
+	# debhelper (see [1]); dh_bash-completion only supports bash, and none of the other shells,
+	# which meant that we had to install 2 out of 3 manually, which was confusing ("what about
+	# Bash?"). Given that locations to install these completion scripts are well-known, we
+	# can safely use the manual approach for installing  them.
+	#
+	# In future, can consider using "dh_shell_completions" (see [2]), which supports bash, zsh
+	# and fish. However, "dh_shell_completions" is still really premature, and not available
+	# in stable releases. So, currently, adding it as build-dependency, especially since
+	# these are well-known, may not be a good choice, but we can revisit that in future
+	# if things mature in this area.
+	#
+	# Observant readers may notice that we don't include PowerShell completion in
+	# this list (even though Cobra provides them, and PowerShell *can* be installed
+	# oon Linux). The short story is that there's no well-defined location, nor
+	# a well-defined approach for this.
+	#
+	# The PowerShell maintainers (see [3]) considering that no completion scripts
+	# are needed for anything following the PowerShell specifications, and for
+	# anything else, PowerShell is capable enough to use zsh and bash completions.
+	#
+	# All of the above taken into account; it's fuzzy enough to just leave it as
+	# an exercise for the user to decide what to do.
+	#
+	# [1]: https://manpages.debian.org/bookworm/bash-completion/dh_bash-completion.1.en.html
+	# [2]: https://manpages.debian.org/testing/dh-shell-completions/dh_shell_completions.1.en.html
+	# [3]: https://github.com/PowerShell/PowerShell/issues/17582
+	install -D -p -m 0644 cli/contrib/completion/bash/docker debian/docker-ce-cli/usr/share/bash-completion/completions/docker
 	install -D -p -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
 	install -D -p -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -48,7 +48,7 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
 pushd /go/src/github.com/docker/cli
-VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} GO_LINKMODE=dynamic ./scripts/build/binary && DISABLE_WARN_OUTSIDE_CONTAINER=1 make manpages # cli
+make DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
 popd
 
 %check

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -57,28 +57,22 @@ ver="$(cli/build/docker --version)"; \
 
 %install
 # install binary
-install -d ${RPM_BUILD_ROOT}%{_bindir}
-install -p -m 755 cli/build/docker ${RPM_BUILD_ROOT}%{_bindir}/docker
+install -D -p -m 755 cli/build/docker ${RPM_BUILD_ROOT}%{_bindir}/docker
 
 # add bash, zsh, and fish completions
-install -d ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions
-install -d ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions
-install -d ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d
-install -p -m 644 cli/contrib/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
-install -p -m 644 cli/contrib/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
-install -p -m 644 cli/contrib/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
+install -D -p -m 644 cli/contrib/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
+install -D -p -m 644 cli/contrib/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
+install -D -p -m 644 cli/contrib/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
 
 # install manpages
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man1
-install -p -m 644 cli/man/man1/*.1 ${RPM_BUILD_ROOT}%{_mandir}/man1
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man5
-install -p -m 644 cli/man/man5/*.5 ${RPM_BUILD_ROOT}%{_mandir}/man5
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man8
-install -p -m 644 cli/man/man8/*.8 ${RPM_BUILD_ROOT}%{_mandir}/man8
+# Note: we need to create destination dirs first (instead "install -D") due to wildcards used.
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man1 && install -p -m 644 cli/man/man1/*.1 ${RPM_BUILD_ROOT}%{_mandir}/man1
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man5 && install -p -m 644 cli/man/man5/*.5 ${RPM_BUILD_ROOT}%{_mandir}/man5
+install -d ${RPM_BUILD_ROOT}%{_mandir}/man8 && install -p -m 644 cli/man/man8/*.8 ${RPM_BUILD_ROOT}%{_mandir}/man8
 
 mkdir -p build-docs
 for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
-    cp "cli/$cli_file" "build-docs/$cli_file"
+    install -D -p -m 644 "cli/$cli_file" "build-docs/$cli_file"
 done
 
 # list files owned by the package here

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -82,8 +82,8 @@ install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/docker-proxy
 install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_libexecdir}/docker/docker-init
 
 # install systemd scripts
-install -D -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
-install -D -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
+install -D -p -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
+install -D -p -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
 # create the config directory
 mkdir -p ${RPM_BUILD_ROOT}/etc/docker


### PR DESCRIPTION
### deb, rpm: use "make dynbinary" instead of ./scripts/build/binary

The "make dynbinary" target calls ./scripts/build/binary with the
right options set, and does not use docker to build (so can be
run as part of our deb/rpm build scripts.

### rpm: use install -D where possible

The "-D" option creates parent directories if missing; we
can use it in most places, except for one where we're using
wildcards, as installing multiple files requires the target
directory to exist.

### rpm: consistently use "install -p" (--preserve-timestamps)

This unlikely makes a big difference, as some files may have timestamps
based on checkout date or being generated, but it doesn't hurt doing
either.

### deb: consistently use "install -p" (--preserve-timestamps)

This unlikely makes a big difference, as some files may have timestamps
based on checkout date or being generated, but it doesn't hurt doing
either.

### deb: stop using dh_bash-completion for bash completions

The dh_bash-completion debhelper provides an easy way to install the
shell-completion scripts for Bash. Unfortunately there is no stable
equivalent yet for the other shells (zsh, fish, powershell), which
resulted in two out of three shells requiring manual install.

Given that the installation path for Bash is [well-documented][1],
we can align Bash with the other shells to make this less confusing.

This patch makes that change, and adds a code-comment to outline
the reasoning (and possible future options) for future readers.

[1]: https://github.com/scop/bash-completion/blob/79fd051907328c8c26372691f68d627c1f0e3916/README.md

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

