### PR TITLE
Bump compose v2.33.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -40,7 +40,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 # DOCKER_COMPOSE_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_COMPOSE_REPO.
-DOCKER_COMPOSE_REF ?= v2.32.4
+DOCKER_COMPOSE_REF ?= v2.33.0
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.20.1

--- a/deb/common/control
+++ b/deb/common/control
@@ -104,6 +104,7 @@ Homepage: https://github.com/docker/buildx
 Package: docker-compose-plugin
 Priority: optional
 Architecture: linux-any
+Recommends: docker-buildx-plugin
 Enhances: docker-ce-cli
 Description: Docker Compose (V2) plugin for the Docker CLI.
  .

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -13,6 +13,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Enhances: docker-ce-cli
+Recommends: docker-buildx-plugin
 
 BuildRequires: bash
 


### PR DESCRIPTION
**- What I did**

Bump compose v2.33.0
Declare buildx as a recommended dependency as v2.33.0 introduces support for delegating build command to bake.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

Compose v2.33.0

**- A picture of a cute animal (not mandatory but encouraged)**

