### PR TITLE
deb: Remove Raspbian support and armhf-specific build flags

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -1,15 +1,5 @@
 #!/usr/bin/make -f
 
-# Include default Makefile variables.
-include /usr/share/dpkg/default.mk
-
-# Build all armhf binaries as ARMv6 with hard float, to support both
-# Debian armhf and Raspbian armhf.
-ifeq ($(DEB_TARGET_ARCH),armhf)
-	export CFLAGS += -marm -march=armv6+fp
-	export GOARM := 6
-endif
-
 VERSION ?= $(shell cat engine/VERSION)
 # TODO(thaJeztah): allow passing this version when building.
 PKG_REVISION ?= 1

--- a/distros.json
+++ b/distros.json
@@ -68,20 +68,6 @@
         ],
         "end_of_life": "December 02, 2026"
     },
-    "raspbian-bullseye": {
-        "image": "balenalib/rpi-raspbian:bullseye",
-        "arches": [
-            "armhf"
-        ],
-        "description": "Debian/Raspbian 11 (stable)"
-    },
-    "raspbian-bookworm": {
-        "image": "balenalib/rpi-raspbian:bookworm",
-        "arches": [
-            "armhf"
-        ],
-        "description": "Debian/Raspbian 12 (next stable)"
-    },
     "ubuntu-jammy": {
         "image": "ubuntu:jammy",
         "arches": [


### PR DESCRIPTION
- related to: https://docs.docker.com/engine/install/raspberry-pi-os/

Remove support for 32-bit Raspbian bullseye and bookworm.

The Debian armhf binaries now target the actual armv7 architecture.
