### PR TITLE
bump compose to v2.40.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ DOCKER_CLI_REF     ?= $(REF)
 DOCKER_ENGINE_REF  ?= $(REF)
 # DOCKER_COMPOSE_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_COMPOSE_REPO.
-DOCKER_COMPOSE_REF ?= v2.39.4
+DOCKER_COMPOSE_REF ?= v2.40.0
 # DOCKER_BUILDX_REF is the version of compose to package. It usually is a tag,
 # but can be a valid git reference in DOCKER_BUILDX_REPO.
 DOCKER_BUILDX_REF  ?= v0.29.1


### PR DESCRIPTION
**- What I did**
bump compose to v2.40.0

**- Description for the changelog**
```markdown changelog
Docker Compose v2.40.0
```
