### PR TITLE
RHEL RPM: require nftables

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -25,11 +25,7 @@ Requires: iptables-nft
 %else
 Requires: iptables
 %endif
-%if %{undefined _no_libnftables}
-# When dockerd is not linked against libnftables, the nftables package
-# is not a hard requirement.
 Requires: nftables
-%endif
 %if %{undefined rhel} || 0%{?rhel} < 9
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup


### PR DESCRIPTION
**- What I did**

- related to https://github.com/docker/docker-ce-packaging/pull/1256#discussion_r2403415085

The dynamically linked RHEL dockerd doesn't strictly need a dependency on nftables (because it doesn't link against libnftables.so). So, commit 1a73c6b didn't make it one.

But, it'll already be installed in most places anyway, it'll be required when we deprecate iptables support, and it's needed to try out the experimental nftables support.

So, make it a hard dependency now.

**- Description for the changelog**
```markdown changelog
- FIXME - no additional note needed here, but remove "apart from on RHEL" from https://github.com/docker/docker-ce-packaging/pull/1256
```
