### PR TITLE
bump compose version to v2.36.2

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 # DOCKER_COMPOSE_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_COMPOSE_REPO.
-DOCKER_COMPOSE_REF ?= v2.36.1
+DOCKER_COMPOSE_REF ?= v2.36.2
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.24.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Bump Compose to the `v2.36.2` version

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Update Compose to [v2.36.2](https://github.com/docker/compose/releases/tag/v2.36.2)
```


**- A picture of a cute animal (not mandatory but encouraged)**

