### PR TITLE
all: manage docker group with systemd-sysusers

### DIFF
--- a/deb/common/docker-ce.postinst
+++ b/deb/common/docker-ce.postinst
@@ -2,19 +2,12 @@
 set -e
 
 case "$1" in
-	configure)
-		if [ -z "$2" ]; then
-			if ! getent group docker > /dev/null; then
-				groupadd --system docker
-			fi
-		fi
-		;;
-	abort-*)
-		# How'd we get here??
-		exit 1
-		;;
-	*)
-		;;
+configure) ;;
+abort-*)
+	# How'd we get here??
+	exit 1
+	;;
+*) ;;
 esac
 
 #DEBHELPER#

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -123,6 +123,12 @@ override_dh_auto_install:
 	install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
 	# TODO: how can we install vpnkit?
 
+	# install systemd sysusers config
+	mkdir -p debian/docker-ce/etc/sysusers.d
+	echo "g docker -" >> debian/docker-ce/etc/sysusers.d/docker.conf
+	chmod 0644 debian/docker-ce/etc/sysusers.d/docker.conf
+	# install -D -p -m 0644 engine/contrib/systemd-sysusers/docker.conf debian/docker-ce/etc/sysusers.d/docker.conf
+
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"
 	dh_installinit --name=docker

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -84,6 +84,12 @@ install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/dockerd) ${R
 install -D -p -m 0755 $(readlink -f engine/bundles/dynbinary-daemon/docker-proxy) ${RPM_BUILD_ROOT}%{_bindir}/docker-proxy
 install -D -p -m 0755 /usr/local/bin/docker-init ${RPM_BUILD_ROOT}%{_libexecdir}/docker/docker-init
 
+# install systemd sysusers config
+mkdir -p ${RPM_BUILD_ROOT}%{_sysusersdir}
+echo "g docker -" >> ${RPM_BUILD_ROOT}%{_sysusersdir}/docker.conf
+chmod 0644 ${RPM_BUILD_ROOT}%{_sysusersdir}/docker.conf
+# install -D -p -m 0644 engine/contrib/systemd-sysusers/docker.conf ${RPM_BUILD_ROOT}%{_sysusersdir}/docker.conf
+
 # install systemd scripts
 install -D -p -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROOT}%{_unitdir}/docker.service
 install -D -p -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
@@ -100,14 +106,12 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/docker
 %{_libexecdir}/docker/docker-init
 %{_unitdir}/docker.service
 %{_unitdir}/docker.socket
+%{_sysusersdir}/docker.conf
 %{_mandir}/man*/*
 %dir /etc/docker
 
 %post
 %systemd_post docker.service
-if ! getent group docker > /dev/null; then
-    groupadd --system docker
-fi
 
 %preun
 %systemd_preun docker.service docker.socket


### PR DESCRIPTION
Closes #1186 

Switches away from the groupadd postinstall commands to managing the docker group with sysusers.

This is a declarative way to create and manage users, better suited for the atomic distros such as Silverblue.

---

This is certainly not ready to merge just yet - there's a dependency on https://github.com/moby/moby/pull/49813.  But hopefully it makes sense as to how this will work.