### PR TITLE
update buildx to v0.26.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -44,7 +44,7 @@ DOCKER_ENGINE_REF  ?= $(REF)
 DOCKER_COMPOSE_REF ?= v2.38.2
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
-DOCKER_BUILDX_REF  ?= v0.25.0
+DOCKER_BUILDX_REF  ?= v0.26.0
 # DOCKER_MODEL_REF is the version of model to package. It is usually a tag,
 # but can be a valid git reference in DOCKER_MODEL_REPO.
 DOCKER_MODEL_REF   ?= v0.1.34


### PR DESCRIPTION
https://github.com/docker/buildx/releases/tag/v0.26.0

```markdown changelog
Update Buildx to [v0.26.0](https://github.com/docker/buildx/releases/tag/v0.26.0)
```
