### PR TITLE
Compose requires Buildx 0.17 or later

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -107,7 +107,7 @@ Homepage: https://github.com/docker/buildx
 Package: docker-compose-plugin
 Priority: optional
 Architecture: linux-any
-Recommends: docker-buildx-plugin
+Recommends: docker-buildx-plugin (>= 0.17.0)
 Enhances: docker-ce-cli
 Description: Docker Compose (V2) plugin for the Docker CLI.
  This plugin provides the 'docker compose' subcommand.

--- a/rpm/SPECS/docker-compose-plugin.spec
+++ b/rpm/SPECS/docker-compose-plugin.spec
@@ -13,7 +13,7 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Enhances: docker-ce-cli
-Recommends: docker-buildx-plugin
+Recommends: docker-buildx-plugin >= 0.17.0
 
 BuildRequires: bash
 


### PR DESCRIPTION
**- What I did**

Added a version constraint on buildx dependency to prevent compatibility issues
see https://github.com/docker/compose/issues/13306
