### PR TITLE
Replace model-cli repository with model-runner

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -28,7 +28,7 @@ DOCKER_CLI_REPO     ?= https://github.com/docker/cli.git
 DOCKER_ENGINE_REPO  ?= https://github.com/docker/docker.git
 DOCKER_COMPOSE_REPO ?= https://github.com/docker/compose.git
 DOCKER_BUILDX_REPO  ?= https://github.com/docker/buildx.git
-DOCKER_MODEL_REPO   ?= https://github.com/docker/model-cli.git
+DOCKER_MODEL_REPO   ?= https://github.com/docker/model-runner.git
 
 # REF can be used to specify the same branch or tag to use for *both* the CLI
 # and Engine source code. This can be useful if both the CLI and Engine have a
@@ -47,7 +47,7 @@ DOCKER_COMPOSE_REF ?= v5.1.4
 DOCKER_BUILDX_REF  ?= v0.32.1
 # DOCKER_MODEL_REF is the version of model to package. It is usually a tag,
 # but can be a valid git reference in DOCKER_MODEL_REPO.
-DOCKER_MODEL_REF   ?= v0.1.39
+DOCKER_MODEL_REF   ?= v1.2.1
 
 # Use "stage" to install dependencies from download-stage.docker.com during the
 # verify step. Leave empty or use any other value to install from download.docker.com

--- a/deb/common/rules
+++ b/deb/common/rules
@@ -41,8 +41,8 @@ override_dh_auto_build:
 	make -C /go/src/github.com/docker/compose VERSION=$(COMPOSE_VERSION) DESTDIR=/usr/libexec/docker/cli-plugins build
 
 	# Build the model plugin
-	GO111MODULE=on make -C /go/src/github.com/docker/model-cli VERSION=$(MODEL_VERSION) ce-release \
-	&& mv /go/src/github.com/docker/model-cli/dist/docker-model /usr/libexec/docker/cli-plugins/docker-model
+	GO111MODULE=on make -C /go/src/github.com/docker/model-cli/cmd/cli VERSION=$(MODEL_VERSION) ce-release \
+	&& mv /go/src/github.com/docker/model-cli/cmd/cli/dist/docker-model /usr/libexec/docker/cli-plugins/docker-model
 
 override_dh_auto_test:
 	ver="$$(engine/bundles/dynbinary-daemon/dockerd --version)"; \

--- a/rpm/SPECS/docker-model-plugin.spec
+++ b/rpm/SPECS/docker-model-plugin.spec
@@ -25,14 +25,14 @@ This plugin provides the 'docker model' subcommand.
 %setup -q -c -n src -a 0
 
 %build
-GO111MODULE=on make -C ${RPM_BUILD_DIR}/src/model VERSION=%{_model_version} ce-release
+GO111MODULE=on make -C ${RPM_BUILD_DIR}/src/model/cmd/cli VERSION=%{_model_version} ce-release
 
 %check
 ver="$(${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-model docker-cli-plugin-metadata | awk '{ gsub(/[",:]/,"")}; $1 == "Version" { print $2 }')"; \
     test "$ver" = "%{_model_version}" && echo "PASS: docker-model version OK" || (echo "FAIL: docker-model version ($ver) did not match" && exit 1)
 
 %install
-install -D -p -m 0755 ${RPM_BUILD_DIR}/src/model/dist/docker-model ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-model
+install -D -p -m 0755 ${RPM_BUILD_DIR}/src/model/cmd/cli/dist/docker-model ${RPM_BUILD_ROOT}%{_libexecdir}/docker/cli-plugins/docker-model
 
 for f in LICENSE; do
     install -D -p -m 0644 "${RPM_BUILD_DIR}/src/model/$f" "docker-model-plugin-docs/$f"


### PR DESCRIPTION
\- What I did

github.com/docker/model-cli has been replaced with github.com/docker/model-runner. Update the packaging to reflect the same.

\- Description for the changelog

`Replace github.com/docker/model-cli with github.com/docker/model-runner.`