### PR TITLE
RPM: require "iptables-nft or iptables"

### DIFF
--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -19,12 +19,7 @@ Requires: docker-ce-cli
 Recommends: docker-ce-rootless-extras
 Requires: container-selinux
 Requires: systemd
-%if (0%{?fedora} >= 43) || (0%{?rhel} >= 10)
-# For Fedora >= 43 and RHEL >= 10, require iptables-nft
-Requires: iptables-nft
-%else
-Requires: iptables
-%endif
+Requires: (iptables-nft or iptables)
 Requires: nftables
 %if %{undefined rhel} || 0%{?rhel} < 9
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.


### PR DESCRIPTION
**- What I did**

Rather than requiring iptables-nft for RHEL10/Fedora43 and iptables for other versions and CentOS, use "(iptables-nft or iptables)".

Newer OSs will have iptables-nft, if anything - and making people install iptables-legacy isn't great if it's not needed.

(When neither dependency is available - dnf seems to install both if they're available, but doesn't mind if it can only find one of them. And, if one's already installed, it doesn't try to install the other.)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
