### PR TITLE
packaging: Bump packaging revision to 2

### DIFF
--- a/deb/common/rules
+++ b/deb/common/rules
@@ -2,7 +2,7 @@
 
 VERSION ?= $(shell cat engine/VERSION)
 # TODO(thaJeztah): allow passing this version when building.
-PKG_REVISION ?= 1
+PKG_REVISION ?= 2
 export PKG_REVISION
 
 # force packages to be built with xz compression, as Ubuntu 21.10 and up use

--- a/rpm/gen-rpm-ver
+++ b/rpm/gen-rpm-ver
@@ -42,7 +42,7 @@ rpmVersion="${VERSION#v}"
 # Docker 23.0.0-beta.1:  version=23.0.0, release=1
 # Docker 23.0.0-rc.1:    version=23.0.0, release=1
 # Docker 23.0.0-dev:     version=0.0.0~YYYYMMDDHHMMSS.gitHASH, release=0
-rpmRelease=1
+rpmRelease=2
 
 # rpm packages require a tilde (~) instead of a hyphen (-) as separator between
 # the version # and pre-release suffixes, otherwise pre-releases are sorted AFTER

--- a/static/Makefile
+++ b/static/Makefile
@@ -7,6 +7,7 @@ BUILDX_DIR=$(realpath $(CURDIR)/../src/github.com/docker/buildx)
 ENGINE_GITCOMMIT?=$(shell cd $(realpath $(CURDIR)/../src/github.com/docker/docker) && git rev-parse --short HEAD)
 
 GEN_STATIC_VER=$(shell ./gen-static-ver $(CLI_DIR) $(VERSION))
+STATIC_PKG_SUFFIX=-2
 HASH_CMD=docker run -v $(CURDIR):/sum -w /sum debian:jessie bash hash_files
 DIR_TO_HASH:=build/linux
 DOCKER_CLI_GOLANG_IMG=golang:$(GO_VERSION)
@@ -46,7 +47,7 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 	for f in dockerd containerd ctr containerd-shim containerd-shim-runc-v2 docker-init docker-proxy runc; do \
 		cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker/$$f; \
 	done
-	tar -C build/linux -c -z -f build/linux/docker-$(GEN_STATIC_VER).tgz docker
+	tar -C build/linux -c -z -f build/linux/docker-$(GEN_STATIC_VER)$(STATIC_PKG_SUFFIX).tgz docker
 
 	# extra binaries for running rootless
 	mkdir -p build/linux/docker-rootless-extras
@@ -55,7 +56,7 @@ static-linux: static-cli static-engine static-buildx-plugin ## create tgz
 			cp -L $(ENGINE_DIR)/bundles/binary/$$f build/linux/docker-rootless-extras/$$f; \
 		fi \
 	done
-	tar -C build/linux -c -z -f build/linux/docker-rootless-extras-$(GEN_STATIC_VER).tgz docker-rootless-extras
+	tar -C build/linux -c -z -f build/linux/docker-rootless-extras-$(GEN_STATIC_VER)$(STATIC_PKG_SUFFIX).tgz docker-rootless-extras
 
 	# buildx
 	tar -C $(BUILDX_DIR)/bin -c -z -f build/linux/docker-buildx-plugin-$(DOCKER_BUILDX_REF:v%=%).tgz docker-buildx
@@ -76,7 +77,7 @@ cross-mac: buildx
 		arch=$$(echo $$platform | cut -d_ -f2); \
 		mkdir -p $$dest/$$arch/docker; \
 		cp $$platform/docker-darwin-* $$dest/$$arch/docker/docker && \
-		tar -C $$dest/$$arch -c -z -f $$dest/$$arch/docker-$(GEN_STATIC_VER).tgz docker; \
+		tar -C $$dest/$$arch -c -z -f $$dest/$$arch/docker-$(GEN_STATIC_VER)$(STATIC_PKG_SUFFIX).tgz docker; \
 	done
 
 .PHONY: cross-win
@@ -85,14 +86,14 @@ cross-win: cross-win-engine
 	mkdir -p build/win/amd64/docker
 	cp $(CLI_DIR)/build/docker-windows-amd64.exe build/win/amd64/docker/docker.exe
 	cp $(ENGINE_DIR)/bundles/cross/win/dockerd.exe build/win/amd64/docker/dockerd.exe
-	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER).zip docker'
+	docker run --rm -v $(CURDIR)/build/win/amd64:/v -w /v alpine sh -c 'apk update&&apk add zip&&zip -r docker-$(GEN_STATIC_VER)$(STATIC_PKG_SUFFIX).zip docker'
 	$(CHOWN) -R $(shell id -u):$(shell id -g) build
 
 .PHONY: cross-arm
 cross-arm: cross-all-cli ## create tgz with linux armhf client only
 	mkdir -p build/arm/docker
 	cp $(CLI_DIR)/build/docker-linux-arm build/arm/docker/docker
-	tar -C build/arm -c -z -f build/arm/docker-$(GEN_STATIC_VER).tgz docker
+	tar -C build/arm -c -z -f build/arm/docker-$(GEN_STATIC_VER)$(STATIC_PKG_SUFFIX).tgz docker
 
 .PHONY: static-cli
 static-cli:


### PR DESCRIPTION
Bump the packaging revision for both deb (PKG_REVISION) and rpm (rpmRelease) from 1 to 2, to publish new package builds for existing release versions.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
