### PR TITLE
Add `-w` to buildx ldflags

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -40,7 +40,7 @@ override_dh_auto_build:
 			go build \
 				-mod=vendor \
 				-trimpath \
-				-ldflags "-X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(BUILDX_GITCOMMIT) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
+				-ldflags "-w -X github.com/docker/buildx/version.Version=$(BUILDX_VERSION) -X github.com/docker/buildx/version.Revision=$(BUILDX_GITCOMMIT) -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
 				-o "/usr/libexec/docker/cli-plugins/docker-buildx" \
 				./cmd/buildx
 

--- a/rpm/SPECS/docker-buildx-plugin.spec
+++ b/rpm/SPECS/docker-buildx-plugin.spec
@@ -27,7 +27,7 @@ pushd ${RPM_BUILD_DIR}/src/buildx
 		go build \
 			-mod=vendor \
 			-trimpath \
-			-ldflags="-X github.com/docker/buildx/version.Version=%{_buildx_version} -X github.com/docker/buildx/version.Revision=%{_buildx_gitcommit} -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
+			-ldflags="-w -X github.com/docker/buildx/version.Version=%{_buildx_version} -X github.com/docker/buildx/version.Revision=%{_buildx_gitcommit} -X github.com/docker/buildx/version.Package=github.com/docker/buildx" \
 			-o "bin/docker-buildx" \
 			./cmd/buildx
 popd


### PR DESCRIPTION
This disables DWARF generation, which dramatically decreases the size of the binary.

Notably, this does *not* include `-s` which disables the symbol table, as doing so would *also* make it so that `govulncheck` cannot be run on the resulting binary with meaningful results.

Before is ~90M and after is ~72M.

If we add `-s` as well, that ~72M drops to ~63M, but we also lose `govulncheck` so again, IMO, that's not worth doing.

See also:
- https://github.com/docker/compose/pull/10325
- https://github.com/docker/buildx/blob/c45185fde0c9e596afb9044be3328b6d39b3d7ca/Dockerfile#L86