### PR TITLE
deb: update "conflicts"

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -38,8 +38,7 @@ Recommends: apparmor,
             xz-utils
 Suggests: cgroupfs-mount | cgroup-lite,
             kmod,
-Conflicts: docker (<< 1.5~),
-           docker.io
+Conflicts: docker.io
 Replaces: docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a
@@ -58,8 +57,7 @@ Depends: ${shlibs:Depends}
 Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
-Conflicts: docker (<< 1.5~),
-           docker.io
+Conflicts: docker.io
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine

--- a/deb/common/control
+++ b/deb/common/control
@@ -39,10 +39,8 @@ Recommends: apparmor,
 Suggests: cgroupfs-mount | cgroup-lite,
             kmod,
 Conflicts: docker (<< 1.5~),
-           docker-engine,
            docker.io
-Replaces: docker-engine,
-          docker-ce-cli (<< 5:28.0.0)
+Replaces: docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine
  Docker is a product for you to build, ship and run any application as a
  lightweight container
@@ -61,7 +59,6 @@ Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
 Conflicts: docker (<< 1.5~),
-           docker-engine,
            docker.io
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)

--- a/deb/common/control
+++ b/deb/common/control
@@ -57,7 +57,10 @@ Depends: ${shlibs:Depends}
 Recommends: docker-buildx-plugin,
             docker-compose-plugin
 Suggests: docker-model-plugin
-Conflicts: docker.io
+# Debian Trixie ships the CLI as docker-cli; older Debian releases and
+# Ubuntu include it in docker.io.
+Conflicts: docker.io,
+           docker-cli
 Replaces: docker-ce (<< 5:0)
 Breaks: docker-ce (<< 5:0)
 Description: Docker CLI: the open-source application container engine


### PR DESCRIPTION
- similar to https://github.com/docker/packaging/pull/438


### deb: remove "conflicts: docker-engine"

The docker-engine package pre-dates docker-ce (< 17.03), and this
package was never published to download.docker.com, so is very
unlikely to be found anywhere.

### deb: remove "conflicts: docker"

The `docker` package is now a transitional package with a dependency
on `wmdocker`, and the `docker` package was removed entirely since
Debian 13 (trixy) and Ubuntu 22.10

- https://packages.debian.org/bullseye/docker
- https://packages.debian.org/bullseye/wmdocker

Neither have a binary named `docker`, or docs that conflict;

- https://packages.debian.org/bookworm/amd64/docker/filelist
- https://packages.debian.org/bookworm/amd64/wmdocker/filelist

So we don't have any conflicts if both would be installed.

### deb: conflict with docker-cli packages

Debian Trixie now ships the Docker CLI as a separate docker-cli package,
while Ubuntu and older Debian releases include it in docker.io.

Add a conflict with docker-cli to prevent file overlaps with the CLI
binaries provided by docker-ce-cli.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
