### PR TITLE
rootless: drop dependency on fuse-overlayfs

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -86,8 +86,6 @@ Replaces: rootlesskit
 Breaks: rootlesskit
 # slirp4netns (>= 0.4.0) is available in Debian since 11 and Ubuntu since 19.10
 Recommends: slirp4netns (>= 0.4.0) | passt
-# Unlike RPM, DEB packages do not contain "Recommends: fuse-overlayfs (>= 0.7.0)" here,
-# because Debian (since 10) and Ubuntu support the kernel-mode rootless overlayfs.
 Description: Rootless support for Docker.
  Use dockerd-rootless.sh to run the daemon.
  Use dockerd-rootless-setuptool.sh to setup systemd for dockerd-rootless.sh.

--- a/rpm/SPECS/docker-ce-rootless-extras.spec
+++ b/rpm/SPECS/docker-ce-rootless-extras.spec
@@ -16,8 +16,6 @@ Requires: docker-ce
 # TODO: conditionally add `Requires: dbus-daemon` for Fedora and CentOS 8
 # slirp4netns >= 0.4 is available in the all supported versions of CentOS and Fedora.
 Requires: (slirp4netns >= 0.4 or passt)
-# fuse-overlayfs >= 0.7 is available in the all supported versions of CentOS and Fedora.
-Requires: fuse-overlayfs >= 0.7
 
 BuildRequires: bash
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

rootless: drop dependency on fuse-overlayfs.

fuse-overlayfs is no longer needed since kernel 5.11. EL 8 (kernel 4.18) distros still need it, but official RPMs are no longer built for them.
https://download.docker.com/linux/centos/8/x86_64/stable/Packages/


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
rootless: drop dependency on fuse-overlayfs
```
