### PR TITLE
Bump Docker Model CLI version to v0.1.33

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -47,7 +47,7 @@ DOCKER_COMPOSE_REF ?= v2.38.2
 DOCKER_BUILDX_REF  ?= v0.25.0
 # DOCKER_MODEL_REF is the version of model to package. It is usually a tag,
 # but can be a valid git reference in DOCKER_MODEL_REPO.
-DOCKER_MODEL_REF   ?= v0.1.32
+DOCKER_MODEL_REF   ?= v0.1.33
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I bumped the Model CLI to v0.1.33.
This adds support for the USER_AGENT environment variable set by Compose (in conjunction with Compose v2.38.2).
https://github.com/docker/compose/pull/13025 is part of https://github.com/docker/compose/releases/tag/v2.38.2.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update Docker Model CLI plugin to [v0.1.33](https://github.com/docker/model-cli/releases/tag/v0.1.33)
```
