### PR TITLE
[master]  deb, rpm: reduce uses of "cd", "popd", "pushd"

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -25,9 +25,9 @@ override_dh_auto_build:
 	cd engine && DOCKER_GITCOMMIT=$(ENGINE_GITCOMMIT) PRODUCT=docker ./hack/make.sh dynbinary
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
+
 	# Build the CLI
-	cd /go/src/github.com/docker/cli \
-		&& make DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages
+	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages
 
 	# Build buildx plugin
 	cd /go/src/github.com/docker/buildx \
@@ -42,8 +42,7 @@ override_dh_auto_build:
 				./cmd/buildx
 
 	# Build the compose plugin
-	cd /go/src/github.com/docker/compose \
-	&& make VERSION=$(COMPOSE_VERSION) DESTDIR=/usr/libexec/docker/cli-plugins build
+	make -C /go/src/github.com/docker/compose VERSION=$(COMPOSE_VERSION) DESTDIR=/usr/libexec/docker/cli-plugins build
 
 override_dh_auto_test:
 	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \

--- a/rpm/SPECS/docker-buildx-plugin.spec
+++ b/rpm/SPECS/docker-buildx-plugin.spec
@@ -37,9 +37,7 @@ ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-buildx docker-c
 	test "$ver" = "%{_buildx_version}" && echo "PASS: docker-buildx version OK" || (echo "FAIL: docker-buildx version ($ver) did not match" && exit 1)
 
 %install
-pushd ${RPM_BUILD_DIR}/src/buildx
-install -D -p -m 0755 bin/docker-buildx ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-buildx
-popd
+install -D -p -m 0755 ${RPM_BUILD_DIR}/src/buildx/bin/docker-buildx ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-buildx
 
 %files
 %{_libexecdir}/docker/cli-plugins/docker-buildx

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -47,9 +47,7 @@ depending on a particular stack or provider.
 mkdir -p /go/src/github.com/docker
 rm -f /go/src/github.com/docker/cli
 ln -snf ${RPM_BUILD_DIR}/src/cli /go/src/github.com/docker/cli
-pushd /go/src/github.com/docker/cli
-make DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
-popd
+make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=%{_origversion} GITCOMMIT=%{_gitcommit_cli} dynbinary manpages
 
 %check
 ver="$(cli/build/docker --version)"; \

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -28,18 +28,14 @@ Docker Compose V1 ('docker-compose').
 %setup -q -c -n src -a 0
 
 %build
-pushd ${RPM_BUILD_DIR}/src/compose
-    make VERSION=%{_compose_version} DESTDIR=./bin build
-popd
+make -C ${RPM_BUILD_DIR}/src/compose VERSION=%{_compose_version} DESTDIR=./bin build
 
 %check
 ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-compose docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
     test "$ver" = "%{_compose_version}" && echo "PASS: docker-compose version OK" || (echo "FAIL: docker-compose version ($ver) did not match" && exit 1)
 
 %install
-pushd ${RPM_BUILD_DIR}/src/compose
-    install -D -p -m 0755 bin/docker-compose ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-compose
-popd
+install -D -p -m 0755 ${RPM_BUILD_DIR}/src/compose/bin/docker-compose ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-compose
 
 for f in LICENSE MAINTAINERS NOTICE README.md; do
     install -D -p -m 0644 "${RPM_BUILD_DIR}/src/compose/$f" "docker-compose-plugin-docs/$f"


### PR DESCRIPTION
For make commands, we can just pass the directory through "-C", and for "install" we can pass the full path of the source.

There's some remaining uses for targets that build through a script or using "go build", which may still require changing.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

