### PR TITLE
bump Model version to v0.1.29

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -47,7 +47,7 @@ DOCKER_COMPOSE_REF ?= v2.37.1
 DOCKER_BUILDX_REF  ?= v0.24.0
 # DOCKER_MODEL_REF is the version of model to package. It is usually a tag,
 # but can be a valid git reference in DOCKER_MODEL_REPO.
-DOCKER_MODEL_REF   ?= v0.1.24
+DOCKER_MODEL_REF   ?= v0.1.29
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I bumped the Docker Model CLI plugin to v0.1.29.

This primarily fixes an issue where the plugin didn't perform API version negotiation.  I don't think it's worthy of a note in the changelog since it's not really user-facing.