### PR TITLE
[master] deb, rpm: make kmod "suggests" instead of "recommends"

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -31,12 +31,12 @@ Recommends: apparmor,
             ca-certificates,
             docker-ce-rootless-extras,
             git,
-            kmod,
             libltdl7,
             pigz,
             procps,
             xz-utils
-Suggests: cgroupfs-mount | cgroup-lite
+Suggests: cgroupfs-mount | cgroup-lite,
+            kmod,
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker.io

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -14,7 +14,7 @@ Packager: Docker <support@docker.com>
 
 Requires: /usr/sbin/groupadd
 # Provides modprobe, which we use to load br_netfilter if not loaded.
-Recommends: kmod
+Suggests: kmod
 Requires: docker-ce-cli
 Recommends: docker-ce-rootless-extras
 Requires: container-selinux


### PR DESCRIPTION
- updates, fixes https://github.com/docker/docker-ce-packaging/pull/1118#issuecomment-2611224201



This was added in deed8d9df8cd90139229748021efcc006900aba5, as the docker engine depended on modprobe to enable br_netfilter. Docker Engine no longer requires this since [moby/moby@4b8c720], and [moby/moby@8a8ab0d] (docker\ engine v27.4.1), so we can reduce this to a "suggests"

[moby/moby@4b8c720]: https://github.com/moby/moby/commit/4b8c72060d1089626e4ac9f5e0624e0cb567d4bc
[moby/moby@8a8ab0d]: https://github.com/moby/moby/commit/8a8ab0d5670dd4f499422120ea4585d07ab464c0


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

