### PR TITLE
rpm: remove Obsoletes for obsolete (selinux) packages

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -47,11 +47,6 @@ Conflicts: docker
 Conflicts: docker-io
 Conflicts: docker-ee
 
-# Obsolete packages
-Obsoletes: docker-ce-selinux
-Obsoletes: docker-engine-selinux
-Obsoletes: docker-engine
-
 %description
 Docker is a product for you to build, ship and run any application as a
 lightweight container.


### PR DESCRIPTION
- reverts https://github.com/docker/docker-ce-packaging/pull/17


Remove the obsoletes for `docker-ce-selinux`, `docker-engine-selinux`, and `docker-engine`.

These were obsoleted in 2017 through 94943b47520aa81bbe30fbc4eb927c79047ef6d2

> Mark docker-*-selinux pkgs as obsolete
>
> These are replaced by `container-selinux` on fedora-25 and centos-7.
> Marking these packages as obsolete makes the installation process a bit
> smoother, otherwise the user will have to manually uninstall the older
> packages to install the new one.
>
> Also makes fedora24 use container-selinux which is now supports labeling
> the `dockerd` binary correctly.

Both CentOS 6/7 and Fedora 25 are EOL now, and these packages have not been published for a long time. Time to remove them, also to reduce some noise during builds;

    RPM build warnings:
        line 51: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-ce-selinux
        line 52: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine-selinux
        line 53: It's not recommended to have unversioned Obsoletes: Obsoletes: docker-engine


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

