### PR TITLE
verify: fix containerd v2 verification

### DIFF
--- a/verify
+++ b/verify
@@ -34,8 +34,15 @@ function verify_binaries() {
 	docker-proxy --version
 	containerd --version
 	ctr --version
-	containerd-shim -v
-	containerd-shim-runc-v1 -v
+
+	containerd_version=$(containerd --version | awk '{print $3}' | sed 's/^v//')
+	containerd_major=$(echo "$containerd_version" | cut -d. -f1)
+	if [ "$containerd_major" -lt 2 ]; then
+		echo "Running containerd-shim and containerd-shim-runc-v1 checks for containerd v$containerd_version (v2+)"
+		containerd-shim -v
+		containerd-shim-runc-v1 -v
+	fi
+
 	containerd-shim-runc-v2 -v
 	runc --version
 }


### PR DESCRIPTION
containerd v2 no longer ships `containerd-shim` and `containerd-shim-runc-v1` binaries.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
