### PR TITLE
docker-engine: add nri_no_wasm build tag

### DIFF
--- a/deb/debian-bookworm/Dockerfile
+++ b/deb/debian-bookworm/Dockerfile
@@ -18,6 +18,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/debian-bullseye/Dockerfile
+++ b/deb/debian-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/debian-trixie/Dockerfile
+++ b/deb/debian-trixie/Dockerfile
@@ -18,6 +18,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/raspbian-bookworm/Dockerfile
+++ b/deb/raspbian-bookworm/Dockerfile
@@ -18,6 +18,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/raspbian-bullseye/Dockerfile
+++ b/deb/raspbian-bullseye/Dockerfile
@@ -18,6 +18,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-jammy/Dockerfile
+++ b/deb/ubuntu-jammy/Dockerfile
@@ -24,6 +24,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-noble/Dockerfile
+++ b/deb/ubuntu-noble/Dockerfile
@@ -24,6 +24,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-plucky/Dockerfile
+++ b/deb/ubuntu-plucky/Dockerfile
@@ -24,6 +24,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/deb/ubuntu-questing/Dockerfile
+++ b/deb/ubuntu-questing/Dockerfile
@@ -24,6 +24,7 @@ ENV GO111MODULE=on
 ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+ENV DOCKER_BUILDTAGS="nri_no_wasm"
 
 ARG COMMON_FILES
 COPY --link ${COMMON_FILES} /root/build-deb/debian

--- a/rpm/centos-10/Dockerfile
+++ b/rpm/centos-10/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH=1
-ENV DOCKER_BUILDTAGS=exclude_graphdriver_btrfs
+ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs nri_no_wasm"
 ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}

--- a/rpm/centos-9/Dockerfile
+++ b/rpm/centos-9/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH=1
-ENV DOCKER_BUILDTAGS=exclude_graphdriver_btrfs
+ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs nri_no_wasm"
 ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}

--- a/rpm/rhel-10/Dockerfile
+++ b/rpm/rhel-10/Dockerfile
@@ -31,7 +31,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH=1
-ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables"
+ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables nri_no_wasm"
 ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}

--- a/rpm/rhel-8/Dockerfile
+++ b/rpm/rhel-8/Dockerfile
@@ -31,7 +31,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH=1
-ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables"
+ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables nri_no_wasm"
 ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}

--- a/rpm/rhel-9/Dockerfile
+++ b/rpm/rhel-9/Dockerfile
@@ -31,7 +31,7 @@ ENV GOPATH=/go
 ENV GOTOOLCHAIN=local
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV AUTO_GOPATH=1
-ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables"
+ENV DOCKER_BUILDTAGS="exclude_graphdriver_btrfs no_libnftables nri_no_wasm"
 ARG DISTRO
 ARG SUITE
 ENV DISTRO=${DISTRO}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This change adds the `nri_no_wasm` build tag for docker engine builds. Reference: https://github.com/containerd/nri/blob/1078130fa016884b4c03880d9d587e6691a67d98/README.md#webassembly-support

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
