### PR TITLE
deb, rpm: require containerd.io >= v2.1.5

### DIFF
--- a/deb/common/control
+++ b/deb/common/control
@@ -24,7 +24,7 @@ Vcs-Git: https://github.com/moby/moby.git
 Package: docker-ce
 Architecture: linux-any
 Pre-Depends: init-system-helpers (>= 1.54~)
-Depends: containerd.io (>= 1.7.27),
+Depends: containerd.io (>= 2.1.5),
          docker-ce-cli,
          iptables,
          nftables,

--- a/rpm/SPECS/docker-ce.spec
+++ b/rpm/SPECS/docker-ce.spec
@@ -23,7 +23,7 @@ Requires: nftables
 # Libcgroup is no longer available in RHEL/CentOS >= 9 distros.
 Requires: libcgroup
 %endif
-Requires: containerd.io >= 1.7.27
+Requires: containerd.io >= 2.1.5
 Requires: tar
 Requires: xz
 


### PR DESCRIPTION
Drop support for containerd.io v1.x. container.io v2.1.5 is the oldest v2 version we shipped as packages.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
