### PR TITLE
deb, rpm: set minimum containerd version to 1.7.27

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -23,7 +23,7 @@ Vcs-Git: git://github.com/docker/docker.git
 Package: docker-ce
 Architecture: linux-any
 Pre-Depends: init-system-helpers (>= 1.54~)
-Depends: containerd.io (>= 1.6.24),
+Depends: containerd.io (>= 1.7.27),
          docker-ce-cli,
          iptables,
          ${shlibs:Depends}

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -24,7 +24,7 @@ Requires: iptables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.6.24
+Requires: containerd.io >= 1.7.27
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Bumping the containerd.io package minimum version.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Bump the containerd.io dependency minimum required version to 1.7.27
```
