### PR TITLE
all: add rules for docker-model-plugin packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean-src:
 	$(RM) -r src
 
 .PHONY: src
-src: src/github.com/docker/cli src/github.com/docker/docker src/github.com/docker/buildx src/github.com/docker/compose ## clone source
+src: src/github.com/docker/cli src/github.com/docker/docker src/github.com/docker/buildx src/github.com/docker/compose src/github.com/docker/model-cli ## clone source
 
 ifdef CLI_DIR
 src/github.com/docker/cli:
@@ -45,6 +45,10 @@ src/github.com/docker/compose:
 	git init $@
 	git -C $@ remote add origin "$(DOCKER_COMPOSE_REPO)"
 
+src/github.com/docker/model-cli:
+	git init $@
+	git -C $@ remote add origin "$(DOCKER_MODEL_REPO)"
+
 .PHONY: checkout-cli
 checkout-cli: src/github.com/docker/cli
 	./scripts/checkout.sh src/github.com/docker/cli "$(DOCKER_CLI_REF)"
@@ -61,8 +65,12 @@ checkout-buildx: src/github.com/docker/buildx
 checkout-compose: src/github.com/docker/compose
 	./scripts/checkout.sh src/github.com/docker/compose "$(DOCKER_COMPOSE_REF)"
 
+.PHONY: checkout-model
+checkout-model: src/github.com/docker/model-cli
+	./scripts/checkout.sh src/github.com/docker/model-cli "$(DOCKER_MODEL_REF)"
+
 .PHONY: checkout
-checkout: checkout-cli checkout-docker checkout-buildx checkout-compose ## checkout source at the given reference(s)
+checkout: checkout-cli checkout-docker checkout-buildx checkout-compose checkout-model ## checkout source at the given reference(s)
 
 .PHONY: clean
 clean: clean-src ## remove build artifacts

--- a/common.mk
+++ b/common.mk
@@ -28,6 +28,7 @@ DOCKER_CLI_REPO     ?= https://github.com/docker/cli.git
 DOCKER_ENGINE_REPO  ?= https://github.com/docker/docker.git
 DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
+DOCKER_MODEL_REPO   ?= https://github.com/docker/model-cli.git
 
 # REF can be used to specify the same branch or tag to use for *both* the CLI
 # and Engine source code. This can be useful if both the CLI and Engine have a
@@ -44,6 +45,9 @@ DOCKER_COMPOSE_REF ?= v2.35.1
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.23.0
+# DOCKER_MODEL_REF is the version of model to package. It is usually a tag,
+# but can be a valid git reference in DOCKER_MODEL_REPO.
+DOCKER_MODEL_REF   ?= v0.1.23
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com

--- a/deb/Makefile
+++ b/deb/Makefile
@@ -7,6 +7,7 @@ EPOCH?=5
 GEN_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 GEN_BUILDX_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/buildx) "$(DOCKER_BUILDX_REF)")
 GEN_COMPOSE_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
+GEN_MODEL_DEB_VER=$(shell ./gen-deb-ver $(realpath $(CURDIR)/../src/github.com/docker/model-cli) "$(DOCKER_MODEL_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
@@ -46,6 +47,8 @@ RUN?=docker run --rm \
 	-e BUILDX_GITCOMMIT=$(BUILDX_GITCOMMIT) \
 	-e COMPOSE_VERSION=$(DOCKER_COMPOSE_REF) \
 	-e COMPOSE_DEB_VERSION=$(word 1, $(GEN_COMPOSE_DEB_VER)) \
+	-e MODEL_VERSION=$(DOCKER_MODEL_REF) \
+	-e MODEL_DEB_VERSION=$(word 1, $(GEN_MODEL_DEB_VER)) \
 	-v $(CURDIR)/debbuild/$@:/build \
 	$(RUN_FLAGS) \
 	debbuild-$@/$(ARCH)
@@ -88,7 +91,7 @@ $(DISTROS): sources
 	$(CHOWN) -R $(shell id -u):$(shell id -g) "debbuild/$@"
 
 .PHONY: sources
-sources: sources/cli.tgz sources/engine.tgz sources/buildx.tgz sources/compose.tgz
+sources: sources/cli.tgz sources/engine.tgz sources/buildx.tgz sources/compose.tgz sources/model.tgz
 
 sources/engine.tgz:
 	mkdir -p $(@D)
@@ -121,6 +124,14 @@ sources/compose.tgz:
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/compose.tgz --exclude .git compose
+
+sources/model.tgz:
+	mkdir -p $(@D)
+	docker run --rm -w /v \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/model-cli):/model \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/model.tgz --exclude .git model
 
 # See ARCHES in common.mk. Could not figure out how to match both distro and arch.
 BUNDLES:=$(addsuffix .tar.gz,$(addprefix debbuild/bundles-ce-%-,$(ARCHES)))

--- a/deb/build-deb
+++ b/deb/build-deb
@@ -11,6 +11,8 @@ mkdir -p /root/build-deb/buildx
 tar -C /root/build-deb -xzf /sources/buildx.tgz
 mkdir -p /root/build-deb/compose
 tar -C /root/build-deb -xzf /sources/compose.tgz
+mkdir -p /root/build-deb/model
+tar -C /root/build-deb -xzf /sources/model.tgz
 
 # link them to their canonical path
 mkdir -p /go/src/github.com/docker
@@ -18,6 +20,7 @@ ln -snf /root/build-deb/engine /go/src/github.com/docker/docker
 ln -snf /root/build-deb/cli /go/src/github.com/docker/cli
 ln -snf /root/build-deb/buildx /go/src/github.com/docker/buildx
 ln -snf /root/build-deb/compose /go/src/github.com/docker/compose
+ln -snf /root/build-deb/model /go/src/github.com/docker/model-cli
 
 EPOCH="${EPOCH:-}"
 EPOCH_SEP=""

--- a/deb/common/control
+++ b/deb/common/control
@@ -58,6 +58,7 @@ Architecture: linux-any
 Depends: ${shlibs:Depends}
 Recommends: docker-buildx-plugin,
             docker-compose-plugin
+Suggests: docker-model-plugin
 Conflicts: docker (<< 1.5~),
            docker-engine,
            docker.io
@@ -113,3 +114,12 @@ Description: Docker Compose (V2) plugin for the Docker CLI.
  The binary can also be run standalone as a direct replacement for
  Docker Compose V1 ('docker-compose').
 Homepage: https://github.com/docker/compose
+
+Package: docker-model-plugin
+Priority: optional
+Architecture: linux-any
+Enhances: docker-ce-cli
+Description: Docker Model Runner plugin for the Docker CLI.
+ .
+ This plugin provides the 'docker model' subcommand.
+Homepage: https://docs.docker.com/model-runner/

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -47,6 +47,10 @@ override_dh_auto_build:
 	# Build the compose plugin
 	make -C /go/src/github.com/docker/compose VERSION=$(COMPOSE_VERSION) DESTDIR=/usr/libexec/docker/cli-plugins build
 
+	# Build the model plugin
+	GO111MODULE=on make -C /go/src/github.com/docker/model-cli VERSION=$(MODEL_VERSION) ce-release \
+	&& mv /go/src/github.com/docker/model-cli/dist/docker-model /usr/libexec/docker/cli-plugins/docker-model
+
 override_dh_auto_test:
 	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \
 		test "$$ver" = "Docker version $(VERSION), build $(ENGINE_GITCOMMIT)" && echo "PASS: daemon version OK" || (echo "FAIL: daemon version ($$ver) did not match" && exit 1)
@@ -59,6 +63,9 @@ override_dh_auto_test:
 
 	ver="$$(/usr/libexec/docker/cli-plugins/docker-compose docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
 		test "$$ver" = "$(COMPOSE_VERSION)" && echo "PASS: docker-compose version OK" || (echo "FAIL: docker-compose version ($$ver) did not match" && exit 1)
+
+	ver="$$(/usr/libexec/docker/cli-plugins/docker-model docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $$1 == "Version" { print $$2 }')"; \
+		test "$$ver" = "$(MODEL_VERSION)" && echo "PASS: docker-model version OK" || (echo "FAIL: docker-model version ($$ver) did not match" && exit 1)
 
 override_dh_strip:
 	# Go has lots of problems with stripping, so just don't
@@ -117,6 +124,9 @@ override_dh_auto_install:
 	# docker-compose-plugin install
 	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-compose debian/docker-compose-plugin/usr/libexec/docker/cli-plugins/docker-compose
 
+	# docker-model-plugin install
+	install -D -p -m 0755 /usr/libexec/docker/cli-plugins/docker-model debian/docker-model-plugin/usr/libexec/docker/cli-plugins/docker-model
+
 	# docker-ce-rootless-extras install
 	install -D -p -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
 	install -D -p -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
@@ -147,6 +157,10 @@ override_dh_gencontrol:
 	# Use separate version for the compose-plugin package, then generate the other control files as usual
 	# TODO override "Source" field in control as well (to point to compose, as it doesn't match the package name)
 	dh_gencontrol -pdocker-compose-plugin -- -v$${COMPOSE_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}~$${SUITE}
+
+	# Use separate version for the model-plugin package, then generate the other control files as usual
+	# TODO override "Source" field in control as well (to point to model, as it doesn't match the package name)
+	dh_gencontrol -pdocker-model-plugin -- -v$${MODEL_DEB_VERSION#v}-$${PKG_REVISION}~$${DISTRO}.$${VERSION_ID}~$${SUITE}
 
 	dh_gencontrol --remaining-packages
 

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -6,6 +6,7 @@ GO_IMAGE?=$(GO_BASE_IMAGE):$(GO_VERSION)-bookworm
 GEN_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/cli) "$(VERSION)")
 GEN_BUILDX_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/buildx) "$(DOCKER_BUILDX_REF)")
 GEN_COMPOSE_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/compose) "$(DOCKER_COMPOSE_REF)")
+GEN_MODEL_RPM_VER=$(shell ./gen-rpm-ver $(realpath $(CURDIR)/../src/github.com/docker/model-cli) "$(DOCKER_MODEL_REF)")
 CLI_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/cli) && git rev-parse --short HEAD)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 BUILDX_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/buildx) && git rev-parse --short HEAD)
@@ -27,7 +28,7 @@ BUILD?=DOCKER_BUILDKIT=1 \
 	.
 
 
-SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec docker-buildx-plugin.spec docker-compose-plugin.spec
+SPEC_FILES?=docker-ce.spec docker-ce-cli.spec docker-ce-rootless-extras.spec docker-buildx-plugin.spec docker-compose-plugin.spec docker-model-plugin.spec
 
 SPECS?=$(addprefix SPECS/, $(SPEC_FILES))
 RPMBUILD_FLAGS?=-ba\
@@ -41,6 +42,8 @@ RPMBUILD_FLAGS?=-ba\
 	--define '_buildx_gitcommit $(BUILDX_GITCOMMIT)' \
 	--define '_compose_rpm_version $(word 1,$(GEN_COMPOSE_RPM_VER))' \
 	--define '_compose_version $(word 4,$(GEN_COMPOSE_RPM_VER))' \
+	--define '_model_rpm_version $(word 1,$(GEN_MODEL_RPM_VER))' \
+	--define '_model_version $(word 4,$(GEN_MODEL_RPM_VER))' \
 	$(RPMBUILD_EXTRA_FLAGS) \
 	$(SPECS)
 
@@ -99,7 +102,7 @@ $(DISTROS): sources
 	$(CHOWN) -R $(shell id -u):$(shell id -g) "rpmbuild/$@"
 
 .PHONY: sources
-sources: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/buildx.tgz rpmbuild/SOURCES/compose.tgz
+sources: rpmbuild/SOURCES/engine.tgz rpmbuild/SOURCES/cli.tgz rpmbuild/SOURCES/buildx.tgz rpmbuild/SOURCES/compose.tgz rpmbuild/SOURCES/model.tgz
 
 rpmbuild/SOURCES/engine.tgz:
 	mkdir -p $(@D)
@@ -132,6 +135,14 @@ rpmbuild/SOURCES/compose.tgz:
 		-v $(CURDIR)/$(@D):/v \
 		alpine \
 		tar -C / -c -z -f /v/compose.tgz --exclude .git compose
+
+rpmbuild/SOURCES/model.tgz:
+	mkdir -p $(@D)
+	docker run --rm -w /v \
+		-v $(realpath $(CURDIR)/../src/github.com/docker/model-cli):/model \
+		-v $(CURDIR)/$(@D):/v \
+		alpine \
+		tar -C / -c -z -f /v/model.tgz --exclude .git model
 
 # See ARCHES in common.mk. Could not figure out how to match both distro and arch.
 BUNDLES:=$(addsuffix .tar.gz,$(addprefix rpmbuild/bundles-ce-%-,$(ARCHES)))

--- a/rpm/SPECS/docker-ce-cli.spec
+++ b/rpm/SPECS/docker-ce-cli.spec
@@ -19,6 +19,8 @@ Requires: /usr/sbin/groupadd
 Recommends: docker-buildx-plugin
 Recommends: docker-compose-plugin
 
+Suggests: docker-model-plugin
+
 BuildRequires: make
 BuildRequires: libtool-ltdl-devel
 BuildRequires: git

--- a/rpm/SPECS/docker-model-plugin.spec
+++ b/rpm/SPECS/docker-model-plugin.spec
@@ -1,0 +1,52 @@
+%global debug_package %{nil}
+
+Name: docker-model-plugin
+Version: %{_model_rpm_version}
+Release: %{_release}%{?dist}
+Epoch: 0
+Source0: model.tgz
+Summary: Docker Model Runner plugin for the Docker CLI
+Group: Tools/Docker
+License: Apache-2.0
+URL: https://docs.docker.com/model-runner/
+Vendor: Docker
+Packager: Docker <support@docker.com>
+
+Enhances: docker-ce-cli
+
+BuildRequires: bash
+
+%description
+Docker Model Runner plugin for the Docker CLI.
+
+This plugin provides the 'docker model' subcommand.
+
+%prep
+%setup -q -c -n src -a 0
+
+%build
+GO111MODULE=on make -C ${RPM_BUILD_DIR}/src/model VERSION=%{_model_version} ce-release
+
+%check
+ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-model docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
+    test "$ver" = "%{_model_version}" && echo "PASS: docker-model version OK" || (echo "FAIL: docker-model version ($ver) did not match" && exit 1)
+
+%install
+install -D -p -m 0755 ${RPM_BUILD_DIR}/src/model/dist/docker-model ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-model
+
+for f in LICENSE; do
+    install -D -p -m 0644 "${RPM_BUILD_DIR}/src/model/$f" "docker-model-plugin-docs/$f"
+done
+
+%files
+%doc docker-model-plugin-docs/*
+%license docker-model-plugin-docs/LICENSE
+%{_libexecdir}/docker/cli-plugins/docker-model
+
+%post
+
+%preun
+
+%postun
+
+%changelog

--- a/verify
+++ b/verify
@@ -29,6 +29,7 @@ function verify_binaries() {
 	docker --version
 	docker buildx version
 	docker compose version
+	docker model version
 	dockerd --version
 	docker-proxy --version
 	containerd --version


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I added a `docker-model-plugin` package in support of [Docker Model Runner](https://docs.docker.com/model-runner/)'s upcoming support for Docker CE.

**- How I did it**

I tried to emulate the structure of the `docker-buildx-plugin` and `docker-compose-plugin` builds / specs (primarily compose).  One small ugly bit is that the source repo is called `model-cli`, and Go requires it retain that name, so I've had to use a `src/github.com/docker/model-cli` path for the code, but for all the variables and specs I've omitted the `-cli` suffix and just used `model`/`MODEL` nomenclature.

**- How to verify it**

The package should build successfully on all supported target distros.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Add `docker-model-plugin` package to enable Docker Model Runner support in Docker CE
```

**- A picture of a cute animal (not mandatory but encouraged)**

