### PR TITLE
deb: add missing pre-depends for init-system-helpers

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -23,6 +23,7 @@ Vcs-Git: git://github.com/docker/docker.git
 
 Package: docker-ce
 Architecture: linux-any
+Pre-Depends: init-system-helpers (>= 1.54~)
 Depends: containerd.io (>= 1.6.24),
          docker-ce-cli,
          iptables,


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/issues/1197

Before this patch, lintian would complain about missing pre-depends:

    lintian ./*.deb
    ...
    W: docker-ce: skip-systemd-native-flag-missing-pre-depends (does not satisfy init-system-helpers:any) [postinst:51]
    W: docker-ce: skip-systemd-native-flag-missing-pre-depends (does not satisfy init-system-helpers:any) [prerm:10]

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

