### PR TITLE
rootless: drop dependency on slirp4netns|vpnkit|pasta

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -84,13 +84,9 @@ Enhances: docker-ce
 Conflicts: rootlesskit
 Replaces: rootlesskit
 Breaks: rootlesskit
-# slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
-Recommends: slirp4netns (>= 0.4.0) | passt
 Description: Rootless support for Docker.
  Use dockerd-rootless.sh to run the daemon.
  Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh.
- This package contains RootlessKit, but does not contain VPNKit.
- Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 Homepage: https://docs.docker.com/engine/security/rootless/
 
 Package: docker-buildx-plugin

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -124,7 +124,6 @@ override_dh_auto_install:
 	install -D -p -m 0755 /usr/local/bin/rootlesskit debian/docker-ce-rootless-extras/usr/bin/rootlesskit
 	install -D -p -m 0755 engine/contrib/dockerd-rootless.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless.sh
 	install -D -p -m 0755 engine/contrib/dockerd-rootless-setuptool.sh debian/docker-ce-rootless-extras/usr/bin/dockerd-rootless-setuptool.sh
-	# TODO: how can we install vpnkit?
 
 override_dh_installinit:
 	# use "docker" as our service name, not "docker-ce"

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -14,8 +14,6 @@ Packager: Docker <support@docker.com>
 
 Requires: docker-ce
 # TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
-# slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
-Requires: (slirp4netns >= 0.4 or passt)
 
 BuildRequires: bash
 
@@ -26,8 +24,6 @@ Conflicts: rootlesskit
 Rootless support for Docker.
 Use dockerd-rootless.sh to run the daemon.
 Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh .
-This package contains RootlessKit, but does not contain VPNKit.
-Either slirp4netns (>= 0.4.0), passt, or VPNKit needs to be installed separately.
 
 %prep
 %setup -q -c -n src -a 0

--- a/static/Makefile
+++ b/static/Makefile
@@ -50,7 +50,7 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 
 	# extra binaries for running rootless
 	mkdir -p build/linux/docker-rootless-extras
-	for f in rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh vpnkit; do \
+	for f in rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh; do \
 		if [ -f $(ENGINE_DIR)/bundles/binary/$$f ]; then \
 			cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker-rootless-extras/$$f; \
 		fi \


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
rootless: drop dependency on slirp4netns|vpnkit|pasta

RootlessKit v3.0 no longer requires an external program for networking. 
See:
- moby/moby#52319

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
rootless: drop dependency on slirp4netns|vpnkit|pasta
```
- - -

TODO:
- [ ] Also update https://github.com/docker/packaging https://github.com/docker/packaging/pull/421