### PR TITLE
deb, rpm: remove kmod dependency

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -36,8 +36,7 @@ Recommends: apparmor,
             pigz,
             procps,
             xz-utils
-Suggests: cgroupfs-mount | cgroup-lite,
-            kmod,
+Suggests: cgroupfs-mount | cgroup-lite
 Conflicts: docker.io
 Replaces: docker-ce-cli (<< 5:28.0.0)
 Description: Docker: the open-source application container engine

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -13,8 +13,6 @@ Vendor: Docker
 Packager: Docker <support@docker.com>
 
 Requires: /usr/sbin/groupadd
-# Provides modprobe, which we use to load br_netfilter if not loaded.
-Suggests: kmod
 Requires: docker-ce-cli
 Recommends: docker-ce-rootless-extras
 Requires: container-selinux


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49038
- https://github.com/docker/docker-ce-packaging/pull/1118
- https://github.com/docker/docker-ce-packaging/pull/1158

This was added in deed8d9df8cd90139229748021efcc006900aba5, as the docker engine depended on modprobe to enable br_netfilter. Docker Engine no longer requires this since [moby@4b8c720], so we can remove this.

[moby@4b8c720]: https://github.com/moby/moby/commit/4b8c72060d1089626e4ac9f5e0624e0cb567d4bc

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
