### PR TITLE
[master] deb,rpm: include dockerd man-page in docker-ce package

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -40,7 +40,8 @@ Suggests: cgroupfs-mount | cgroup-lite
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker.io
-Replaces: docker-engine
+Replaces: docker-engine,
+          docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a
  lightweight container

--- a/deb/common/docker-ce.manpages
+++ b/deb/common/docker-ce.manpages
@@ -1,0 +1,1 @@
+engine/man/man*/*

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -26,6 +26,9 @@ override_dh_auto_build:
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
 	cd engine && TMP_GOPATH="/go" hack/dockerfile/install/install.sh rootlesskit dynamic
 
+	#  build  man-pages
+	make -C engine/man
+
 	# Build the CLI
 	make -C /go/src/github.com/docker/cli DISABLE_WARN_OUTSIDE_CONTAINER=1 VERSION=$(VERSION) GITCOMMIT=$(CLI_GITCOMMIT) LDFLAGS='' dynbinary manpages shell-completion
 

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -62,11 +62,14 @@ install -D -p -m 644 cli/build/completion/bash/docker ${RPM_BUILD_ROOT}%{_datadi
 install -D -p -m 644 cli/build/completion/zsh/_docker ${RPM_BUILD_ROOT}%{_datadir}/zsh/vendor-completions/_docker
 install -D -p -m 644 cli/build/completion/fish/docker.fish ${RPM_BUILD_ROOT}%{_datadir}/fish/vendor_completions.d/docker.fish
 
-# install manpages
-# Note: we need to create destination dirs first (instead "install -D") due to wildcards used.
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man1 && install -p -m 644 cli/man/man1/*.1 ${RPM_BUILD_ROOT}%{_mandir}/man1
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man5 && install -p -m 644 cli/man/man5/*.5 ${RPM_BUILD_ROOT}%{_mandir}/man5
-install -d ${RPM_BUILD_ROOT}%{_mandir}/man8 && install -p -m 644 cli/man/man8/*.8 ${RPM_BUILD_ROOT}%{_mandir}/man8
+# install man-pages
+for sec in $(seq 1 9); do
+    if [ -d "cli/man/man${sec}" ]; then
+        # Note: we need to create destination dirs first (instead "install -D") due to wildcards used.
+        install -d ${RPM_BUILD_ROOT}%{_mandir}/man${sec} && \
+        install -p -m 644 cli/man/man${sec}/*.${sec} ${RPM_BUILD_ROOT}%{_mandir}/man${sec};
+    fi
+done
 
 mkdir -p build-docs
 for cli_file in LICENSE MAINTAINERS NOTICE README.md; do
@@ -80,10 +83,7 @@ done
 %{_datadir}/bash-completion/completions/docker
 %{_datadir}/zsh/vendor-completions/_docker
 %{_datadir}/fish/vendor_completions.d/docker.fish
-%doc
-%{_mandir}/man1/*
-%{_mandir}/man5/*
-%{_mandir}/man8/*
+%{_mandir}/man*/*
 
 
 %post

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -72,6 +72,9 @@ TMP_GOPATH="/go" hack/dockerfile/install/install.sh tini
 VERSION=%{_origversion} PRODUCT=docker hack/make.sh dynbinary
 popd
 
+#  build  man-pages
+make -C ${RPM_BUILD_DIR}/src/engine/man
+
 %check
 ver="$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
     test "$ver" = "Docker version %{_origversion}, build %{_gitcommit_engine}" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($ver) did not match" && exit 1)
@@ -85,6 +88,9 @@ install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_libexecdir}
 install -D -p -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
 install -D -p -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
+# install manpages
+make -C ${RPM_BUILD_DIR}/src/engine/man DESTDIR=${RPM_BUILD_ROOT} prefix=%{_mandir} install
+
 # create the config directory
 mkdir -p ${RPM_BUILD_ROOT}/etc/docker
 
@@ -94,6 +100,7 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/docker
 %{_libexecdir}/docker/docker-init
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
+%{_mandir}/man*/*
 %dir /etc/docker
 
 %post


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48298
- relates to https://github.com/docker/cli/pull/5773
- relates to  https://github.com/docker/runtime-team/issues/161



### rpm: adjust spec to account for varying list of man-page sections

The CLI currently builds man-pages for sections 1, 5, and 8, but this
list may change; for example, the dockerd man-page is currently built
from the CLI repository but intended to be removed.

This patch changes the code to check all (1..9) secions, and install the
man-pages found in them.

This patch also updates the %doc and %files section; from the Fedora packaging
guide (see [1]);

> The %files section holds a list of all the files that RPM should install
> from the package. **This list should be exhaustive**, so that the RPM system
> knows exactly what your package installs. There are some options, though,
> to name all the files within a directory to help with packages containing
> hundreds of files.
> (...)
> In addition to naming each file on a line, you can use glob-style wildcards.

But also worth noting that it's NOT needed to mark manpages as %doc, see [2];

> Note also that files installed in %{_mandir} are automatically marked by RPM
> as documentation. Thus it is not necessary to use %doc.

So this patch:

- uses wildcards to enumerate all manpages in all sections
- removes the %doc for manpages, as this is automatic.


[1]: https://jfearn.fedorapeople.org/en-US/RPM/4/html/RPM_Guide/ch09s05.html
[2]: https://docs.fedoraproject.org/en-US/packaging-guidelines/#_manpages

###  deb,rpm: include dockerd man-page in docker-ce package

When splitting the docker CLI from the moby/moby repository, the dockerd
documentation and man-pages were moved to the CLI repository. This was a
bit of a bad choice, as now the documentation and code lived in separate
repositories, but when the CLI and dockerd packages were split, the man
page for dockerd ended up in the CLI package.

Starting with [moby@d6e9b5f], the dockerd man-page has been reintegrated
into the moby repository, which means that we can build the man-page
from that repository, and remove it from the CLI repository.

This patch updates the packing to do so:

Before this patch;

    dpkg-deb -c docker-ce_0.0.0~20250124134141.b8879a4-1~ubuntu.24.04~noble_arm64.deb | grep -E '^-'
    -rw-r--r-- root/root       642 2025-01-24 14:29 ./etc/default/docker
    -rwxr-xr-x root/root      2946 2025-01-24 14:29 ./etc/init.d/docker
    -rwxr-xr-x root/root   2741336 2025-01-24 19:54 ./usr/bin/docker-proxy
    -rw-r--r-- root/root      1727 2025-01-24 14:29 ./usr/lib/systemd/system/docker.service
    -rw-r--r-- root/root       295 2025-01-24 14:29 ./usr/lib/systemd/system/docker.socket
    -rwxr-xr-x root/root    604336 2025-01-24 19:54 ./usr/libexec/docker/docker-init
    -rw-r--r-- root/root      2248 2025-01-24 14:29 ./usr/share/doc/docker-ce/README.md
    -rw-r--r-- root/root       168 2025-01-24 19:54 ./usr/share/doc/docker-ce/changelog.Debian.gz

    rpm -qpl ./docker-ce-0.0.0~20250124134141.b8879a4-0.fc41.aarch64.rpm
    /etc/docker
    /usr/bin/docker-proxy
    /usr/bin/dockerd
    /usr/lib/systemd/system/docker.service
    /usr/lib/systemd/system/docker.socket
    /usr/libexec/docker/docker-init

With this patch:

    dpkg-deb -c docker-ce_0.0.0~20250124134141.b8879a4-1~ubuntu.24.04~noble_arm64.deb | grep -E '^-'
    -rw-r--r-- root/root       642 2025-01-24 14:29 ./etc/default/docker
    -rwxr-xr-x root/root      2946 2025-01-24 14:29 ./etc/init.d/docker
    -rwxr-xr-x root/root   2741336 2025-01-24 20:55 ./usr/bin/docker-proxy
    -rwxr-xr-x root/root  79458592 2025-01-24 20:55 ./usr/bin/dockerd
    -rw-r--r-- root/root      1727 2025-01-24 14:29 ./usr/lib/systemd/system/docker.service
    -rw-r--r-- root/root       295 2025-01-24 14:29 ./usr/lib/systemd/system/docker.socket
    -rwxr-xr-x root/root    604336 2025-01-24 20:55 ./usr/libexec/docker/docker-init
    -rw-r--r-- root/root      2248 2025-01-24 14:29 ./usr/share/doc/docker-ce/README.md
    -rw-r--r-- root/root       166 2025-01-24 20:55 ./usr/share/doc/docker-ce/changelog.Debian.gz
    -rw-r--r-- root/root      6561 2025-01-24 20:55 ./usr/share/man/man8/dockerd.8.gz

    rpm -qpl ./docker-ce-0.0.0~20250124134141.b8879a4-0.fc41.aarch64.rpm
    /etc/docker
    /usr/bin/docker-proxy
    /usr/bin/dockerd
    /usr/lib/systemd/system/docker.service
    /usr/lib/systemd/system/docker.socket
    /usr/libexec/docker/docker-init
    /usr/share/man/man8/dockerd.8.gz


Given that the dockerd man-page was previously packaged as part of docker-ce-cli,
we need to add a "Replaces:" condition to the package, to prevent dpkg from
detecting it as a conflict when an older version of the docker-ce-cli package
was installed that contains the manpage;

    Unpacking docker-ce (5:0.0.0~20250124134141.b8879a4-1~raspbian.12~bookworm) ...
    dpkg: error processing archive ./deb/debbuild/raspbian-bookworm/docker-ce_0.0.0~20250124134141.b8879a4-1~raspbian.12~bookworm_armhf.deb (--install):
    trying to overwrite '/usr/share/man/man8/dockerd.8.gz', which is also in package docker-ce-cli 5:0.0.0~20250124134141.b8879a4-1~raspbian.12~bookworm

From the [Debian manual][4]

> 7.6.1. Overwriting files in other packages
>
> It is usually an error for a package to contain files which are on the
> system in another package. However, if the overwriting package declares
> that it Replaces the one containing the file being overwritten, then dpkg
> will replace the file from the old package with that from the new. The
> file will no longer be listed as “owned” by the old package and will be
> taken over by the new package. 

[4]: https://www.debian.org/doc/debian-policy/ch-relationships.html
[moby@d6e9b5f]: https://github.com/moby/moby/commit/d6e9b5fe304294d7b1ea52234dca6933214e78df


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

