### PR TITLE
[TEMP] deb,rpm: use cobra generated completions with  alternative paths

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -27,7 +27,10 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 
 	# Build the CLI
-	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages
+	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages \
+		&& /go/src/github.com/docker/cli/build/docker completion bash > /go/src/github.com/docker/cli/contrib/completion/bash/docker \
+		&& /go/src/github.com/docker/cli/build/docker completion zsh > /go/src/github.com/docker/cli/contrib/completion/zsh/_docker \
+		&& /go/src/github.com/docker/cli/build/docker completion fish > /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish
 
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -27,10 +27,7 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 
 	# Build the CLI
-	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages \
-		&& /go/src/github.com/docker/cli/build/docker completion bash > /go/src/github.com/docker/cli/contrib/completion/bash/docker \
-		&& /go/src/github.com/docker/cli/build/docker completion zsh > /go/src/github.com/docker/cli/contrib/completion/zsh/_docker \
-		&& /go/src/github.com/docker/cli/build/docker completion fish > /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish
+	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages shell-completion
 
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \
@@ -102,9 +99,9 @@ override_dh_auto_install:
 	# [1]: https://manpages.debian.org/bookworm/bash-completion/dh_bash-completion.1.en.html
 	# [2]: https://manpages.debian.org/testing/dh-shell-completions/dh_shell_completions.1.en.html
 	# [3]: https://github.com/PowerShell/PowerShell/issues/17582
-	install -D -p -m 0644 cli/contrib/completion/bash/docker debian/docker-ce-cli/usr/share/bash-completion/completions/docker
-	install -D -p -m 0644 cli/contrib/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
-	install -D -p -m 0644 cli/contrib/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
+	install -D -p -m 0644 cli/build/completion/bash/docker debian/docker-ce-cli/usr/share/bash-completion/completions/docker
+	install -D -p -m 0644 cli/build/completion/fish/docker.fish debian/docker-ce-cli/usr/share/fish/vendor_completions.d/docker.fish
+	install -D -p -m 0644 cli/build/completion/zsh/_docker debian/docker-ce-cli/usr/share/zsh/vendor-completions/_docker
 
 	# docker-ce install
 	install -D -p -m 0755 $(shell readlink -e engine/bundles/dynbinary-daemon/dockerd) debian/docker-ce/usr/bin/dockerd

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -47,10 +47,7 @@ depending on a particular stack or provider.
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
-make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
-/go/src/github.com/docker/cli/build/docker completion bash > /go/src/github.com/docker/cli/contrib/completion/bash/docker
-/go/src/github.com/docker/cli/build/docker completion zsh > /go/src/github.com/docker/cli/contrib/completion/zsh/_docker
-/go/src/github.com/docker/cli/build/docker completion fish > /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish
+make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages shell-completion
 
 %check
 ver="$(cli/build/docker --version)"; \
@@ -61,9 +58,9 @@ ver="$(cli/build/docker --version)"; \
 install -D -p -m 755 cli/build/docker ${RPM_BUILD_ROOT}%{_bindir}/docker
 
 # add bash, zsh, and fish completions
-install -D -p -m 644 cli/contrib/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
-install -D -p -m 644 cli/contrib/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
-install -D -p -m 644 cli/contrib/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
+install -D -p -m 644 cli/build/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadir}/bash-completion/completions/docker
+install -D -p -m 644 cli/build/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
+install -D -p -m 644 cli/build/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
 
 # install manpages
 # Note: we need to create destination dirs first (instead "install -D") due to wildcards used.

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -48,6 +48,9 @@ mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
 make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
+/go/src/github.com/docker/cli/build/docker completion bash > /go/src/github.com/docker/cli/contrib/completion/bash/docker
+/go/src/github.com/docker/cli/build/docker completion zsh > /go/src/github.com/docker/cli/contrib/completion/zsh/_docker
+/go/src/github.com/docker/cli/build/docker completion fish > /go/src/github.com/docker/cli/contrib/completion/fish/docker.fish
 
 %check
 ver="$(cli/build/docker --version)"; \


### PR DESCRIPTION
-  rebase of https://github.com/docker/docker-ce-packaging/pull/1150, on top of https://github.com/docker/docker-ce-packaging/pull/1154
- with alternative intermediate path, but needs to be updated after https://github.com/docker/cli/pull/5770


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

