### PR TITLE
rpm: Add iptables-nft requirement for Fedora 43+ and RHEL 10+

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,7 +19,12 @@ Requires: docker-ce-cli
 Recommends: docker-ce-rootless-extras
 Requires: container-selinux
 Requires: systemd
+%if (0%{?fedora} >= 43) || (0%{?rhel} >= 10)
+# For Fedora >= 43 and RHEL >= 10, require iptables-nft
+Requires: iptables-nft
+%else
 Requires: iptables
+%endif
 %if %{undefined rhel} || 0%{?rhel} < 9
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup


### PR DESCRIPTION
Fedora 43 and RHEL 10 have transitioned to nftables as the default packet filtering framework.

By default Docker requires iptables compatibility to function properly with these systems.
