### PR TITLE
rpm: fix install location for docker-ce man-pages

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -89,7 +89,7 @@ install -D -p -m 0644 engine/contrib/init/systemd/docker.service ${RPM_BUILD_ROO
 install -D -p -m 0644 engine/contrib/init/systemd/docker.socket ${RPM_BUILD_ROOT}%{_unitdir}/docker.socket
 
 # install manpages
-make -C ${RPM_BUILD_DIR}/src/engine/man DESTDIR=${RPM_BUILD_ROOT} prefix=%{_mandir} install
+make -C ${RPM_BUILD_DIR}/src/engine/man DESTDIR=${RPM_BUILD_ROOT} mandir=%{_mandir} install
 
 # create the config directory
 mkdir -p ${RPM_BUILD_ROOT}/etc/docker


### PR DESCRIPTION
- fixes https://github.com/docker/docker-ce-packaging/issues/1176
- relates to https://github.com/docker/docker-ce-packaging/pull/1159


commit 3ded61e6d77efa4759c2f9cf820299f4b7a1a16d moved the man-pages for dockerd to the docker-ce package, but used the wrong path for installing them, which resulted in the man-pages being installed in a "man" subdirectory with.

Before this patch:

    make fedora-42
    rpm -ql ./rpm/rpmbuild/fedora-42/RPMS/aarch64/docker-ce-*.rpm | grep dockerd.8
    /usr/share/man/man/man8/dockerd.8.gz

After this patch:

    make fedora-42
    rpm -ql ./rpm/rpmbuild/fedora-42/RPMS/aarch64/docker-ce-*.rpm | grep dockerd.8
    /usr/share/man/man8/dockerd.8.gz

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix install location for RPM-based `docker-ce` man-pages
```



**- A picture of a cute animal (not mandatory but encouraged)**

